### PR TITLE
Claude Code のプロジェクト設定とフックを追加する

### DIFF
--- a/.claude/hooks/guard-vrt-baseline.sh
+++ b/.claude/hooks/guard-vrt-baseline.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# VRT ベースライン画像への書き込みを止める。
+#
+# ベースラインは darwin が `npm run test:update`、linux が visual-test.yml の
+# workflow_dispatch でしか生成できない。linux 側は macOS 上では描画結果が違うため
+# 原理的に正しく作れず、手で書き換えると CI のスクリーンショット比較が必ず落ちる。
+
+INPUT=$(cat)
+JQ=$(command -v jq || echo /opt/homebrew/bin/jq)
+FILE=$(printf '%s' "$INPUT" | "$JQ" -r '.tool_input.file_path // ""')
+
+case "$FILE" in
+  */tests/visual/__screenshots__/*)
+    echo "VRT ベースラインは直接編集できません: $FILE" >&2
+    echo "→ darwin: npm run test:update で再生成し、差分画像を確認してからコミットに含める" >&2
+    echo "→ linux: visual-test.yml の workflow_dispatch (update_snapshots) から更新する" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/rust-check.sh
+++ b/.claude/hooks/rust-check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Rust を編集した直後に、build.yml と同じ fmt / clippy を回す。
+#
+# CI で落ちる内容を編集直後に返すのが目的なので、オプションは build.yml に揃える。
+# --all-targets を外すとテストコードの警告を CI だけが検出する状態になる。
+
+INPUT=$(cat)
+JQ=$(command -v jq || echo /opt/homebrew/bin/jq)
+FILE=$(printf '%s' "$INPUT" | "$JQ" -r '.tool_input.file_path // ""')
+
+case "$FILE" in
+  *.rs) ;;
+  *) exit 0 ;;
+esac
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+MANIFEST="$ROOT/src-tauri/Cargo.toml"
+[ -f "$MANIFEST" ] || exit 0
+
+# Homebrew の rustup は keg-only で PATH に載らないため、見つからなければ実体を直接見る
+CARGO=$(command -v cargo || echo /opt/homebrew/opt/rustup/bin/cargo)
+[ -x "$CARGO" ] || exit 0
+
+if ! FMT_OUT=$("$CARGO" fmt --manifest-path "$MANIFEST" --check 2>&1); then
+  echo "cargo fmt --check に失敗しました。cargo fmt で整形してください" >&2
+  printf '%s\n' "$FMT_OUT" | tail -40 >&2
+  exit 2
+fi
+
+if ! CLIPPY_OUT=$("$CARGO" clippy --manifest-path "$MANIFEST" --all-targets -- -D warnings 2>&1); then
+  echo "cargo clippy に失敗しました" >&2
+  printf '%s\n' "$CLIPPY_OUT" | tail -40 >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo build:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo test:*)",
+      "Bash(npm ci:*)",
+      "Bash(npm test:*)",
+      "Bash(npm run test:*)",
+      "Bash(npx playwright test:*)",
+      "Bash(npx playwright install:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-vrt-baseline.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rust-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ cargo fmt --manifest-path src-tauri/Cargo.toml --check
 - フロントエンド（`src/*`）を変更したら `npm test` を通す。UI 変更でベースラインが変わったら `npm run test:update` で更新し、差分画像を見て意図どおりか確かめてからコミットに含める
 - JS/CSS 専用のリンター・フォーマッターは未導入（`npm` スクリプトは Playwright のみ）
 
+`.claude/settings.json` に登録したフックが一部を自動で回す。`.rs` を編集すると `rust-check.sh` が fmt / clippy を実行し、失敗すれば内容を返す。`tests/visual/__screenshots__/` への書き込みは `guard-vrt-baseline.sh` が止める（ベースラインは再生成でしか正しく作れない）。`cargo test` と `npm test` は自分で流す。
+
 ## リリース
 
 タグ push をトリガーに GitHub Actions が universal DMG ビルド → Release 作成 → Homebrew tap 更新まで自動実行する。手順は [DEVELOPMENT.md](DEVELOPMENT.md) を参照。


### PR DESCRIPTION
## 背景

`CLAUDE.md` の「コミット前の検証」は文章として置いてあるだけで、実行するかは書き手次第になっている。Rust の整形崩れと clippy 警告は CI で落ちるが、気づくのが push のあとになる。

VRT ベースラインは darwin と linux で生成経路が違い、linux 側は macOS 上では描画結果が違うため正しく作れない。手で書き換えるとスクリーンショット比較が必ず落ちる。

## やったこと

- `.claude/settings.json` — 読み取り専用コマンドの allowlist と、下記フック 2 本の登録
- `.claude/hooks/rust-check.sh` — `.rs` の編集後に `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings` を回す。オプションは `build.yml` に揃えた
- `.claude/hooks/guard-vrt-baseline.sh` — `tests/visual/__screenshots__/` への書き込みを止め、darwin / linux それぞれの更新手順を返す
- `CLAUDE.md` — フックが回す範囲と自分で流す範囲を「コミット前の検証」に書いた

整形崩れ・clippy 警告のそれぞれで失敗が返ること、`.rs` 以外では cargo を起動しないことを捨てクレートで確認した。`shellcheck --severity=warning` の指摘は無い。

## 注意点

Homebrew の `rustup` は keg-only で `cargo` が PATH に載らない。フックは `command -v cargo` で見つからなければ実体を直接見て、どこにも無ければ何もせず通す。

## 関連リンク

- Closes #10
- フロントエンドの静的検査: #8
