### PR TITLE
✨ 空の付箋は確認もゴミ箱行きも無しで削除する

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -102,7 +102,18 @@ pub(crate) fn update_note_pinned(
 }
 
 /// Confirm deletion if setting is enabled. Returns false if user cancelled.
-pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState) -> bool {
+/// 空の付箋（issue #56）は消えて困る中身が無いため、設定に関わらず確認しない。
+pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState, id: &str) -> bool {
+    let is_empty = state
+        .notes
+        .recover()
+        .iter()
+        .find(|n| n.id == id)
+        .map(Note::is_empty)
+        .unwrap_or(false);
+    if is_empty {
+        return true;
+    }
     let (confirm, lang) = {
         let settings = state.settings.recover();
         (
@@ -132,14 +143,40 @@ pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState) -> boo
 /// 戻さない。メモリは意図した最終状態にあり、ディスクは両方のファイルに付箋が
 /// 残っているので次に成功した保存で収束する。
 pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, String> {
-    let (notes_snapshot, trash_snapshot) = {
+    let (notes_snapshot, mut note) = {
         let notes = state.notes.recover();
         let Some(pos) = notes.iter().position(|n| n.id == id) else {
             return Ok(false);
         };
         let mut notes_snap = notes.clone();
         drop(notes);
-        let mut note = notes_snap.remove(pos);
+        let note = notes_snap.remove(pos);
+        (notes_snap, note)
+    };
+
+    // 空の付箋（issue #56）は消えて困る中身が無いので、ゴミ箱に入れず notes から取り除くだけにする
+    if note.is_empty() {
+        // 保存が途中で止まって同じ id がゴミ箱にも残っている場合は、その残骸も一緒に
+        // 掃除する（掃除しないと空の付箋がゴミ箱に残り続ける）。書き込み順は非空の
+        // 削除と同じ trash 先行
+        let stale_trash = {
+            let trash = state.trash.recover();
+            trash.iter().any(|n| n.id == id).then(|| {
+                let mut snap = trash.clone();
+                snap.retain(|n| n.id != id);
+                snap
+            })
+        };
+        if let Some(ts) = &stale_trash {
+            save_trash(state, ts)?;
+            *state.trash.recover() = ts.clone();
+        }
+        save_notes(state, &notes_snapshot)?;
+        *state.notes.recover() = notes_snapshot;
+        return Ok(true);
+    }
+
+    let trash_snapshot = {
         note.deleted_at = Some(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -152,7 +189,7 @@ pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, Strin
         trash_snap.retain(|n| n.id != id);
         trash_snap.push(note);
         enforce_trash_limit(&mut trash_snap);
-        (notes_snap, trash_snap)
+        trash_snap
     };
     // 付箋側を先に消すと、間で中断したときにどちらのファイルからも消える。
     // この順なら両方に残るので捨て直せる
@@ -197,7 +234,7 @@ pub(crate) fn delete_note(
     app: AppHandle,
     state: State<AppState>,
 ) -> Result<(), String> {
-    if !confirm_delete_if_needed(&app, &state) {
+    if !confirm_delete_if_needed(&app, &state, &id) {
         return Ok(());
     }
     do_delete_note(&id, &app, &state)
@@ -465,7 +502,7 @@ mod tests {
     #[test]
     fn delete_note_data_sets_deleted_at() {
         let dir = TempDir::new().unwrap();
-        let state = make_state(&dir, vec![make_note("a", "")], vec![]);
+        let state = make_state(&dir, vec![make_note("a", "hello")], vec![]);
 
         delete_note_data(&state, "a").unwrap();
 
@@ -492,7 +529,7 @@ mod tests {
         let existing_trash: Vec<Note> = (0..TRASH_MAX)
             .map(|i| make_note(&i.to_string(), ""))
             .collect();
-        let state = make_state(&dir, vec![make_note("new", "")], existing_trash);
+        let state = make_state(&dir, vec![make_note("new", "hello")], existing_trash);
 
         delete_note_data(&state, "new").unwrap();
 
@@ -512,6 +549,72 @@ mod tests {
         assert!(!found);
         assert!(!dir.path().join("notes.json").exists());
         assert!(!dir.path().join("trash.json").exists());
+    }
+
+    // ── delete_note_data: 空の付箋（issue #56） ──────────────────
+
+    #[test]
+    fn delete_note_data_empty_note_skips_trash() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "")], vec![make_note("z", "kept")]);
+
+        let found = delete_note_data(&state, "a").unwrap();
+
+        assert!(found);
+        assert!(state.notes.recover().is_empty());
+        let trash = state.trash.recover();
+        assert_eq!(trash.len(), 1);
+        assert_eq!(trash[0].id, "z");
+        assert!(read_notes_json(&dir).is_empty());
+        assert!(!dir.path().join("trash.json").exists());
+    }
+
+    #[test]
+    fn delete_note_data_whitespace_only_note_skips_trash() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir, vec![make_note("a", "  \n\t\n  ")], vec![]);
+
+        delete_note_data(&state, "a").unwrap();
+
+        assert!(state.notes.recover().is_empty());
+        assert!(state.trash.recover().is_empty());
+        assert!(!dir.path().join("trash.json").exists());
+    }
+
+    /// 保存の中断で同じ id がゴミ箱にも残っていた空の付箋を削除すると、残骸も掃除される。
+    #[test]
+    fn delete_note_data_empty_note_cleans_stale_trash_entry() {
+        let dir = TempDir::new().unwrap();
+        let mut stale = make_note("a", "stale");
+        stale.deleted_at = Some(1);
+        let state = make_state(
+            &dir,
+            vec![make_note("a", "")],
+            vec![stale, make_note("z", "kept")],
+        );
+
+        delete_note_data(&state, "a").unwrap();
+
+        assert!(state.notes.recover().is_empty());
+        let trash_ids: Vec<String> = state.trash.recover().iter().map(|n| n.id.clone()).collect();
+        assert_eq!(trash_ids, vec!["z"]);
+        let disk = read_trash_json(&dir);
+        assert_eq!(disk.len(), 1);
+        assert_eq!(disk[0].id, "z");
+    }
+
+    /// 空の付箋の削除で notes.json の保存が失敗しても、メモリは無傷のまま。
+    #[test]
+    fn delete_note_data_empty_note_save_failure_leaves_memory_untouched() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("notes.json")).unwrap();
+        let state = make_state(&dir, vec![make_note("a", "")], vec![]);
+
+        assert!(delete_note_data(&state, "a").is_err());
+
+        assert_eq!(state.notes.recover().len(), 1);
+        assert_eq!(state.notes.recover()[0].id, "a");
+        assert!(state.trash.recover().is_empty());
     }
 
     /// ゴミ箱側を先に書く順序の確認。notes.json への書き込みをディレクトリ衝突で

--- a/src-tauri/src/context_menu.rs
+++ b/src-tauri/src/context_menu.rs
@@ -176,7 +176,7 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
             create_note_with_window(app, &state);
         }
         "ctx_delete" => {
-            if confirm_delete_if_needed(app, &state) {
+            if confirm_delete_if_needed(app, &state, &note_id) {
                 if let Err(e) = do_delete_note(&note_id, app, &state) {
                     eprintln!("delete note error: {}", e);
                 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -30,7 +30,7 @@ pub(crate) fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
                     let label = win.label().to_string();
                     if let Some(note_id) = label.strip_prefix("note-") {
                         let state: State<AppState> = app.state();
-                        if confirm_delete_if_needed(app, &state) {
+                        if confirm_delete_if_needed(app, &state, note_id) {
                             if let Err(e) = do_delete_note(note_id, app, &state) {
                                 eprintln!("delete note error: {}", e);
                             }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -126,6 +126,11 @@ pub(crate) fn clamp_opacity(opacity: u32) -> u32 {
 }
 
 impl Note {
+    /// 内容が空（空文字・空白のみ・改行のみを含む）かどうか。
+    pub(crate) fn is_empty(&self) -> bool {
+        self.content.trim().is_empty()
+    }
+
     pub(crate) fn new(color: &str) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
@@ -250,6 +255,27 @@ mod tests {
     fn note_new_color_reflected() {
         assert_eq!(Note::new("pink").color, "pink");
         assert_eq!(Note::new("green").color, "green");
+    }
+
+    // ── Note::is_empty() ──
+
+    #[test]
+    fn note_is_empty_for_empty_string() {
+        assert!(Note::new("yellow").is_empty());
+    }
+
+    #[test]
+    fn note_is_empty_for_whitespace_and_newlines_only() {
+        let mut note = Note::new("yellow");
+        note.content = "  \n\t\n  ".to_string();
+        assert!(note.is_empty());
+    }
+
+    #[test]
+    fn note_is_not_empty_with_content() {
+        let mut note = Note::new("yellow");
+        note.content = "hello".to_string();
+        assert!(!note.is_empty());
     }
 
     // ── Settings::default() ──

--- a/src/note.js
+++ b/src/note.js
@@ -544,7 +544,18 @@ function scheduleSave() {
 function saveNow() {
   clearTimeout(saveTimer);
   saveTimer = null;
-  fireInvoke('update_note_content', { id: noteId, content: rawContent }, I18N.t('toastSaveFailed'));
+  return fireInvoke('update_note_content', { id: noteId, content: rawContent }, I18N.t('toastSaveFailed'));
+}
+
+/**
+ * デバウンス中の入力と生表示中の行を書き戻して保存し、完了を待つ。
+ * 削除の空判定はバックエンドのメモリ上の内容で行われるため、削除前に
+ * これを挟まないと、入力直後の付箋が空とみなされて内容ごと消える。
+ */
+function flushContent() {
+  if (!saveTimer && activeStart == null) return Promise.resolve();
+  snapshotContent();
+  return saveNow();
 }
 
 // ── Raw Editor Bindings ───────────────────────────
@@ -698,7 +709,8 @@ newBtn.addEventListener('click', () => {
   fireInvoke('create_note', undefined, I18N.t('toastCreateFailed'));
 });
 
-document.getElementById('btn-delete').addEventListener('click', () => {
+document.getElementById('btn-delete').addEventListener('click', async () => {
+  await flushContent();
   fireInvoke('delete_note', { id: noteId }, I18N.t('toastDeleteFailed'));
 });
 
@@ -779,9 +791,11 @@ window.addEventListener('beforeunload', () => {
 });
 
 // ── Context Menu (native via Tauri) ──────────────────
-document.addEventListener('contextmenu', (e) => {
+document.addEventListener('contextmenu', async (e) => {
   if (e.shiftKey) return;
   e.preventDefault();
+  // メニューから削除が選ばれてもよいように、開く前に保存を済ませておく
+  await flushContent();
   invoke('show_context_menu', {
     id: noteId,
     isPinned: pinBtn.classList.contains('active'),


### PR DESCRIPTION
## 背景

空の付箋を消すときも、内容のある付箋と同じく確認ダイアログが出てゴミ箱に入る。消えて困る中身が無いので、どちらも手間になっている。

## 仕様

内容が空（空白・改行のみを含む）の付箋は、`confirm_before_delete` の設定に関わらず確認ダイアログを出さず、ゴミ箱にも入れずに削除する。削除ボタン・右クリックメニュー・アプリメニューのどの経路でも同じ。

## やったこと

- model.rs: `Note::is_empty()`（`content.trim()` が空）を追加し、空の判定を一箇所に集約
- commands.rs: `confirm_delete_if_needed` は空の付箋ならダイアログを出さず削除を許可。`delete_note_data` は空の付箋を trash に入れず notes からだけ取り除く（保存が中断して trash に残っていた同 id の残骸は掃除する）
- note.js: 削除ボタンとコンテキストメニューを開く前に、デバウンス中の入力を保存してから進む `flushContent()` を追加。空判定はバックエンドのメモリ上の内容で行われるため、これが無いと入力直後の削除で書いたばかりの内容が空とみなされて消える

## 確認したこと

`cargo test` 93 件（空・空白のみ・残骸掃除・保存失敗時のテストを追加）、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check`、`npm run lint`、Playwright 197 件が通る。実機でも、空の付箋が確認なし・ゴミ箱なしで消えること、入力直後の削除では従来どおり確認が出てゴミ箱に入ることを確認した。

## 関連リンク

- Closes #56
