### PR TITLE
✅ 削除・復元の保存ロジックをテストできるようにする

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,8 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
 use crate::i18n::{self, Lang, Msg};
 use crate::model::{
-    resolve_color, AppState, LanguageSetting, Note, RecoverMutex, Settings, COLOR_DEFS, TRASH_MAX,
+    clamp_opacity, clamp_zoom, resolve_color, AppState, LanguageSetting, Note, RecoverMutex,
+    Settings, COLOR_DEFS, TRASH_MAX,
 };
 use crate::persistence::{enforce_trash_limit, save_notes, save_settings, save_trash};
 use crate::window::{
@@ -88,7 +89,7 @@ pub(crate) fn update_note_zoom(
     zoom: u32,
     state: State<AppState>,
 ) -> Result<(), String> {
-    update_note_field(&state, &id, |note| note.zoom = zoom.clamp(50, 200))
+    update_note_field(&state, &id, |note| note.zoom = clamp_zoom(zoom))
 }
 
 /// 付箋のピン留め状態を更新して保存する。
@@ -123,8 +124,9 @@ pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState) -> boo
         .blocking_show()
 }
 
-/// Move a note to trash and close its window.
-pub(crate) fn do_delete_note(id: &str, app: &AppHandle, state: &AppState) -> Result<(), String> {
+/// 付箋をゴミ箱へ移動する（メモリ上の移動＋保存のみ。ウィンドウは操作しない）。
+/// 該当 id の付箋があったかどうかを返す。
+pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, String> {
     let (notes_snapshot, trash_snapshot) = {
         let mut notes = state.notes.recover();
         if let Some(pos) = notes.iter().position(|n| n.id == id) {
@@ -150,6 +152,7 @@ pub(crate) fn do_delete_note(id: &str, app: &AppHandle, state: &AppState) -> Res
             (None, None)
         }
     };
+    let found = notes_snapshot.is_some();
     // 付箋側を先に消すと、間で中断したときにどちらのファイルからも消える。
     // この順なら両方に残るので捨て直せる
     if let Some(ts) = &trash_snapshot {
@@ -158,6 +161,12 @@ pub(crate) fn do_delete_note(id: &str, app: &AppHandle, state: &AppState) -> Res
     if let Some(ns) = &notes_snapshot {
         save_notes(state, ns)?;
     }
+    Ok(found)
+}
+
+/// Move a note to trash and close its window.
+pub(crate) fn do_delete_note(id: &str, app: &AppHandle, state: &AppState) -> Result<(), String> {
+    delete_note_data(state, id)?;
     if let Some(win) = app.get_webview_window(&format!("note-{}", id)) {
         let _ = win.close();
     }
@@ -189,13 +198,9 @@ pub(crate) fn get_trash_max() -> usize {
     TRASH_MAX
 }
 
-/// ゴミ箱から付箋を復元し、ウィンドウを開く。見つからない場合は `None`。
-#[tauri::command]
-pub(crate) fn restore_note(
-    id: String,
-    app: AppHandle,
-    state: State<AppState>,
-) -> Result<Option<Note>, String> {
+/// ゴミ箱から付箋を notes へ戻す（メモリ上の移動＋保存のみ。ウィンドウは操作しない）。
+/// 見つからない場合は `None`。
+pub(crate) fn restore_note_data(state: &AppState, id: &str) -> Result<Option<Note>, String> {
     let (note, trash_snapshot) = {
         let mut trash = state.trash.recover();
         if let Some(pos) = trash.iter().position(|n| n.id == id) {
@@ -206,28 +211,56 @@ pub(crate) fn restore_note(
             (None, None)
         }
     };
-    if let Some(mut note) = note {
-        note.deleted_at = None;
-        open_note_window(&app, &note);
-        let notes_snapshot = {
-            let mut notes = state.notes.recover();
-            // 保存が途中で止まって付箋とゴミ箱の両方に残った付箋を復元しても
-            // 付箋側に同じ id が並ばないようにする。ゴミ箱のコピーは削除時点のもので
-            // 以降の編集を含まないため、付箋側に残っているほうを勝たせる
-            if !notes.iter().any(|n| n.id == note.id) {
-                notes.push(note.clone());
-            }
-            notes.clone()
-        };
-        // ゴミ箱側を先に消すと、間で中断したときにどちらのファイルからも消える。
-        // この順なら両方に残るので復元し直せる
-        save_notes(&state, &notes_snapshot)?;
-        if let Some(ts) = &trash_snapshot {
-            save_trash(&state, ts)?;
+    let Some(mut note) = note else {
+        return Ok(None);
+    };
+    note.deleted_at = None;
+    let notes_snapshot = {
+        let mut notes = state.notes.recover();
+        // 保存が途中で止まって付箋とゴミ箱の両方に残った付箋を復元しても
+        // 付箋側に同じ id が並ばないようにする。ゴミ箱のコピーは削除時点のもので
+        // 以降の編集を含まないため、付箋側に残っているほうを勝たせる
+        if !notes.iter().any(|n| n.id == note.id) {
+            notes.push(note.clone());
         }
-        Ok(Some(note))
-    } else {
-        Ok(None)
+        notes.clone()
+    };
+    // ゴミ箱側を先に消すと、間で中断したときにどちらのファイルからも消える。
+    // この順なら両方に残るので復元し直せる
+    save_notes(state, &notes_snapshot)?;
+    if let Some(ts) = &trash_snapshot {
+        save_trash(state, ts)?;
+    }
+    Ok(Some(note))
+}
+
+/// ゴミ箱から付箋を復元し、ウィンドウを開く。見つからない場合は `None`。
+#[tauri::command]
+pub(crate) fn restore_note(
+    id: String,
+    app: AppHandle,
+    state: State<AppState>,
+) -> Result<Option<Note>, String> {
+    match restore_note_data(&state, &id) {
+        Ok(note) => {
+            if let Some(n) = &note {
+                open_note_window(&app, n);
+            }
+            Ok(note)
+        }
+        Err(e) => {
+            // 保存に失敗してもメモリ上では復元済みで、ゴミ箱一覧からは既に消えている。
+            // ウィンドウまで出さないと付箋がどこにも見えなくなるので、開いたうえで
+            // エラーを返す
+            let note = {
+                let notes = state.notes.recover();
+                notes.iter().find(|n| n.id == id).cloned()
+            };
+            if let Some(n) = &note {
+                open_note_window(&app, n);
+            }
+            Err(e)
+        }
     }
 }
 
@@ -268,7 +301,7 @@ pub(crate) fn update_settings(
         let mut settings = state.settings.recover();
         let language_changed = settings.language != language;
         settings.default_color = default_color;
-        settings.opacity = opacity.clamp(20, 100);
+        settings.opacity = clamp_opacity(opacity);
         settings.bring_all_to_front = bring_all_to_front;
         settings.show_pin_button = show_pin_button;
         settings.show_new_button = show_new_button;
@@ -562,6 +595,207 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    fn make_note(id: &str, content: &str) -> Note {
+        Note {
+            id: id.to_string(),
+            content: content.to_string(),
+            color: "yellow".to_string(),
+            x: 0.0,
+            y: 0.0,
+            width: 280.0,
+            height: 320.0,
+            zoom: 100,
+            pinned: false,
+            deleted_at: None,
+        }
+    }
+
+    /// notes / trash を初期値付きで構築するテスト用 `AppState`。保存先には `dir` を使う。
+    fn make_state(dir: &TempDir, notes: Vec<Note>, trash: Vec<Note>) -> AppState {
+        AppState {
+            notes: Mutex::new(notes),
+            settings: Mutex::new(Settings::default()),
+            trash: Mutex::new(trash),
+            last_bring_to_front: Mutex::new(Instant::now()),
+            context_menu_note_id: Mutex::new(String::new()),
+            data_dir: dir.path().to_path_buf(),
+            notes_loaded: true,
+            settings_loaded: true,
+            trash_loaded: true,
+        }
+    }
+
+    fn read_notes_json(dir: &TempDir) -> Vec<Note> {
+        let s = std::fs::read_to_string(dir.path().join("notes.json")).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    fn read_trash_json(dir: &TempDir) -> Vec<Note> {
+        let s = std::fs::read_to_string(dir.path().join("trash.json")).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    // ── delete_note_data ──────────────────────────────────────
+
+    #[test]
+    fn delete_note_data_moves_note_to_trash_and_persists() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
+
+        let found = delete_note_data(&state, "a").unwrap();
+
+        assert!(found);
+        assert!(state.notes.recover().is_empty());
+        assert_eq!(state.trash.recover().len(), 1);
+        assert!(read_notes_json(&dir).is_empty());
+        let trash_on_disk = read_trash_json(&dir);
+        assert_eq!(trash_on_disk.len(), 1);
+        assert_eq!(trash_on_disk[0].id, "a");
+    }
+
+    #[test]
+    fn delete_note_data_sets_deleted_at() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "")], vec![]);
+
+        delete_note_data(&state, "a").unwrap();
+
+        assert!(state.trash.recover()[0].deleted_at.is_some());
+    }
+
+    #[test]
+    fn delete_note_data_replaces_existing_trash_entry_with_same_id() {
+        let dir = TempDir::new().unwrap();
+        let mut stale = make_note("a", "stale");
+        stale.deleted_at = Some(1);
+        let state = make_state(&dir, vec![make_note("a", "fresh")], vec![stale]);
+
+        delete_note_data(&state, "a").unwrap();
+
+        let trash = state.trash.recover();
+        assert_eq!(trash.len(), 1);
+        assert_eq!(trash[0].content, "fresh");
+    }
+
+    #[test]
+    fn delete_note_data_enforces_trash_limit() {
+        let dir = TempDir::new().unwrap();
+        let existing_trash: Vec<Note> = (0..TRASH_MAX)
+            .map(|i| make_note(&i.to_string(), ""))
+            .collect();
+        let state = make_state(&dir, vec![make_note("new", "")], existing_trash);
+
+        delete_note_data(&state, "new").unwrap();
+
+        let trash = state.trash.recover();
+        assert_eq!(trash.len(), TRASH_MAX);
+        assert_eq!(trash[0].id, "1"); // oldest ("0") dropped
+        assert_eq!(trash.last().unwrap().id, "new");
+    }
+
+    #[test]
+    fn delete_note_data_nonexistent_id_returns_false_and_writes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "")], vec![]);
+
+        let found = delete_note_data(&state, "missing").unwrap();
+
+        assert!(!found);
+        assert!(!dir.path().join("notes.json").exists());
+        assert!(!dir.path().join("trash.json").exists());
+    }
+
+    /// ゴミ箱側を先に書く順序の確認。notes.json への書き込みをディレクトリ衝突で
+    /// 失敗させても、trash.json には既に書けているので捨て直せる状態が残る。
+    #[test]
+    fn delete_note_data_writes_trash_before_notes() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("notes.json")).unwrap();
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
+
+        assert!(delete_note_data(&state, "a").is_err());
+
+        assert_eq!(read_trash_json(&dir)[0].id, "a");
+    }
+
+    // ── restore_note_data ─────────────────────────────────────
+
+    #[test]
+    fn restore_note_data_moves_note_to_notes_and_persists() {
+        let dir = TempDir::new().unwrap();
+        let mut trashed = make_note("a", "hello");
+        trashed.deleted_at = Some(123);
+        let state = make_state(&dir, vec![], vec![trashed]);
+
+        let restored = restore_note_data(&state, "a").unwrap();
+
+        assert_eq!(restored.unwrap().deleted_at, None);
+        assert!(state.trash.recover().is_empty());
+        assert_eq!(state.notes.recover().len(), 1);
+        let notes_on_disk = read_notes_json(&dir);
+        assert_eq!(notes_on_disk.len(), 1);
+        assert_eq!(notes_on_disk[0].id, "a");
+        assert!(read_trash_json(&dir).is_empty());
+    }
+
+    #[test]
+    fn restore_note_data_keeps_existing_notes_entry_on_duplicate_id() {
+        let dir = TempDir::new().unwrap();
+        let mut trashed = make_note("a", "stale-from-trash");
+        trashed.deleted_at = Some(1);
+        let state = make_state(&dir, vec![make_note("a", "fresh-in-notes")], vec![trashed]);
+
+        restore_note_data(&state, "a").unwrap();
+
+        let notes = state.notes.recover();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].content, "fresh-in-notes");
+    }
+
+    #[test]
+    fn restore_note_data_nonexistent_id_returns_none_and_writes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "")]);
+
+        let restored = restore_note_data(&state, "missing").unwrap();
+
+        assert!(restored.is_none());
+        assert!(!dir.path().join("notes.json").exists());
+        assert!(!dir.path().join("trash.json").exists());
+    }
+
+    /// 付箋側を先に書く順序の確認。trash.json への書き込みをディレクトリ衝突で
+    /// 失敗させても、notes.json には既に書けているので復元し直せる状態が残る。
+    #[test]
+    fn restore_note_data_writes_notes_before_trash() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("trash.json")).unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "hello")]);
+
+        assert!(restore_note_data(&state, "a").is_err());
+
+        assert_eq!(read_notes_json(&dir)[0].id, "a");
+    }
+
+    // ── delete → restore round-trip ───────────────────────────
+
+    #[test]
+    fn delete_then_restore_returns_note_to_notes() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
+
+        delete_note_data(&state, "a").unwrap();
+        let restored = restore_note_data(&state, "a").unwrap().unwrap();
+
+        assert_eq!(restored.content, "hello");
+        assert_eq!(restored.deleted_at, None);
+        assert!(read_trash_json(&dir).is_empty());
+        assert_eq!(read_notes_json(&dir)[0].id, "a");
+    }
 
     // ── color_circle ────────────────────────────────────────
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,17 +21,18 @@ use window::{bring_all_to_front, open_note_window};
 // ── App Entry ───────────────────────────────────────────────
 
 pub fn run() {
-    let (notes, notes_loaded) = match load_notes() {
+    let data_dir = persistence::data_dir();
+    let (notes, notes_loaded) = match load_notes(&data_dir) {
         Loaded::Missing => (Vec::new(), true),
         Loaded::Ok(v) => (v, true),
         Loaded::Unreadable => (Vec::new(), false),
     };
-    let (settings, settings_loaded) = match load_settings() {
+    let (settings, settings_loaded) = match load_settings(&data_dir) {
         Loaded::Missing => (Settings::default(), true),
         Loaded::Ok(v) => (v, true),
         Loaded::Unreadable => (Settings::default(), false),
     };
-    let (trash, trash_loaded) = match load_trash() {
+    let (trash, trash_loaded) = match load_trash(&data_dir) {
         Loaded::Missing => (Vec::new(), true),
         Loaded::Ok(v) => (v, true),
         Loaded::Unreadable => (Vec::new(), false),
@@ -42,6 +43,7 @@ pub fn run() {
         trash: Mutex::new(trash),
         last_bring_to_front: Mutex::new(Instant::now() - std::time::Duration::from_secs(10)),
         context_menu_note_id: Mutex::new(String::new()),
+        data_dir,
         notes_loaded,
         settings_loaded,
         trash_loaded,
@@ -133,10 +135,9 @@ pub fn run() {
                     // データフォルダ名が .app で終わるため、Finder はこれをアプリケーション
                     // バンドルとみなし、フォルダとして開けない。-R でファイルを選択状態に
                     // すれば起動を試みずに済む。直後にプロセスを落とすので完了を待つ
-                    let dir = persistence::data_dir();
                     let result = std::process::Command::new("open")
                         .arg("-R")
-                        .args(unreadable.iter().map(|name| dir.join(name)))
+                        .args(unreadable.iter().map(|name| state.data_dir.join(name)))
                         .status();
                     match result {
                         Ok(status) if !status.success() => {

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 use std::time::Instant;
 use uuid::Uuid;
@@ -104,6 +105,16 @@ fn default_zoom() -> u32 {
     100
 }
 
+/// zoom の許容範囲（50〜200%）にクランプする。
+pub(crate) fn clamp_zoom(zoom: u32) -> u32 {
+    zoom.clamp(50, 200)
+}
+
+/// opacity の許容範囲（20〜100%）にクランプする。
+pub(crate) fn clamp_opacity(opacity: u32) -> u32 {
+    opacity.clamp(20, 100)
+}
+
 impl Note {
     pub(crate) fn new(color: &str) -> Self {
         Self {
@@ -191,6 +202,8 @@ pub struct AppState {
     pub(crate) last_bring_to_front: Mutex<Instant>,
     /// Note ID that last opened the context menu (for routing menu events)
     pub(crate) context_menu_note_id: Mutex<String>,
+    /// notes.json / settings.json / trash.json を置くディレクトリ。テストでは `TempDir` を指す
+    pub(crate) data_dir: PathBuf,
     /// 対応するファイルを起動時に読み込めたか。`false` は「ファイルはあるが読めなかった」を
     /// 意味する。このとき中身は既定値で初期化されるため、付箋 0 件の初回起動と混同してはならない。
     pub(crate) notes_loaded: bool,
@@ -247,34 +260,34 @@ mod tests {
 
     #[test]
     fn zoom_clamp_below_min() {
-        assert_eq!(30_u32.clamp(50, 200), 50);
+        assert_eq!(clamp_zoom(30), 50);
     }
 
     #[test]
     fn zoom_clamp_above_max() {
-        assert_eq!(250_u32.clamp(50, 200), 200);
+        assert_eq!(clamp_zoom(250), 200);
     }
 
     #[test]
     fn zoom_clamp_within_range() {
-        assert_eq!(120_u32.clamp(50, 200), 120);
+        assert_eq!(clamp_zoom(120), 120);
     }
 
     // ── Opacity clamp ──
 
     #[test]
     fn opacity_clamp_below_min() {
-        assert_eq!(10_u32.clamp(20, 100), 20);
+        assert_eq!(clamp_opacity(10), 20);
     }
 
     #[test]
     fn opacity_clamp_above_max() {
-        assert_eq!(150_u32.clamp(20, 100), 100);
+        assert_eq!(clamp_opacity(150), 100);
     }
 
     #[test]
     fn opacity_clamp_within_range() {
-        assert_eq!(75_u32.clamp(20, 100), 75);
+        assert_eq!(clamp_opacity(75), 75);
     }
 
     // ── Note serde backward compat (missing zoom field) ──

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -27,16 +27,16 @@ pub(crate) fn data_dir() -> PathBuf {
     dir
 }
 
-fn data_file() -> PathBuf {
-    data_dir().join("notes.json")
+fn data_file(dir: &Path) -> PathBuf {
+    dir.join("notes.json")
 }
 
-fn settings_file() -> PathBuf {
-    data_dir().join("settings.json")
+fn settings_file(dir: &Path) -> PathBuf {
+    dir.join("settings.json")
 }
 
-fn trash_file() -> PathBuf {
-    data_dir().join("trash.json")
+fn trash_file(dir: &Path) -> PathBuf {
+    dir.join("trash.json")
 }
 
 /// tmp へ書き、fsync してから rename する。
@@ -48,6 +48,11 @@ fn trash_file() -> PathBuf {
 /// 使い回しても衝突しないのは、プロセス ID で他プロセスと分かれ、同一プロセス内では
 /// Tauri コマンドがメインスレッドで直列に実行されるからである。
 fn atomic_write(path: &Path, data: &str) -> Result<(), String> {
+    // 保存先ディレクトリが起動後に消されても、次の保存で作り直して復帰できるようにする。
+    // 作成に失敗しても直後の File::create が理由付きで失敗するので、ここでは握り潰す
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
     let tmp = path.with_file_name(format!(
         "{}.tmp.{}",
         path.file_name().unwrap().to_string_lossy(),
@@ -99,8 +104,8 @@ fn load_notes_from(path: &Path) -> Loaded<Vec<Note>> {
     load_json(path)
 }
 
-pub(crate) fn load_notes() -> Loaded<Vec<Note>> {
-    load_notes_from(&data_file())
+pub(crate) fn load_notes(dir: &Path) -> Loaded<Vec<Note>> {
+    load_notes_from(&data_file(dir))
 }
 
 fn save_notes_to(notes: &[Note], path: &Path) -> Result<(), String> {
@@ -122,15 +127,15 @@ fn refuse_if_unloaded(state: &AppState) -> Result<(), String> {
 
 pub(crate) fn save_notes(state: &AppState, notes: &[Note]) -> Result<(), String> {
     refuse_if_unloaded(state)?;
-    save_notes_to(notes, &data_file())
+    save_notes_to(notes, &data_file(&state.data_dir))
 }
 
 fn load_settings_from(path: &Path) -> Loaded<Settings> {
     load_json(path)
 }
 
-pub(crate) fn load_settings() -> Loaded<Settings> {
-    load_settings_from(&settings_file())
+pub(crate) fn load_settings(dir: &Path) -> Loaded<Settings> {
+    load_settings_from(&settings_file(dir))
 }
 
 fn save_settings_to(settings: &Settings, path: &Path) -> Result<(), String> {
@@ -139,15 +144,15 @@ fn save_settings_to(settings: &Settings, path: &Path) -> Result<(), String> {
 
 pub(crate) fn save_settings(state: &AppState, settings: &Settings) -> Result<(), String> {
     refuse_if_unloaded(state)?;
-    save_settings_to(settings, &settings_file())
+    save_settings_to(settings, &settings_file(&state.data_dir))
 }
 
 fn load_trash_from(path: &Path) -> Loaded<Vec<Note>> {
     load_json(path)
 }
 
-pub(crate) fn load_trash() -> Loaded<Vec<Note>> {
-    load_trash_from(&trash_file())
+pub(crate) fn load_trash(dir: &Path) -> Loaded<Vec<Note>> {
+    load_trash_from(&trash_file(dir))
 }
 
 fn save_trash_to(trash: &[Note], path: &Path) -> Result<(), String> {
@@ -156,7 +161,7 @@ fn save_trash_to(trash: &[Note], path: &Path) -> Result<(), String> {
 
 pub(crate) fn save_trash(state: &AppState, trash: &[Note]) -> Result<(), String> {
     refuse_if_unloaded(state)?;
-    save_trash_to(trash, &trash_file())
+    save_trash_to(trash, &trash_file(&state.data_dir))
 }
 
 /// ゴミ箱のFIFO制限: TRASH_MAXを超えた分を先頭から削除
@@ -191,13 +196,19 @@ mod tests {
     }
 
     /// テスト用の `AppState`。ロード済みフラグ以外は使わない。
-    fn make_state(notes_loaded: bool, settings_loaded: bool, trash_loaded: bool) -> AppState {
+    fn make_state(
+        data_dir: &Path,
+        notes_loaded: bool,
+        settings_loaded: bool,
+        trash_loaded: bool,
+    ) -> AppState {
         AppState {
             notes: Mutex::new(Vec::new()),
             settings: Mutex::new(Settings::default()),
             trash: Mutex::new(Vec::new()),
             last_bring_to_front: Mutex::new(Instant::now()),
             context_menu_note_id: Mutex::new(String::new()),
+            data_dir: data_dir.to_path_buf(),
             notes_loaded,
             settings_loaded,
             trash_loaded,
@@ -411,37 +422,42 @@ mod tests {
         assert_eq!(names, vec!["test.json"]);
     }
 
+    /// 保存先ディレクトリが消えていても作り直して保存できる（自己修復）。
     #[test]
-    fn atomic_write_to_nonexistent_dir_returns_err() {
+    fn atomic_write_creates_missing_parent_dir() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("no_such_dir").join("file.json");
-        let result = atomic_write(&path, "data");
-        assert!(result.is_err());
+        atomic_write(&path, "data").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "data");
     }
 
     // ── save_*_to error path tests ──
+    // 親パスを通常ファイルで塞ぐとディレクトリを作れず、保存は失敗する
 
     #[test]
-    fn save_notes_to_nonexistent_dir_returns_err() {
+    fn save_notes_to_blocked_parent_returns_err() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("no_such_dir").join("notes.json");
+        fs::write(dir.path().join("blocker"), "").unwrap();
+        let path = dir.path().join("blocker").join("notes.json");
         let notes = vec![make_note("e1", "yellow", "err")];
         let result = save_notes_to(&notes, &path);
         assert!(result.is_err());
     }
 
     #[test]
-    fn save_settings_to_nonexistent_dir_returns_err() {
+    fn save_settings_to_blocked_parent_returns_err() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("no_such_dir").join("settings.json");
+        fs::write(dir.path().join("blocker"), "").unwrap();
+        let path = dir.path().join("blocker").join("settings.json");
         let result = save_settings_to(&Settings::default(), &path);
         assert!(result.is_err());
     }
 
     #[test]
-    fn save_trash_to_nonexistent_dir_returns_err() {
+    fn save_trash_to_blocked_parent_returns_err() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("no_such_dir").join("trash.json");
+        fs::write(dir.path().join("blocker"), "").unwrap();
+        let path = dir.path().join("blocker").join("trash.json");
         let trash = vec![make_note("t1", "green", "err")];
         let result = save_trash_to(&trash, &path);
         assert!(result.is_err());
@@ -451,29 +467,14 @@ mod tests {
 
     #[test]
     fn save_notes_refuses_when_not_loaded() {
-        // save_notes は固定パス（data_dir() 配下）に書くため、HOME を差し替えて
-        // 実データに触れずに検証する。
         let dir = TempDir::new().unwrap();
-        let prev_home = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", dir.path());
-        }
-
-        let state = make_state(false, true, true);
+        let state = make_state(dir.path(), false, true, true);
         let notes = vec![make_note("a", "yellow", "should not be saved")];
         let result = save_notes(&state, &notes);
-        let notes_written = data_dir().join("notes.json").exists();
-
-        unsafe {
-            match &prev_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert!(
-            !notes_written,
+            !dir.path().join("notes.json").exists(),
             "notes.json must not be created when notes_loaded is false"
         );
     }
@@ -481,8 +482,9 @@ mod tests {
     /// 読めなかったのが別のファイルでも保存を止める。
     #[test]
     fn save_notes_refuses_when_another_file_failed_to_load() {
-        assert!(refuse_if_unloaded(&make_state(true, false, true)).is_err());
-        assert!(refuse_if_unloaded(&make_state(true, true, false)).is_err());
-        assert!(refuse_if_unloaded(&make_state(true, true, true)).is_ok());
+        let dir = TempDir::new().unwrap();
+        assert!(refuse_if_unloaded(&make_state(dir.path(), true, false, true)).is_err());
+        assert!(refuse_if_unloaded(&make_state(dir.path(), true, true, false)).is_err());
+        assert!(refuse_if_unloaded(&make_state(dir.path(), true, true, true)).is_ok());
     }
 }


### PR DESCRIPTION
## 背景

削除と復元は「付箋とゴミ箱の両方に残った同じ id の削除し直し・復元し直し」「中断してもデータが消えない書き込み順」という要のロジックを持つが、保存先が `data_dir()` の固定パスで、ウィンドウ操作に `AppHandle` も要るため、テストが書けない。

## やったこと

- 保存先の注入: `AppState` に `data_dir` を追加し、読み込み・保存はそのディレクトリを使う。テストは `TempDir` を注入する（`HOME` を差し替えていた保存ガードのテストも注入で書き直し）
- 削除・復元の分離: メモリ上の移動＋保存を `delete_note_data` / `restore_note_data` として `AppHandle` なしで呼べる形にし、コマンド側はウィンドウ操作だけを担う。復元は保存に失敗してもメモリ上では復元済みなので、ウィンドウを開いてからエラーを返す
- 自己修復: `atomic_write` が親ディレクトリを作る。保存先ディレクトリが消えても次の保存で作り直して復帰できる
- クランプの集約: `clamp_zoom` / `clamp_opacity` を `model.rs` に置き、標準ライブラリだけを検証していたテストを置き換え
- テスト追加: 削除→復元の往復・id 重複排除・`TRASH_MAX` 超過の先頭破棄・書き込み順序（片側の書き込みを故意に失敗させて残る側を確認）

## 確認したこと

`cargo test` 75 件、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check` が通る。

## 関連リンク

- Closes #46
