### PR TITLE
♻️ commands.rs と lib.rs の不揃いを直す

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,14 +1,13 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tauri::image::Image;
-use tauri::menu::{ContextMenu, IconMenuItem, Menu, MenuItem, NativeIcon, PredefinedMenuItem};
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
-use crate::i18n::{self, Lang, Msg};
+use crate::context_menu::build_context_menu;
+use crate::i18n::{self, Msg};
 use crate::model::{
-    clamp_opacity, clamp_zoom, resolve_color, AppState, LanguageSetting, Note, RecoverMutex,
-    Settings, COLOR_DEFS, TRASH_MAX,
+    clamp_opacity, clamp_zoom, is_valid_color_key, is_valid_default_color, resolve_color, AppState,
+    LanguageSetting, Note, RecoverMutex, Settings, TRASH_MAX,
 };
 use crate::persistence::{enforce_trash_limit, save_notes, save_settings, save_trash};
 use crate::window::{
@@ -58,7 +57,7 @@ pub(crate) fn update_note_color(
     state: State<AppState>,
 ) -> Result<(), String> {
     let resolved = resolve_color(&color);
-    if !COLOR_DEFS.iter().any(|c| c.key == resolved) {
+    if !is_valid_color_key(&resolved) {
         return Ok(());
     }
     update_note_field(&state, &id, |note| note.color = resolved)
@@ -300,7 +299,9 @@ pub(crate) fn update_settings(
     let (snapshot, language_changed) = {
         let mut settings = state.settings.recover();
         let language_changed = settings.language != language;
-        settings.default_color = default_color;
+        if is_valid_default_color(&default_color) {
+            settings.default_color = default_color;
+        }
         settings.opacity = clamp_opacity(opacity);
         settings.bring_all_to_front = bring_all_to_front;
         settings.show_pin_button = show_pin_button;
@@ -347,154 +348,6 @@ pub(crate) fn create_note(app: AppHandle, state: State<AppState>) -> Note {
     create_note_with_window(&app, &state)
 }
 
-/// Generate a colored circle icon (16×16 RGBA) for context menu color items.
-fn color_circle(r: u8, g: u8, b: u8) -> Image<'static> {
-    const S: u32 = 16;
-    let mut rgba = vec![0u8; (S * S * 4) as usize];
-    let c = S as f32 / 2.0;
-    let rad = c - 1.0;
-    for y in 0..S {
-        for x in 0..S {
-            let d = ((x as f32 - c).powi(2) + (y as f32 - c).powi(2)).sqrt();
-            let i = ((y * S + x) * 4) as usize;
-            if d <= rad {
-                rgba[i] = r;
-                rgba[i + 1] = g;
-                rgba[i + 2] = b;
-                rgba[i + 3] = 255;
-            }
-        }
-    }
-    Image::new_owned(rgba, S, S)
-}
-
-/// Build and display the note context menu. Returns Err on menu construction failure.
-fn build_context_menu(
-    app: &AppHandle,
-    webview_win: &tauri::WebviewWindow,
-    is_pinned: bool,
-    current_color: &str,
-    lang: Lang,
-) -> tauri::Result<()> {
-    let color_items: Vec<IconMenuItem<tauri::Wry>> = COLOR_DEFS
-        .iter()
-        .map(|c| {
-            let check = if c.key == current_color {
-                "✓ "
-            } else {
-                "    "
-            };
-            IconMenuItem::with_id(
-                app,
-                format!("ctx_color_{}", c.key),
-                format!("{}{}", check, i18n::color_label(lang, c.key)),
-                true,
-                Some(color_circle(c.r, c.g, c.b)),
-                None::<&str>,
-            )
-            .unwrap()
-        })
-        .collect();
-
-    let copy = PredefinedMenuItem::copy(app, None)?;
-    let paste = PredefinedMenuItem::paste(app, None)?;
-    let sep0 = PredefinedMenuItem::separator(app)?;
-    let pin_label = if is_pinned {
-        Msg::CtxUnpin
-    } else {
-        Msg::CtxPin
-    };
-    let pin = MenuItem::with_id(
-        app,
-        "ctx_pin",
-        i18n::text(lang, pin_label),
-        true,
-        None::<&str>,
-    )?;
-    let new_note = IconMenuItem::with_id_and_native_icon(
-        app,
-        "ctx_new",
-        i18n::text(lang, Msg::NewNote),
-        true,
-        Some(NativeIcon::Add),
-        Some("CmdOrCtrl+N"),
-    )?;
-    let delete = IconMenuItem::with_id_and_native_icon(
-        app,
-        "ctx_delete",
-        i18n::text(lang, Msg::CtxDelete),
-        true,
-        Some(NativeIcon::Remove),
-        None::<&str>,
-    )?;
-    let trash = IconMenuItem::with_id_and_native_icon(
-        app,
-        "ctx_trash",
-        i18n::text(lang, Msg::CtxOpenTrash),
-        true,
-        Some(NativeIcon::TrashEmpty),
-        Some("CmdOrCtrl+Shift+T"),
-    )?;
-    let sep1 = PredefinedMenuItem::separator(app)?;
-    let sep1b = PredefinedMenuItem::separator(app)?;
-    let zoom_in = MenuItem::with_id(
-        app,
-        "ctx_zoom_in",
-        i18n::text(lang, Msg::ZoomIn),
-        true,
-        Some("CmdOrCtrl+="),
-    )?;
-    let zoom_out = MenuItem::with_id(
-        app,
-        "ctx_zoom_out",
-        i18n::text(lang, Msg::ZoomOut),
-        true,
-        Some("CmdOrCtrl+-"),
-    )?;
-    let zoom_reset = MenuItem::with_id(
-        app,
-        "ctx_zoom_reset",
-        i18n::text(lang, Msg::CtxZoomReset),
-        true,
-        Some("CmdOrCtrl+0"),
-    )?;
-    let sep2 = PredefinedMenuItem::separator(app)?;
-    let settings = MenuItem::with_id(
-        app,
-        "ctx_settings",
-        i18n::text(lang, Msg::CtxOpenSettings),
-        true,
-        Some("CmdOrCtrl+,"),
-    )?;
-    let sep3 = PredefinedMenuItem::separator(app)?;
-
-    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![
-        &copy,
-        &paste,
-        &sep0,
-        &pin,
-        &sep1,
-        &new_note,
-        &delete,
-        &trash,
-        &sep1b,
-        &zoom_in,
-        &zoom_out,
-        &zoom_reset,
-        &sep2,
-        &settings,
-        &sep3,
-    ];
-    for ci in &color_items {
-        items.push(ci as &dyn tauri::menu::IsMenuItem<tauri::Wry>);
-    }
-
-    let menu = Menu::with_items(app, &items)?;
-    // popup() is blocking — shows native menu and returns after user selects or dismisses
-    menu.popup(webview_win.as_ref().window().clone())?;
-    Ok(())
-}
-
 #[tauri::command]
 pub(crate) fn show_context_menu(
     id: String,
@@ -514,81 +367,6 @@ pub(crate) fn show_context_menu(
     let lang = i18n::resolve(state.settings.recover().language);
     if let Err(e) = build_context_menu(&app, &webview_win, is_pinned, &current_color, lang) {
         eprintln!("context menu error: {}", e);
-    }
-}
-
-/// Handle context menu events (called from menu.rs on_menu_event)
-pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
-    let state: State<AppState> = app.state();
-    let note_id = state.context_menu_note_id.recover().clone();
-    if note_id.is_empty() {
-        return;
-    }
-    let win_label = format!("note-{}", note_id);
-
-    let win = app.get_webview_window(&win_label);
-
-    match event_id {
-        "ctx_pin" => {
-            if let Some(w) = &win {
-                let _ = w.emit_to(w.label(), "ctx-toggle-pin", ());
-            }
-        }
-        "ctx_new" => {
-            create_note_with_window(app, &state);
-        }
-        "ctx_delete" => {
-            if confirm_delete_if_needed(app, &state) {
-                if let Err(e) = do_delete_note(&note_id, app, &state) {
-                    eprintln!("delete note error: {}", e);
-                }
-            }
-        }
-        "ctx_trash" => {
-            open_trash_window(app);
-        }
-        "ctx_settings" => {
-            open_settings_window(app, None);
-        }
-        "ctx_zoom_in" => {
-            if let Some(w) = &win {
-                let _ = w.emit_to(w.label(), "ctx-zoom", "in");
-            }
-        }
-        "ctx_zoom_out" => {
-            if let Some(w) = &win {
-                let _ = w.emit_to(w.label(), "ctx-zoom", "out");
-            }
-        }
-        "ctx_zoom_reset" => {
-            if let Some(w) = &win {
-                let _ = w.emit_to(w.label(), "ctx-zoom", "reset");
-            }
-        }
-        _ if event_id.starts_with("ctx_color_") => {
-            let color = event_id.trim_start_matches("ctx_color_");
-            if !COLOR_DEFS.iter().any(|c| c.key == color) {
-                return;
-            }
-            let snapshot = {
-                let mut notes = state.notes.recover();
-                if let Some(note) = notes.iter_mut().find(|n| n.id == note_id) {
-                    note.color = color.to_string();
-                    Some(notes.clone())
-                } else {
-                    None
-                }
-            };
-            if let Some(snap) = snapshot {
-                if let Err(e) = save_notes(&state, &snap) {
-                    eprintln!("save notes error: {}", e);
-                }
-            }
-            if let Some(w) = &win {
-                let _ = w.emit_to(w.label(), "ctx-apply-color", color);
-            }
-        }
-        _ => {}
     }
 }
 
@@ -795,55 +573,5 @@ mod tests {
         assert_eq!(restored.deleted_at, None);
         assert!(read_trash_json(&dir).is_empty());
         assert_eq!(read_notes_json(&dir)[0].id, "a");
-    }
-
-    // ── color_circle ────────────────────────────────────────
-
-    #[test]
-    fn color_circle_is_16x16() {
-        let img = color_circle(255, 0, 0);
-        assert_eq!(img.width(), 16);
-        assert_eq!(img.height(), 16);
-    }
-
-    #[test]
-    fn color_circle_center_is_opaque() {
-        let img = color_circle(255, 128, 0);
-        // Center pixel at (7, 7)
-        let i = (7 * 16 + 7) * 4;
-        let rgba = img.rgba();
-        assert_eq!(rgba[i], 255); // R
-        assert_eq!(rgba[i + 1], 128); // G
-        assert_eq!(rgba[i + 2], 0); // B
-        assert_eq!(rgba[i + 3], 255); // A = fully opaque
-    }
-
-    #[test]
-    fn color_circle_corner_is_transparent() {
-        let img = color_circle(255, 0, 0);
-        // Corner pixel at (0, 0) is outside the circle
-        let rgba = img.rgba();
-        assert_eq!(rgba[3], 0); // A = transparent
-    }
-
-    // ── COLOR_DEFS validation ────────────────────────────────
-
-    #[test]
-    fn color_defs_keys_are_unique() {
-        let keys: Vec<&str> = COLOR_DEFS.iter().map(|c| c.key).collect();
-        let mut sorted = keys.clone();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), keys.len(), "COLOR_DEFS has duplicate keys");
-    }
-
-    #[test]
-    fn color_defs_matches_valid_color_check() {
-        // All keys in COLOR_DEFS must pass the validation used in handle_context_menu_event
-        for c in COLOR_DEFS {
-            assert!(COLOR_DEFS.iter().any(|d| d.key == c.key));
-        }
-        // A bogus key must not pass
-        assert!(!COLOR_DEFS.iter().any(|c| c.key == "bogus"));
     }
 }

--- a/src-tauri/src/context_menu.rs
+++ b/src-tauri/src/context_menu.rs
@@ -1,0 +1,286 @@
+use tauri::image::Image;
+use tauri::menu::{ContextMenu, IconMenuItem, Menu, MenuItem, NativeIcon, PredefinedMenuItem};
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::commands::{confirm_delete_if_needed, do_delete_note};
+use crate::i18n::{self, Lang, Msg};
+use crate::model::{is_valid_color_key, AppState, RecoverMutex, COLOR_DEFS};
+use crate::persistence::save_notes;
+use crate::window::{create_note_with_window, open_settings_window, open_trash_window};
+
+/// Generate a colored circle icon (16×16 RGBA) for context menu color items.
+fn color_circle(r: u8, g: u8, b: u8) -> Image<'static> {
+    const S: u32 = 16;
+    let mut rgba = vec![0u8; (S * S * 4) as usize];
+    let c = S as f32 / 2.0;
+    let rad = c - 1.0;
+    for y in 0..S {
+        for x in 0..S {
+            let d = ((x as f32 - c).powi(2) + (y as f32 - c).powi(2)).sqrt();
+            let i = ((y * S + x) * 4) as usize;
+            if d <= rad {
+                rgba[i] = r;
+                rgba[i + 1] = g;
+                rgba[i + 2] = b;
+                rgba[i + 3] = 255;
+            }
+        }
+    }
+    Image::new_owned(rgba, S, S)
+}
+
+/// Build and display the note context menu. Returns Err on menu construction failure.
+pub(crate) fn build_context_menu(
+    app: &AppHandle,
+    webview_win: &tauri::WebviewWindow,
+    is_pinned: bool,
+    current_color: &str,
+    lang: Lang,
+) -> tauri::Result<()> {
+    let color_items: Vec<IconMenuItem<tauri::Wry>> = COLOR_DEFS
+        .iter()
+        .map(|c| {
+            let check = if c.key == current_color {
+                "✓ "
+            } else {
+                "    "
+            };
+            IconMenuItem::with_id(
+                app,
+                format!("ctx_color_{}", c.key),
+                format!("{}{}", check, i18n::color_label(lang, c.key)),
+                true,
+                Some(color_circle(c.r, c.g, c.b)),
+                None::<&str>,
+            )
+        })
+        .collect::<tauri::Result<Vec<_>>>()?;
+
+    let copy = PredefinedMenuItem::copy(app, None)?;
+    let paste = PredefinedMenuItem::paste(app, None)?;
+    let sep0 = PredefinedMenuItem::separator(app)?;
+    let pin_label = if is_pinned {
+        Msg::CtxUnpin
+    } else {
+        Msg::CtxPin
+    };
+    let pin = MenuItem::with_id(
+        app,
+        "ctx_pin",
+        i18n::text(lang, pin_label),
+        true,
+        None::<&str>,
+    )?;
+    let new_note = IconMenuItem::with_id_and_native_icon(
+        app,
+        "ctx_new",
+        i18n::text(lang, Msg::NewNote),
+        true,
+        Some(NativeIcon::Add),
+        Some("CmdOrCtrl+N"),
+    )?;
+    let delete = IconMenuItem::with_id_and_native_icon(
+        app,
+        "ctx_delete",
+        i18n::text(lang, Msg::CtxDelete),
+        true,
+        Some(NativeIcon::Remove),
+        None::<&str>,
+    )?;
+    let trash = IconMenuItem::with_id_and_native_icon(
+        app,
+        "ctx_trash",
+        i18n::text(lang, Msg::CtxOpenTrash),
+        true,
+        Some(NativeIcon::TrashEmpty),
+        Some("CmdOrCtrl+Shift+T"),
+    )?;
+    let sep1 = PredefinedMenuItem::separator(app)?;
+    let sep1b = PredefinedMenuItem::separator(app)?;
+    let zoom_in = MenuItem::with_id(
+        app,
+        "ctx_zoom_in",
+        i18n::text(lang, Msg::ZoomIn),
+        true,
+        Some("CmdOrCtrl+="),
+    )?;
+    let zoom_out = MenuItem::with_id(
+        app,
+        "ctx_zoom_out",
+        i18n::text(lang, Msg::ZoomOut),
+        true,
+        Some("CmdOrCtrl+-"),
+    )?;
+    let zoom_reset = MenuItem::with_id(
+        app,
+        "ctx_zoom_reset",
+        i18n::text(lang, Msg::CtxZoomReset),
+        true,
+        Some("CmdOrCtrl+0"),
+    )?;
+    let sep2 = PredefinedMenuItem::separator(app)?;
+    let settings = MenuItem::with_id(
+        app,
+        "ctx_settings",
+        i18n::text(lang, Msg::CtxOpenSettings),
+        true,
+        Some("CmdOrCtrl+,"),
+    )?;
+    let sep3 = PredefinedMenuItem::separator(app)?;
+
+    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![
+        &copy,
+        &paste,
+        &sep0,
+        &pin,
+        &sep1,
+        &new_note,
+        &delete,
+        &trash,
+        &sep1b,
+        &zoom_in,
+        &zoom_out,
+        &zoom_reset,
+        &sep2,
+        &settings,
+        &sep3,
+    ];
+    for ci in &color_items {
+        items.push(ci as &dyn tauri::menu::IsMenuItem<tauri::Wry>);
+    }
+
+    let menu = Menu::with_items(app, &items)?;
+    // popup() is blocking — shows native menu and returns after user selects or dismisses
+    menu.popup(webview_win.as_ref().window().clone())?;
+    Ok(())
+}
+
+/// Handle context menu events (called from menu.rs on_menu_event)
+pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
+    let state: State<AppState> = app.state();
+    let note_id = state.context_menu_note_id.recover().clone();
+    if note_id.is_empty() {
+        return;
+    }
+    let win_label = format!("note-{}", note_id);
+
+    let win = app.get_webview_window(&win_label);
+
+    match event_id {
+        "ctx_pin" => {
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-toggle-pin", ());
+            }
+        }
+        "ctx_new" => {
+            create_note_with_window(app, &state);
+        }
+        "ctx_delete" => {
+            if confirm_delete_if_needed(app, &state) {
+                if let Err(e) = do_delete_note(&note_id, app, &state) {
+                    eprintln!("delete note error: {}", e);
+                }
+            }
+        }
+        "ctx_trash" => {
+            open_trash_window(app);
+        }
+        "ctx_settings" => {
+            open_settings_window(app, None);
+        }
+        "ctx_zoom_in" => {
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-zoom", "in");
+            }
+        }
+        "ctx_zoom_out" => {
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-zoom", "out");
+            }
+        }
+        "ctx_zoom_reset" => {
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-zoom", "reset");
+            }
+        }
+        _ if event_id.starts_with("ctx_color_") => {
+            let color = event_id.trim_start_matches("ctx_color_");
+            if !is_valid_color_key(color) {
+                return;
+            }
+            let snapshot = {
+                let mut notes = state.notes.recover();
+                if let Some(note) = notes.iter_mut().find(|n| n.id == note_id) {
+                    note.color = color.to_string();
+                    Some(notes.clone())
+                } else {
+                    None
+                }
+            };
+            if let Some(snap) = snapshot {
+                if let Err(e) = save_notes(&state, &snap) {
+                    eprintln!("save notes error: {}", e);
+                }
+            }
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-apply-color", color);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── color_circle ────────────────────────────────────────
+
+    #[test]
+    fn color_circle_is_16x16() {
+        let img = color_circle(255, 0, 0);
+        assert_eq!(img.width(), 16);
+        assert_eq!(img.height(), 16);
+    }
+
+    #[test]
+    fn color_circle_center_is_opaque() {
+        let img = color_circle(255, 128, 0);
+        // Center pixel at (7, 7)
+        let i = (7 * 16 + 7) * 4;
+        let rgba = img.rgba();
+        assert_eq!(rgba[i], 255); // R
+        assert_eq!(rgba[i + 1], 128); // G
+        assert_eq!(rgba[i + 2], 0); // B
+        assert_eq!(rgba[i + 3], 255); // A = fully opaque
+    }
+
+    #[test]
+    fn color_circle_corner_is_transparent() {
+        let img = color_circle(255, 0, 0);
+        // Corner pixel at (0, 0) is outside the circle
+        let rgba = img.rgba();
+        assert_eq!(rgba[3], 0); // A = transparent
+    }
+
+    // ── COLOR_DEFS validation ────────────────────────────────
+
+    #[test]
+    fn color_defs_keys_are_unique() {
+        let keys: Vec<&str> = COLOR_DEFS.iter().map(|c| c.key).collect();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), keys.len(), "COLOR_DEFS has duplicate keys");
+    }
+
+    #[test]
+    fn color_defs_matches_valid_color_check() {
+        // All keys in COLOR_DEFS must pass the validation used in handle_context_menu_event
+        for c in COLOR_DEFS {
+            assert!(is_valid_color_key(c.key));
+        }
+        // A bogus key must not pass
+        assert!(!is_valid_color_key("bogus"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod context_menu;
 mod i18n;
 mod menu;
 pub mod model;
@@ -14,7 +15,7 @@ use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
 use i18n::{Lang, Msg};
-use model::{resolve_color, AppState, Note, Settings};
+use model::{resolve_color, AppState, Note, RecoverMutex, Settings};
 use persistence::{load_notes, load_settings, load_trash, save_notes, Loaded};
 use window::{bring_all_to_front, open_note_window};
 
@@ -107,13 +108,7 @@ pub fn run() {
             .collect::<Vec<_>>();
 
             if !unreadable.is_empty() {
-                let lang = i18n::resolve(
-                    state
-                        .settings
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .language,
-                );
+                let lang = i18n::resolve(state.settings.recover().language);
                 let separator = match lang {
                     Lang::Ja => "、",
                     Lang::En => ", ",
@@ -152,22 +147,13 @@ pub fn run() {
             }
 
             // Restore saved notes
-            let notes = state
-                .notes
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .clone();
+            let notes = state.notes.recover().clone();
 
             if notes.is_empty() {
                 // Create default notes on first launch — one in Japanese, one in
                 // English, so a first-time user sees both regardless of OS locale.
                 drop(notes);
-                let default_color = state
-                    .settings
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .default_color
-                    .clone();
+                let default_color = state.settings.recover().default_color.clone();
                 let color = resolve_color(&default_color);
 
                 let mut note_ja = Note::new(&color);
@@ -179,7 +165,7 @@ pub fn run() {
 
                 open_note_window(app.handle(), &note_ja);
                 open_note_window(app.handle(), &note_en);
-                let mut notes = state.notes.lock().unwrap_or_else(|e| e.into_inner());
+                let mut notes = state.notes.recover();
                 notes.push(note_ja);
                 notes.push(note_en);
                 if let Err(e) = save_notes(&state, &notes) {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -21,7 +21,7 @@ pub(crate) fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
         let eid_str = eid.as_ref();
         // Context menu events (ctx_ prefix)
         if eid_str.starts_with("ctx_") {
-            crate::commands::handle_context_menu_event(app, eid_str);
+            crate::context_menu::handle_context_menu_event(app, eid_str);
             return;
         }
         match eid_str {

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -79,6 +79,16 @@ pub(crate) const COLOR_DEFS: &[ColorDef] = &[
     },
 ];
 
+/// `COLOR_DEFS` に実在する色キーか検証する。
+pub(crate) fn is_valid_color_key(color: &str) -> bool {
+    COLOR_DEFS.iter().any(|c| c.key == color)
+}
+
+/// `default_color` として妥当な値か検証する。`"random"` と `COLOR_DEFS` のキーのみを許可する。
+pub(crate) fn is_valid_default_color(color: &str) -> bool {
+    color == "random" || is_valid_color_key(color)
+}
+
 // ── Data Model ──────────────────────────────────────────────
 
 pub(crate) const TRASH_MAX: usize = 200;
@@ -444,5 +454,24 @@ mod tests {
     fn resolve_color_unknown_key_passthrough() {
         // 不明なキーはそのまま返す（バリデーションは呼び出し側が行う）
         assert_eq!(resolve_color("bogus"), "bogus");
+    }
+
+    // ── is_valid_default_color ──
+
+    #[test]
+    fn is_valid_default_color_accepts_random() {
+        assert!(is_valid_default_color("random"));
+    }
+
+    #[test]
+    fn is_valid_default_color_accepts_color_defs_keys() {
+        for c in COLOR_DEFS {
+            assert!(is_valid_default_color(c.key));
+        }
+    }
+
+    #[test]
+    fn is_valid_default_color_rejects_unknown_key() {
+        assert!(!is_valid_default_color("bogus"));
     }
 }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::de::DeserializeOwned;
 
-use crate::model::{AppState, Note, Settings, TRASH_MAX};
+use crate::model::{is_valid_default_color, AppState, Note, Settings, TRASH_MAX};
 
 /// ファイル読み込みの結果。「無い」「読めた」「あるが読めない」を区別する。
 /// `Vec<Note>` の `Default` が空であるのと同じ形になってしまう `Unreadable` を
@@ -131,7 +131,17 @@ pub(crate) fn save_notes(state: &AppState, notes: &[Note]) -> Result<(), String>
 }
 
 fn load_settings_from(path: &Path) -> Loaded<Settings> {
-    load_json(path)
+    match load_json::<Settings>(path) {
+        Loaded::Ok(mut s) => {
+            // 未知の `language` を `Auto` に倒すのと同じ方針で、手編集などで壊れた
+            // `default_color` も既定色に倒し、不正値のまま付箋が作られるのを防ぐ
+            if !is_valid_default_color(&s.default_color) {
+                s.default_color = Settings::default().default_color;
+            }
+            Loaded::Ok(s)
+        }
+        other => other,
+    }
 }
 
 pub(crate) fn load_settings(dir: &Path) -> Loaded<Settings> {
@@ -295,6 +305,24 @@ mod tests {
         assert!(!loaded.bring_all_to_front);
         assert!(loaded.confirm_before_delete);
         assert_eq!(loaded.language, LanguageSetting::En);
+    }
+
+    #[test]
+    fn load_settings_invalid_default_color_falls_back_to_default() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, r#"{"default_color":"vermilion","opacity":100}"#).unwrap();
+        let loaded = unwrap_ok(load_settings_from(&path));
+        assert_eq!(loaded.default_color, "yellow");
+    }
+
+    #[test]
+    fn load_settings_random_default_color_is_kept() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, r#"{"default_color":"random","opacity":100}"#).unwrap();
+        let loaded = unwrap_ok(load_settings_from(&path));
+        assert_eq!(loaded.default_color, "random");
     }
 
     #[test]

--- a/tests/unit/tauri-commands.test.js
+++ b/tests/unit/tauri-commands.test.js
@@ -15,7 +15,8 @@ function handlerCommands() {
   const src = read("src-tauri/src/lib.rs");
   const block = src.match(/generate_handler!\[([\s\S]*?)\]/);
   assert.ok(block, "generate_handler! が lib.rs に見つからない");
-  return [...block[1].matchAll(/commands::(\w+)/g)].map((m) => m[1]);
+  // モジュール名は固定しない。コマンドが commands.rs 以外へ移っても一覧から落とさない
+  return [...block[1].matchAll(/\w+::(\w+)/g)].map((m) => m[1]);
 }
 
 /** fixtures.ts のモックの switch が分岐するコマンド名。plugin 呼び出しは対象外。 */


### PR DESCRIPTION
## 背景

commands.rs と lib.rs に、同じことを別々の書き方でやっている箇所が残っている。コンテキストメニューの色アイテムだけ `.unwrap()` で他は `?`、`RecoverMutex::recover()` があるのに lib.rs は生の `lock().unwrap_or_else(...)`、`update_note_color` は色キーを検証するのに `update_settings` の `default_color` は素通し、といった不揃いで、commands.rs は 615 行の半分近くをコンテキストメニュー構築が占めている。

## やったこと

- context_menu.rs を新設し、`color_circle` / `build_context_menu` / `handle_context_menu_event` とそのテストを commands.rs から移動。`show_context_menu` コマンドは commands.rs に残す
- 色アイテム生成の `.unwrap()` をエラー伝播（`?`）に揃え、メニュー構築失敗でパニックしないように
- lib.rs の `lock().unwrap_or_else(...)` 3 箇所を `recover()` へ
- 色キーの検証を `is_valid_color_key` として model.rs に一本化し、`update_note_color` / コンテキストメニュー / `is_valid_default_color` が同じ関数を通るように
- `default_color` の検証を追加: `update_settings` は不正値なら既存値を維持（`update_note_color` と同じ方針）、読み込み時は既定色に倒す（未知の `language` を `Auto` に倒すのと同じ方針）
- コマンド照合テストの `generate_handler!` 抽出をモジュール名固定にしない形へ

## 確認したこと

`cargo test` 80 件、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check`、node 単体テスト 124 件が通る。

## 関連リンク

- Closes #49
