### PR TITLE
🔧 dependabot を手動チェック時だけ動かす

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,13 @@ version: 2
 
 # 更新は Insights → Dependency graph → Dependabot の「Check for updates」を押したときに拾う。
 # interval はスケジュール実行を実質止めるための yearly（手動チェックは interval と無関係に走る）。
-# 押すタイミングは DEVELOPMENT.md のリリース手順に紐づけている。
-# 脆弱性の alerts はこの設定とは別系統で、advisory の公開時に届く。
+# 押し忘れは scripts/release.sh がリリース前に止める。
+# 脆弱性はこの設定ではなく Dependabot alerts が拾う（リポジトリの Settings 側で有効にする）。
 # 自動マージは入れない。CI は実アプリを起動しない（Playwright は __TAURI__ をモックし、
 # Rust 側は純粋関数の unit test だけ）ので、緑でも挙動の変化は人が見るしかない。
+#
+# major を minor / patch と同じグループに入れないこと。major だけが壊れたときに
+# 無害な更新まで道連れになり、リリース直前に切り分け作業が発生する。
 
 updates:
   - package-ecosystem: npm
@@ -15,11 +18,15 @@ updates:
     commit-message:
       prefix: "⬆️"
     groups:
-      npm:
+      # Playwright は VRT のベースライン再生成が要るので単独 PR にする
+      npm-minor-patch:
         patterns: ["*"]
-        # Playwright は VRT のベースライン再生成が要るので単独 PR にする
         exclude-patterns: ["@playwright/test"]
-        update-types: [major, minor, patch]
+        update-types: [minor, patch]
+      npm-major:
+        patterns: ["*"]
+        exclude-patterns: ["@playwright/test"]
+        update-types: [major]
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,9 +35,12 @@ updates:
     commit-message:
       prefix: "⬆️"
     groups:
-      actions:
+      actions-minor-patch:
         patterns: ["*"]
-        update-types: [major, minor, patch]
+        update-types: [minor, patch]
+      actions-major:
+        patterns: ["*"]
+        update-types: [major]
 
   # Cargo.toml は src-tauri/ にある
   - package-ecosystem: cargo
@@ -40,6 +50,9 @@ updates:
     commit-message:
       prefix: "⬆️"
     groups:
-      cargo:
+      cargo-minor-patch:
         patterns: ["*"]
-        update-types: [major, minor, patch]
+        update-types: [minor, patch]
+      cargo-major:
+        patterns: ["*"]
+        update-types: [major]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 
+# 更新は Insights → Dependency graph → Dependabot の「Check for updates」を押したときに拾う。
+# interval はスケジュール実行を実質止めるための yearly（手動チェックは interval と無関係に走る）。
+# 押すタイミングは DEVELOPMENT.md のリリース手順に紐づけている。
+# 脆弱性の alerts はこの設定とは別系統で、advisory の公開時に届く。
+# 自動マージは入れない。CI は実アプリを起動しない（Playwright は __TAURI__ をモックし、
+# Rust 側は純粋関数の unit test だけ）ので、緑でも挙動の変化は人が見るしかない。
+
 updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: yearly
     commit-message:
       prefix: "⬆️"
     groups:
@@ -12,27 +19,27 @@ updates:
         patterns: ["*"]
         # Playwright は VRT のベースライン再生成が要るので単独 PR にする
         exclude-patterns: ["@playwright/test"]
-        update-types: [minor, patch]
+        update-types: [major, minor, patch]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: yearly
     commit-message:
       prefix: "⬆️"
     groups:
       actions:
         patterns: ["*"]
-        update-types: [minor, patch]
+        update-types: [major, minor, patch]
 
   # Cargo.toml は src-tauri/ にある
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
-      interval: weekly
+      interval: yearly
     commit-message:
       prefix: "⬆️"
     groups:
       cargo:
         patterns: ["*"]
-        update-types: [minor, patch]
+        update-types: [major, minor, patch]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,6 +43,8 @@ npm run test:update
 
 タグ push をトリガーに GitHub Actions が自動で universal DMG ビルド → GitHub Release 作成 → Homebrew tap 更新を行います。
 
