### PR TITLE
💚 CI の待ち時間と実行資源を削る

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# 同じブランチへ push を重ねたら古い実行を打ち切る
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,15 @@
-name: Frontend Lint
+name: Frontend Checks
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+# 同じブランチへ push を重ねたら古い実行を打ち切る
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -21,3 +26,6 @@ jobs:
       - run: npm ci
 
       - run: npm run lint
+
+      # ブラウザ不要の単体テストはこの ubuntu ジョブで速く検出する
+      - run: npm run test:unit

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# 同じブランチへ push を重ねたら古い実行を打ち切る
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-test:
     # ベースラインはローカルの npm run test:update で生成するため、macOS を揃える
@@ -16,10 +21,20 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # ブラウザ本体のダウンロードを毎回やらない
+      - uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
 
       - run: npx playwright install chromium
 


### PR DESCRIPTION
## 背景

PR へ push を重ねると 3 つのワークフローの古い実行が走り続ける。visual-test は macOS ランナーで chromium を毎回ダウンロードし、node の単体テストは visual-test の `npm test` の中でしか走らないため、ブラウザ不要の失敗も macOS ランナーの順番待ちの後にしか分からない。Node のバージョンも lint と visual-test で不揃いになっている。

## やったこと

- 3 ワークフロー共通: `concurrency` を追加し、同一ブランチへの連続 push で古い実行を打ち切る
- lint.yml: `npm run test:unit` を追加し、単体テストを ubuntu で検出する。ワークフロー名を Frontend Checks へ変更（ジョブ名 `lint` は据え置き）
- visual-test.yml: Playwright のバージョンをキーに `~/Library/Caches/ms-playwright` をキャッシュする。Node を 22 に統一

## 確認したこと

`npm run test:unit` 54 件と actionlint が通る。ブラウザキャッシュは保存と復元の両方が効いて初めて短縮になるため、マージ後の 2 回目以降の実行で所要時間を見る。

## 関連リンク

- Closes #47
