### PR TITLE
✅ Tauri コマンド名の食い違いを検出するテストを足す

### DIFF
--- a/tests/unit/tauri-commands.test.js
+++ b/tests/unit/tauri-commands.test.js
@@ -1,0 +1,59 @@
+// Tauri コマンド名の照合テスト。バックエンドの登録一覧を正として、
+// テスト用モックとフロントエンドの呼び出しに、実在しないコマンド名が
+// 紛れ込んでいないかを検出する。モックの default 節が null を返すため、
+// 名前の食い違いはテストの失敗としては現れない。
+const { test, describe } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..", "..");
+const read = (p) => fs.readFileSync(path.join(root, p), "utf8");
+
+/** `generate_handler![...]` に登録されたコマンド名。 */
+function handlerCommands() {
+  const src = read("src-tauri/src/lib.rs");
+  const block = src.match(/generate_handler!\[([\s\S]*?)\]/);
+  assert.ok(block, "generate_handler! が lib.rs に見つからない");
+  return [...block[1].matchAll(/commands::(\w+)/g)].map((m) => m[1]);
+}
+
+/** fixtures.ts のモックの switch が分岐するコマンド名。plugin 呼び出しは対象外。 */
+function mockCommands() {
+  const src = read("tests/visual/fixtures.ts");
+  return [...src.matchAll(/case "([^"]+)":/g)]
+    .map((m) => m[1])
+    .filter((c) => !c.startsWith("plugin:"));
+}
+
+/** src/*.js が invoke / fireInvoke に渡すコマンド名リテラル。plugin 呼び出しは対象外。 */
+function invokedCommands() {
+  const names = new Set();
+  for (const f of fs.readdirSync(path.join(root, "src"))) {
+    if (!f.endsWith(".js")) continue;
+    const src = read(path.join("src", f));
+    for (const m of src.matchAll(/(?:invoke|fireInvoke)\(\s*['"]([^'"]+)['"]/g)) {
+      if (!m[1].startsWith("plugin:")) names.add(m[1]);
+    }
+  }
+  return [...names];
+}
+
+describe("Tauri コマンド名の照合", () => {
+  const handlers = handlerCommands();
+
+  test("抽出の空振り検知: 登録一覧が取れている", () => {
+    assert.ok(handlers.includes("get_note"));
+    assert.ok(handlers.length >= 10, `抽出できたのは ${handlers.length} 件だけ`);
+  });
+
+  test("モックの分岐は実在するコマンドだけを持つ", () => {
+    const unknown = mockCommands().filter((c) => !handlers.includes(c));
+    assert.deepEqual(unknown, [], `generate_handler! に無いコマンド: ${unknown}`);
+  });
+
+  test("フロントエンドが呼ぶコマンドはすべて実在する", () => {
+    const unknown = invokedCommands().filter((c) => !handlers.includes(c));
+    assert.deepEqual(unknown, [], `generate_handler! に無いコマンド: ${unknown}`);
+  });
+});

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -47,7 +47,6 @@ export async function injectNoteMock(
         case "update_settings":       return null;
         case "delete_note":           return null;
         case "create_note":           return null;
-        case "bring_other_notes_to_front": return null;
         default:                      return null;
       }
     };


### PR DESCRIPTION
## 背景

fixtures.ts のモックはコマンド名を switch で分岐し、未知の名前は `default` 節が `null` を返す。このためモックとバックエンドの `generate_handler!` でコマンド名が食い違っていても、テストは気づかず通る。実際にモックには登録に無い `bring_other_notes_to_front` が残っていた。フロントエンドの `invoke` に渡す名前の打ち間違いも同じ理由で検出されない。

## やったこと

- `tests/unit/tauri-commands.test.js` を追加: `generate_handler!` の登録一覧を正として、モックの switch 分岐とフロントエンドの `invoke` / `fireInvoke` 呼び出しに実在しないコマンド名が無いことを照合する。抽出の空振り（正規表現が何も拾えていない状態）も検知する
- fixtures.ts から `bring_other_notes_to_front` を削除

## 確認したこと

`npm run lint`、node 単体テスト 124 件、Playwright 197 件が通る。モックに偽のコマンド名を混ぜると照合テストが落ちることを確認した。

## 関連リンク

- Closes #48
