### PR TITLE
🐛 リリース時の確認を省略したら警告を出す

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,12 +38,16 @@ if [[ "$OPEN_BOT_PRS" != "0" ]]; then
   exit 1
 fi
 
+# 端末が無いときは確認できないので、黙って飛ばさず警告を出す。制御端末を持たない
+# 経路（パイプ越し、CI やエージェント経由の非対話実行）では /dev/tty も開けず、聞く手段が無い。
 if [[ -t 0 ]]; then
   read -r -p "Dependabot の Check for updates は押しましたか? [y/N] " reply
   if [[ ! "$reply" =~ ^[yY]$ ]]; then
     echo "中断しました。Insights → Dependency graph → Dependabot で押してください" >&2
     exit 1
   fi
+else
+  echo "WARNING: 端末が無いので Check for updates の確認を省略しました" >&2
 fi
 
 # バージョンを各設定ファイルに反映


### PR DESCRIPTION
## 背景

`release.sh` はタグを打つ前に「Dependabot の Check for updates を押したか」を対話で確認する。この確認は `[[ -t 0 ]]` で囲ってあるため、制御端末を持たない経路では実行されない。省略したことが出力に現れないので、押さないままリリースしても気づけない。

`/dev/tty` から読む形にしても解決しない。端末を持たない経路では `/dev/tty` はデバイスとして存在するが開けず（`Device not configured`）、`set -e` の下では read の失敗でリリース自体が止まる。

## やったこと

- `scripts/release.sh` — 確認を飛ばしたときに警告を出す

## 確認したこと

`bash -n` と shellcheck が通る。この環境で `test -t 0` が偽、`test -e /dev/tty` が真、`/dev/tty` を開くと `Device not configured` になることを実測した。

## 関連リンク

- リリース手順にゲートを足した PR: #32
