### PR TITLE
🔧 dependabot で依存の更新を拾う

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "⬆️"
+    groups:
+      npm:
+        patterns: ["*"]
+        # Playwright は VRT のベースライン再生成が要るので単独 PR にする
+        exclude-patterns: ["@playwright/test"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "⬆️"
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # Cargo.toml は src-tauri/ にある
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "⬆️"
+    groups:
+      cargo:
+        patterns: ["*"]
+        update-types: [minor, patch]


### PR DESCRIPTION
## 背景

依存の更新は手動で、新しいバージョンが出たことに気づく仕組みが無い。GitHub Actions の `checkout` / `setup-node` / `upload-artifact` は `v4` 固定で、最新は v7。

## やったこと

- `.github/dependabot.yml` — npm `/`、github-actions `/`、cargo `/src-tauri` の 3 つを weekly で見る。minor と patch は ecosystem ごとに 1 本へまとめ、major は個別の PR になる
- `@playwright/test` はグループから外した。更新で VRT にピクセル差が出たら、macOS で `npm run test:update` を回してベースラインを作り直す必要があるため
- `commit-message.prefix` は `⬆️`。dependabot がコロンを足すのは prefix が英数字か閉じ括弧で終わるときなので、絵文字なら `⬆️ Bump ...` になる

## 仕様の注意点

マージ後の最初の週に Actions の major が 3 本開く。`open-pull-requests-limit` は既定の 5 のまま。

有効にしたのは version updates。脆弱性の alerts は `dependabot.yml` と無関係に動く。

## 確認したこと

`.github/dependabot.yml` が YAML としてパースでき、3 つの ecosystem と prefix が読める。設定そのものの検証は GitHub 側がリポジトリの Dependabot タブで行う。

## 関連リンク

- Closes #20