+タグを打つ前に Insights → Dependency graph → Dependabot で「Check for updates」を押し、出てきた PR を片付けてください。dependabot は定期実行しない設定なので、依存を上げる機会はここだけです。
+
 ```bash
 # tauri.conf.json / Cargo.toml / Cargo.lock の更新からコミット・タグ・push まで
 # スクリプトが行います

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,7 @@ npm run test:update
 
 タグ push をトリガーに GitHub Actions が自動で universal DMG ビルド → GitHub Release 作成 → Homebrew tap 更新を行います。
 
-タグを打つ前に Insights → Dependency graph → Dependabot で「Check for updates」を押し、出てきた PR を片付けてください。dependabot は定期実行しない設定なので、依存を上げる機会はここだけです。
+dependabot は定期実行しない設定なので、依存を上げるのはリリース前です。Insights → Dependency graph → Dependabot で「Check for updates」を押し、出てきた PR を片付けてから実行してください。押したかの確認と、未処理の dependabot PR が残っていないかのチェックは `release.sh` が行います。
 
 ```bash
 # tauri.conf.json / Cargo.toml / Cargo.lock の更新からコミット・タグ・push まで

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,6 +28,24 @@ if git tag -l "$TAG" | grep -q .; then
   exit 1
 fi
 
+# 依存の更新はここで拾う（dependabot は定期実行しない設定。.github/dependabot.yml 参照）。
+# バージョン更新のコミットより前に置くこと。後ろだと中断時に未 push のコミットが残り、
+# その間に dependabot PR をマージすると再実行時の push が分岐して失敗する。
+OPEN_BOT_PRS="$(gh pr list --repo somei-san/hattotto --author "app/dependabot" --state open --json number --jq 'length')"
+if [[ "$OPEN_BOT_PRS" != "0" ]]; then
+  echo "ERROR: dependabot の PR が ${OPEN_BOT_PRS} 件残っています。片付けてからリリースしてください" >&2
+  gh pr list --repo somei-san/hattotto --author "app/dependabot" --state open >&2
+  exit 1
+fi
+
+if [[ -t 0 ]]; then
+  read -r -p "Dependabot の Check for updates は押しましたか? [y/N] " reply
+  if [[ ! "$reply" =~ ^[yY]$ ]]; then
+    echo "中断しました。Insights → Dependency graph → Dependabot で押してください" >&2
+    exit 1
+  fi
+fi
+
 # バージョンを各設定ファイルに反映
 CURRENT="$(jq -r '.version' "$TAURI_CONF")"
 if [[ "$CURRENT" != "$VERSION" ]]; then


### PR DESCRIPTION
## 背景

定期実行で依存の更新 PR を受け取ると、確認する回数だけが増える。急ぐのは脆弱性だけで、それは Dependabot alerts が advisory の公開時に届ける別系統の仕事になる。version updates が運ぶのは「新しいバージョンが出た」という待てる情報だけ。

## やったこと

- `.github/dependabot.yml`
  - `schedule.interval` を `yearly` にした。Dependabot 画面の「Check for updates」は interval と無関係に走るので、押したときだけ PR が出る
  - グループを ecosystem ごとに minor / patch と major の 2 つに分けた。major だけが壊れたときに無害な更新まで道連れにしないため
- `scripts/release.sh` — タグを打つ前に、未処理の dependabot PR が無いかを確認し、「Check for updates」を押したか対話で聞く。バージョン更新のコミットより前に置いてある
- `DEVELOPMENT.md` — リリース手順に、依存を上げるのはリリース前だと明記した

## 仕様の注意点

この設定は脆弱性を拾わない。リポジトリの Settings で Dependabot alerts を有効にしておく必要がある。

`open-pull-requests-limit: 0` でも定期実行は止まるが、手動チェックでも PR が作られなくなる。

`release.sh` の対話は `[[ -t 0 ]]` で囲ってあるので、端末以外から呼んでも止まらない。未処理 PR のチェックはその場合も効く。

`@playwright/test` はグループから外したまま。更新で VRT にピクセル差が出たら、macOS で `npm run test:update` を回してベースラインを作り直す必要があるため。

## 確認したこと

`.github/dependabot.yml` が YAML としてパースでき、3 つの ecosystem がそれぞれ 2 グループになっている。`release.sh` は `bash -n` と shellcheck が通り、`gh pr list --author "app/dependabot"` が件数を返すことも確認した。スクリプト全体の実行は、途中でコミットとタグ push が走るため試していない。

## 関連リンク

- dependabot の導入: #21
