### PR TITLE
⬆️ rand 0.8.5 を脆弱性修正版へ上げる

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
## 背景

dependabot が rand の脆弱性（GHSA: カスタムロガー使用時の `rand::rng()` の unsoundness、対象 0.7.0〜0.8.5）を報告している。ロックには 0.7.3 / 0.8.5 / 0.10.2 の 3 つのバージョンが並び、このうち 0.8.5（phf_macros 経由）だけが semver 互換の修正版 0.8.6 以降へ上げられる。0.7.3 は phf_generator 0.8 の要求で 0.7 系に修正版が無く、上流（tauri-utils の依存）待ち。

## やったこと

- `cargo update -p rand@0.8.5` — 0.8.7 へ更新（Cargo.lock のみ）

## 確認したこと

`cargo test` 93 件、`cargo clippy --all-targets -- -D warnings` が通る。

## 関連リンク

- [dependabot アラート](https://github.com/somei-san/hattotto/security/dependabot)
