### PR TITLE
🐛 保存に失敗したときメモリ上の変更が巻き戻らないのを直す

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -125,51 +125,69 @@ pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState) -> boo
 
 /// 付箋をゴミ箱へ移動する（メモリ上の移動＋保存のみ。ウィンドウは操作しない）。
 /// 該当 id の付箋があったかどうかを返す。
+///
+/// 移動後の notes / trash を計算してから保存し、1 本目 (trash.json) が成功して
+/// はじめてメモリへ反映する。1 本目が失敗した時点ではメモリはまだ計算前のままなので
+/// 呼び出し元は無傷な状態で Err を受け取る。2 本目 (notes.json) の失敗はメモリを
+/// 戻さない。メモリは意図した最終状態にあり、ディスクは両方のファイルに付箋が
+/// 残っているので次に成功した保存で収束する。
 pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, String> {
     let (notes_snapshot, trash_snapshot) = {
-        let mut notes = state.notes.recover();
-        if let Some(pos) = notes.iter().position(|n| n.id == id) {
-            let mut note = notes.remove(pos);
-            let notes_snap = notes.clone();
-            drop(notes);
-            note.deleted_at = Some(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-            );
-            let mut trash = state.trash.recover();
-            // 保存が途中で止まって付箋とゴミ箱の両方に残った付箋を再度削除しても
-            // ゴミ箱に同じ id が並ばないようにする
-            trash.retain(|n| n.id != id);
-            trash.push(note);
-            enforce_trash_limit(&mut trash);
-            let trash_snap = trash.clone();
-            drop(trash);
-            (Some(notes_snap), Some(trash_snap))
-        } else {
-            (None, None)
-        }
+        let notes = state.notes.recover();
+        let Some(pos) = notes.iter().position(|n| n.id == id) else {
+            return Ok(false);
+        };
+        let mut notes_snap = notes.clone();
+        drop(notes);
+        let mut note = notes_snap.remove(pos);
+        note.deleted_at = Some(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+        let mut trash_snap = state.trash.recover().clone();
+        // 保存が途中で止まって付箋とゴミ箱の両方に残った付箋を再度削除しても
+        // ゴミ箱に同じ id が並ばないようにする
+        trash_snap.retain(|n| n.id != id);
+        trash_snap.push(note);
+        enforce_trash_limit(&mut trash_snap);
+        (notes_snap, trash_snap)
     };
-    let found = notes_snapshot.is_some();
     // 付箋側を先に消すと、間で中断したときにどちらのファイルからも消える。
     // この順なら両方に残るので捨て直せる
-    if let Some(ts) = &trash_snapshot {
-        save_trash(state, ts)?;
-    }
-    if let Some(ns) = &notes_snapshot {
-        save_notes(state, ns)?;
-    }
-    Ok(found)
+    save_trash(state, &trash_snapshot)?;
+    // スナップショットで丸ごと差し替える。計算と反映の間に notes / trash を書く
+    // 経路が並行して走ると更新が消えるため、コマンドのメインスレッド直列実行が前提
+    *state.notes.recover() = notes_snapshot.clone();
+    *state.trash.recover() = trash_snapshot.clone();
+    save_notes(state, &notes_snapshot)?;
+    Ok(true)
 }
 
 /// Move a note to trash and close its window.
 pub(crate) fn do_delete_note(id: &str, app: &AppHandle, state: &AppState) -> Result<(), String> {
-    delete_note_data(state, id)?;
-    if let Some(win) = app.get_webview_window(&format!("note-{}", id)) {
-        let _ = win.close();
+    match delete_note_data(state, id) {
+        Ok(_) => {
+            if let Some(win) = app.get_webview_window(&format!("note-{}", id)) {
+                let _ = win.close();
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // 2 本目の保存 (notes.json) が失敗した場合、メモリの notes からは既に
+            // 消えている。ウィンドウを残すとオートセーブが note not found で失敗し
+            // 続けるので、メモリの状態を見てウィンドウを閉じる。1 本目の失敗では
+            // メモリは無傷なのでウィンドウは残す
+            let still_in_notes = state.notes.recover().iter().any(|n| n.id == id);
+            if !still_in_notes {
+                if let Some(win) = app.get_webview_window(&format!("note-{}", id)) {
+                    let _ = win.close();
+                }
+            }
+            Err(e)
+        }
     }
-    Ok(())
 }
 
 /// 付箋をゴミ箱へ移動する。`confirm_before_delete` が有効な場合は確認ダイアログを表示する。
@@ -199,37 +217,38 @@ pub(crate) fn get_trash_max() -> usize {
 
 /// ゴミ箱から付箋を notes へ戻す（メモリ上の移動＋保存のみ。ウィンドウは操作しない）。
 /// 見つからない場合は `None`。
+///
+/// `delete_note_data` と対称に、移動後の notes / trash を計算してから保存し、
+/// 1 本目 (notes.json) が成功してはじめてメモリへ反映する。1 本目が失敗した時点
+/// ではメモリはまだ計算前のまま（ゴミ箱に残ったまま）なので、呼び出し元は無傷な
+/// 状態で Err を受け取る。2 本目 (trash.json) の失敗はメモリを戻さない。
 pub(crate) fn restore_note_data(state: &AppState, id: &str) -> Result<Option<Note>, String> {
-    let (note, trash_snapshot) = {
-        let mut trash = state.trash.recover();
-        if let Some(pos) = trash.iter().position(|n| n.id == id) {
-            let note = trash.remove(pos);
-            let snap = trash.clone();
-            (Some(note), Some(snap))
-        } else {
-            (None, None)
-        }
-    };
-    let Some(mut note) = note else {
-        return Ok(None);
-    };
-    note.deleted_at = None;
-    let notes_snapshot = {
-        let mut notes = state.notes.recover();
+    let (note, notes_snapshot, trash_snapshot) = {
+        let trash = state.trash.recover();
+        let Some(pos) = trash.iter().position(|n| n.id == id) else {
+            return Ok(None);
+        };
+        let mut trash_snap = trash.clone();
+        drop(trash);
+        let mut note = trash_snap.remove(pos);
+        note.deleted_at = None;
+        let mut notes_snap = state.notes.recover().clone();
         // 保存が途中で止まって付箋とゴミ箱の両方に残った付箋を復元しても
         // 付箋側に同じ id が並ばないようにする。ゴミ箱のコピーは削除時点のもので
         // 以降の編集を含まないため、付箋側に残っているほうを勝たせる
-        if !notes.iter().any(|n| n.id == note.id) {
-            notes.push(note.clone());
+        if !notes_snap.iter().any(|n| n.id == note.id) {
+            notes_snap.push(note.clone());
         }
-        notes.clone()
+        (note, notes_snap, trash_snap)
     };
     // ゴミ箱側を先に消すと、間で中断したときにどちらのファイルからも消える。
     // この順なら両方に残るので復元し直せる
     save_notes(state, &notes_snapshot)?;
-    if let Some(ts) = &trash_snapshot {
-        save_trash(state, ts)?;
-    }
+    // スナップショットで丸ごと差し替える。計算と反映の間に notes / trash を書く
+    // 経路が並行して走ると更新が消えるため、コマンドのメインスレッド直列実行が前提
+    *state.notes.recover() = notes_snapshot;
+    *state.trash.recover() = trash_snapshot.clone();
+    save_trash(state, &trash_snapshot)?;
     Ok(Some(note))
 }
 
@@ -248,9 +267,11 @@ pub(crate) fn restore_note(
             Ok(note)
         }
         Err(e) => {
-            // 保存に失敗してもメモリ上では復元済みで、ゴミ箱一覧からは既に消えている。
-            // ウィンドウまで出さないと付箋がどこにも見えなくなるので、開いたうえで
-            // エラーを返す
+            // ウィンドウを開くかは失敗した保存の本数ではなくメモリの状態で決める。
+            // メモリの notes に付箋があれば（2 本目の保存失敗で反映済みの場合と、
+            // 付箋側に同じ id が残っていた場合）ウィンドウを開く。出さないと
+            // 付箋がどこにも見えなくなる。1 本目の失敗ではメモリも無傷で、
+            // 付箋はまだゴミ箱に残っている
             let note = {
                 let notes = state.notes.recover();
                 notes.iter().find(|n| n.id == id).cloned()
@@ -263,14 +284,20 @@ pub(crate) fn restore_note(
     }
 }
 
+/// ゴミ箱を空にする（メモリ上の反映＋保存）。
+///
+/// 保存が成功してからメモリを clear する。先に clear すると、保存失敗時に
+/// メモリだけ空になりディスクの trash.json には付箋が残ったままになる。
+pub(crate) fn empty_trash_data(state: &AppState) -> Result<(), String> {
+    save_trash(state, &[])?;
+    state.trash.recover().clear();
+    Ok(())
+}
+
 /// ゴミ箱を空にする。
 #[tauri::command]
 pub(crate) fn empty_trash(state: State<AppState>) -> Result<(), String> {
-    {
-        let mut trash = state.trash.recover();
-        trash.clear();
-    }
-    save_trash(&state, &[])
+    empty_trash_data(&state)
 }
 
 /// 現在の設定を返す。
@@ -500,6 +527,38 @@ mod tests {
         assert_eq!(read_trash_json(&dir)[0].id, "a");
     }
 
+    /// 1 本目 (trash.json) の保存が失敗したとき、メモリはまだ計算前のまま
+    /// （notes に残り trash には入らない）で、notes.json も書かれない。
+    #[test]
+    fn delete_note_data_first_save_failure_leaves_memory_untouched() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("trash.json")).unwrap();
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
+
+        assert!(delete_note_data(&state, "a").is_err());
+
+        assert_eq!(state.notes.recover().len(), 1);
+        assert_eq!(state.notes.recover()[0].id, "a");
+        assert!(state.trash.recover().is_empty());
+        assert!(!dir.path().join("notes.json").exists());
+    }
+
+    /// 2 本目 (notes.json) の保存が失敗しても、メモリは新しい状態（notes から消え
+    /// trash に入る）へ反映済みで、1 本目に成功した trash.json にも書かれている。
+    #[test]
+    fn delete_note_data_second_save_failure_still_updates_memory() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("notes.json")).unwrap();
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
+
+        assert!(delete_note_data(&state, "a").is_err());
+
+        assert!(state.notes.recover().is_empty());
+        assert_eq!(state.trash.recover().len(), 1);
+        assert_eq!(state.trash.recover()[0].id, "a");
+        assert_eq!(read_trash_json(&dir)[0].id, "a");
+    }
+
     // ── restore_note_data ─────────────────────────────────────
 
     #[test]
@@ -557,6 +616,63 @@ mod tests {
         assert!(restore_note_data(&state, "a").is_err());
 
         assert_eq!(read_notes_json(&dir)[0].id, "a");
+    }
+
+    /// 1 本目 (notes.json) の保存が失敗したとき、メモリはまだ計算前のまま
+    /// （trash に残り notes には入らない）で、trash.json も書かれない。
+    #[test]
+    fn restore_note_data_first_save_failure_leaves_memory_untouched() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("notes.json")).unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "hello")]);
+
+        assert!(restore_note_data(&state, "a").is_err());
+
+        assert!(state.notes.recover().is_empty());
+        assert_eq!(state.trash.recover().len(), 1);
+        assert_eq!(state.trash.recover()[0].id, "a");
+        assert!(!dir.path().join("trash.json").exists());
+    }
+
+    /// 2 本目 (trash.json) の保存が失敗しても、メモリは新しい状態（trash から消え
+    /// notes に入る）へ反映済みで、1 本目に成功した notes.json にも書かれている。
+    #[test]
+    fn restore_note_data_second_save_failure_still_updates_memory() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("trash.json")).unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "hello")]);
+
+        assert!(restore_note_data(&state, "a").is_err());
+
+        assert_eq!(state.notes.recover().len(), 1);
+        assert_eq!(state.notes.recover()[0].id, "a");
+        assert!(state.trash.recover().is_empty());
+        assert_eq!(read_notes_json(&dir)[0].id, "a");
+    }
+
+    // ── empty_trash_data ──────────────────────────────────────
+
+    /// 保存が失敗したときはメモリの trash を clear しない。
+    #[test]
+    fn empty_trash_data_save_failure_leaves_memory_untouched() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("trash.json")).unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "hello")]);
+
+        assert!(empty_trash_data(&state).is_err());
+
+        assert_eq!(state.trash.recover().len(), 1);
+    }
+
+    #[test]
+    fn empty_trash_data_clears_memory_and_persists() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![], vec![make_note("a", "hello")]);
+
+        empty_trash_data(&state).unwrap();
+
+        assert!(state.trash.recover().is_empty());
+        assert!(read_trash_json(&dir).is_empty());
     }
 
     // ── delete → restore round-trip ───────────────────────────


### PR DESCRIPTION
## 背景

削除と復元はメモリ上の付箋一覧とゴミ箱を先に書き換えてから 2 つのファイルを順に保存するため、1 本目の保存が失敗するとメモリだけが変更後の状態で残る。その状態で別の操作が反対側のファイルを保存すると、付箋が両方のファイルから消える（issue #43 の再現筋道）。副症状として、削除の早期 return ではウィンドウが閉じられないのにメモリからは消えているため、そのウィンドウのオートセーブが失敗し続ける。empty_trash も同型で、メモリを clear してから保存している。

## やったこと

- `delete_note_data` / `restore_note_data`: 「ロック中は新しい notes / trash の計算のみ → 1 本目の保存 → 成功したらメモリへ反映 → 2 本目の保存」の順に組み替え。1 本目の失敗ではメモリ・ディスクとも無傷、2 本目の失敗ではメモリが最終状態でディスクは両ファイルに残り、次に成功した保存で収束する
- `do_delete_note` / `restore_note`: 保存が失敗してもメモリの状態を見てウィンドウを閉じる / 開く（メモリから消えた付箋のウィンドウを残さない・見えない付箋を作らない）
- `empty_trash`: `empty_trash_data` に抽出し、保存が成功してからメモリを clear する順に変更

## 確認したこと

`cargo test` 86 件（1 本目 / 2 本目の保存を故意に失敗させてメモリとファイルの状態を確認するテスト 6 本を追加）、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check` が通る。

## 関連リンク

- Closes #43
