### PR TITLE
🔊 失敗をログファイルに残して不具合を追えるようにする

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,11 @@ npm test
 npm run test:update
 ```
 
+## ログ
+
+`~/Library/Logs/com.hattotto.app/` にログファイルが出力される。不具合の追跡はまずここを見る。
+上限 1MB・直近 1 世代のみ保持（超えたら古い世代を破棄して書き直す）。
+
 ## 技術スタック
 
 - **Backend:** Rust + Tauri v2

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1585,6 +1621,7 @@ name = "hattotto"
 version = "0.4.0"
 dependencies = [
  "dirs 6.0.0",
+ "log",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -1593,6 +1630,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-log",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tempfile",
@@ -2375,6 +2413,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4187,6 +4234,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4406,7 +4474,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-log = "2"
+log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -377,10 +377,10 @@ pub(crate) fn update_settings(
     };
     if language_changed {
         if let Err(e) = menu::rebuild_app_menu(&app) {
-            eprintln!("rebuild app menu error: {}", e);
+            log::error!("rebuild app menu error: {}", e);
         }
         if let Err(e) = tray::rebuild_tray(&app) {
-            eprintln!("rebuild tray error: {}", e);
+            log::error!("rebuild tray error: {}", e);
         }
         // ネイティブウィンドウのタイトルは生成時にしか設定されないため、開いていれば組み直す
         let lang = i18n::resolve(snapshot.language);
@@ -430,7 +430,7 @@ pub(crate) fn show_context_menu(
 
     let lang = i18n::resolve(state.settings.recover().language);
     if let Err(e) = build_context_menu(&app, &webview_win, is_pinned, &current_color, lang) {
-        eprintln!("context menu error: {}", e);
+        log::error!("context menu error: {}", e);
     }
 }
 
@@ -468,6 +468,9 @@ mod tests {
             notes_loaded: true,
             settings_loaded: true,
             trash_loaded: true,
+            notes_load_error: None,
+            settings_load_error: None,
+            trash_load_error: None,
         }
     }
 

--- a/src-tauri/src/context_menu.rs
+++ b/src-tauri/src/context_menu.rs
@@ -178,7 +178,7 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
         "ctx_delete" => {
             if confirm_delete_if_needed(app, &state, &note_id) {
                 if let Err(e) = do_delete_note(&note_id, app, &state) {
-                    eprintln!("delete note error: {}", e);
+                    log::error!("delete note error: {}", e);
                 }
             }
         }
@@ -219,7 +219,7 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
             };
             if let Some(snap) = snapshot {
                 if let Err(e) = save_notes(&state, &snap) {
-                    eprintln!("save notes error: {}", e);
+                    log::error!("save notes error: {}", e);
                 }
             }
             if let Some(w) = &win {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use tauri::{Manager, State};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
 
 use i18n::{Lang, Msg};
 use model::{resolve_color, AppState, Note, RecoverMutex, Settings};
@@ -23,20 +24,20 @@ use window::{bring_all_to_front, open_note_window};
 
 pub fn run() {
     let data_dir = persistence::data_dir();
-    let (notes, notes_loaded) = match load_notes(&data_dir) {
-        Loaded::Missing => (Vec::new(), true),
-        Loaded::Ok(v) => (v, true),
-        Loaded::Unreadable => (Vec::new(), false),
+    let (notes, notes_loaded, notes_load_error) = match load_notes(&data_dir) {
+        Loaded::Missing => (Vec::new(), true, None),
+        Loaded::Ok(v) => (v, true, None),
+        Loaded::Unreadable(e) => (Vec::new(), false, Some(e)),
     };
-    let (settings, settings_loaded) = match load_settings(&data_dir) {
-        Loaded::Missing => (Settings::default(), true),
-        Loaded::Ok(v) => (v, true),
-        Loaded::Unreadable => (Settings::default(), false),
+    let (settings, settings_loaded, settings_load_error) = match load_settings(&data_dir) {
+        Loaded::Missing => (Settings::default(), true, None),
+        Loaded::Ok(v) => (v, true, None),
+        Loaded::Unreadable(e) => (Settings::default(), false, Some(e)),
     };
-    let (trash, trash_loaded) = match load_trash(&data_dir) {
-        Loaded::Missing => (Vec::new(), true),
-        Loaded::Ok(v) => (v, true),
-        Loaded::Unreadable => (Vec::new(), false),
+    let (trash, trash_loaded, trash_load_error) = match load_trash(&data_dir) {
+        Loaded::Missing => (Vec::new(), true, None),
+        Loaded::Ok(v) => (v, true, None),
+        Loaded::Unreadable(e) => (Vec::new(), false, Some(e)),
     };
     let state = AppState {
         notes: Mutex::new(notes),
@@ -48,6 +49,9 @@ pub fn run() {
         notes_loaded,
         settings_loaded,
         trash_loaded,
+        notes_load_error,
+        settings_load_error,
+        trash_load_error,
     };
 
     tauri::Builder::default()
@@ -63,6 +67,40 @@ pub fn run() {
         ))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        // ログは補助機能なので、初期化に失敗しても起動は止めない。
+        // `tauri_plugin_log::Builder::build()` は内部で失敗を setup の Err として
+        // 伝播させ、`app.build().expect(...)` の panic につながる。`split()` +
+        // `attach_logger()` を自前の plugin setup 内で呼び、エラーは握り潰して
+        // 常に `Ok(())` を返すことでこの経路を避ける
+        .plugin(
+            tauri::plugin::Builder::<_, ()>::new("hattotto-log")
+                .setup(|app_handle, _api| {
+                    let split = tauri_plugin_log::Builder::new()
+                        .targets([
+                            Target::new(TargetKind::LogDir { file_name: None }),
+                            Target::new(TargetKind::Stdout),
+                        ])
+                        .max_file_size(1_000_000)
+                        .rotation_strategy(RotationStrategy::KeepOne)
+                        // 依存クレート（tauri / wry / tao 等）の Info ログで
+                        // 1MB のローテーション上限を食い切ると、追跡したい
+                        // 自アプリの error まで KeepOne で失われる。全体は Warn
+                        // に絞り、自クレートだけ Info まで通す
+                        .level(log::LevelFilter::Warn)
+                        .level_for(env!("CARGO_PKG_NAME"), log::LevelFilter::Info)
+                        .split(app_handle);
+                    match split {
+                        Ok((_plugin, max_level, logger)) => {
+                            if let Err(e) = tauri_plugin_log::attach_logger(max_level, logger) {
+                                eprintln!("Failed to attach logger: {e}");
+                            }
+                        }
+                        Err(e) => eprintln!("Failed to initialize logger: {e}"),
+                    }
+                    Ok(())
+                })
+                .build(),
+        )
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             commands::get_note,
@@ -86,10 +124,10 @@ pub fn run() {
         .setup(|app| {
             // Set up app menu and system tray
             if let Err(e) = menu::setup_app_menu(app.handle()) {
-                eprintln!("Failed to setup app menu: {e}");
+                log::error!("Failed to setup app menu: {e}");
             }
             if let Err(e) = tray::setup_tray(app.handle()) {
-                eprintln!("Failed to setup tray: {e}");
+                log::error!("Failed to setup tray: {e}");
             }
 
             let state: State<AppState> = app.state();
@@ -106,6 +144,18 @@ pub fn run() {
             .filter(|(_, loaded)| !loaded)
             .map(|(name, _)| *name)
             .collect::<Vec<_>>();
+
+            // 原因をログに残す。ファイルの中身（付箋本文等）は含めず、
+            // io / serde エラーの文字列だけを出す
+            for (name, err) in [
+                ("notes.json", &state.notes_load_error),
+                ("settings.json", &state.settings_load_error),
+                ("trash.json", &state.trash_load_error),
+            ] {
+                if let Some(e) = err {
+                    log::error!("data file unreadable: {name} ({e})");
+                }
+            }
 
             if !unreadable.is_empty() {
                 let lang = i18n::resolve(state.settings.recover().language);
@@ -136,9 +186,9 @@ pub fn run() {
                         .status();
                     match result {
                         Ok(status) if !status.success() => {
-                            eprintln!("Failed to reveal data files: open exited with {status}");
+                            log::error!("Failed to reveal data files: open exited with {status}");
                         }
-                        Err(e) => eprintln!("Failed to reveal data files: {e}"),
+                        Err(e) => log::error!("Failed to reveal data files: {e}"),
                         Ok(_) => {}
                     }
                 }
@@ -169,7 +219,7 @@ pub fn run() {
                 notes.push(note_ja);
                 notes.push(note_en);
                 if let Err(e) = save_notes(&state, &notes) {
-                    eprintln!("save notes error: {}", e);
+                    log::error!("save notes error: {}", e);
                 }
             } else {
                 for note in &notes {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -32,7 +32,7 @@ pub(crate) fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
                         let state: State<AppState> = app.state();
                         if confirm_delete_if_needed(app, &state, note_id) {
                             if let Err(e) = do_delete_note(note_id, app, &state) {
-                                eprintln!("delete note error: {}", e);
+                                log::error!("delete note error: {}", e);
                             }
                         }
                     } else {

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -224,6 +224,11 @@ pub struct AppState {
     pub(crate) notes_loaded: bool,
     pub(crate) settings_loaded: bool,
     pub(crate) trash_loaded: bool,
+    /// 読み込み失敗時の理由（io / serde エラーの文字列）。ログ用で、`*_loaded` が
+    /// `true` のときは常に `None`。ファイルの内容（付箋本文等）は含まない
+    pub(crate) notes_load_error: Option<String>,
+    pub(crate) settings_load_error: Option<String>,
+    pub(crate) trash_load_error: Option<String>,
 }
 
 #[cfg(test)]

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -13,8 +13,9 @@ pub(crate) enum Loaded<T> {
     /// ファイルが存在しない。初回起動として扱ってよい
     Missing,
     Ok(T),
-    /// ファイルはあるが読み取り・パースに失敗した。上書き保存してはいけない
-    Unreadable,
+    /// ファイルはあるが読み取り・パースに失敗した。上書き保存してはいけない。
+    /// 理由文字列はログ用（io / serde エラーの `to_string()`）。ファイルの内容は含まない
+    Unreadable(String),
 }
 
 // ── Persistence ─────────────────────────────────────────────
@@ -80,14 +81,21 @@ fn load_json<T: DeserializeOwned>(path: &Path) -> Loaded<T> {
     match fs::metadata(path) {
         Ok(_) => {}
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Loaded::Missing,
-        Err(_) => return Loaded::Unreadable,
+        Err(e) => return Loaded::Unreadable(e.to_string()),
     }
     match fs::read_to_string(path) {
         Ok(s) => match serde_json::from_str(&s) {
             Ok(v) => Loaded::Ok(v),
-            Err(_) => Loaded::Unreadable,
+            // serde エラーの Display はファイル内の文字列値を逐語で含みうる
+            // （付箋本文がログに漏れる）ため、種別と位置だけを残す
+            Err(e) => Loaded::Unreadable(format!(
+                "{:?} error at line {} column {}",
+                e.classify(),
+                e.line(),
+                e.column()
+            )),
         },
-        Err(_) => Loaded::Unreadable,
+        Err(e) => Loaded::Unreadable(e.to_string()),
     }
 }
 
@@ -222,6 +230,9 @@ mod tests {
             notes_loaded,
             settings_loaded,
             trash_loaded,
+            notes_load_error: None,
+            settings_load_error: None,
+            trash_load_error: None,
         }
     }
 
@@ -368,7 +379,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("notes.json");
         fs::write(&path, r#"{"broken"#).unwrap();
-        assert!(matches!(load_notes_from(&path), Loaded::Unreadable));
+        assert!(matches!(load_notes_from(&path), Loaded::Unreadable(_)));
     }
 
     #[test]
@@ -392,7 +403,7 @@ mod tests {
             return;
         }
 
-        assert!(matches!(load_notes_from(&path), Loaded::Unreadable));
+        assert!(matches!(load_notes_from(&path), Loaded::Unreadable(_)));
         fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
     }
 
@@ -423,7 +434,7 @@ mod tests {
             );
             return;
         }
-        assert!(matches!(result, Loaded::Unreadable));
+        assert!(matches!(result, Loaded::Unreadable(_)));
     }
 
     // ── atomic_write tests ──

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -61,7 +61,7 @@ pub(crate) fn create_note_with_window(app: &AppHandle, state: &AppState) -> Note
         notes.clone()
     };
     if let Err(e) = save_notes(state, &snapshot) {
-        eprintln!("save notes error: {}", e);
+        log::error!("save notes error: {}", e);
     }
     n
 }
@@ -107,7 +107,7 @@ pub(crate) fn open_note_window(app: &AppHandle, note: &Note) {
     let url = format!("note.html?id={}", note.id);
 
     let (x, y) = clamp_to_screen(app, note.x, note.y);
-    let Ok(win) = WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
+    let win = match WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
         .title("") // No title for Stickies-like feel
         .inner_size(note.width, note.height)
         .min_inner_size(200.0, 150.0)
@@ -118,8 +118,12 @@ pub(crate) fn open_note_window(app: &AppHandle, note: &Note) {
         .accept_first_mouse(true)
         .visible(true)
         .build()
-    else {
-        return;
+    {
+        Ok(win) => win,
+        Err(e) => {
+            log::error!("open note window error: note={} err={}", note.id, e);
+            return;
+        }
     };
 
     // Bring other notes to front when this window receives native focus.
@@ -190,13 +194,16 @@ pub(crate) fn open_settings_window(app: &AppHandle, tab: Option<&str>) {
         None => "settings.html".to_string(),
     };
     let lang = i18n::resolve(app.state::<AppState>().settings.recover().language);
-    let _ = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App(url.into()))
+    if let Err(e) = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App(url.into()))
         .title(i18n::text(lang, Msg::SettingsWindowTitle))
         .inner_size(440.0, 600.0)
         .min_inner_size(380.0, 460.0)
         .resizable(true)
         .visible(true)
-        .build();
+        .build()
+    {
+        log::error!("open settings window error: {}", e);
+    }
 }
 
 pub(crate) fn open_trash_window(app: &AppHandle) {
@@ -205,13 +212,16 @@ pub(crate) fn open_trash_window(app: &AppHandle) {
         return;
     }
     let lang = i18n::resolve(app.state::<AppState>().settings.recover().language);
-    let _ = WebviewWindowBuilder::new(app, "trash", WebviewUrl::App("trash.html".into()))
+    if let Err(e) = WebviewWindowBuilder::new(app, "trash", WebviewUrl::App("trash.html".into()))
         .title(i18n::text(lang, Msg::TrashWindowTitle))
         .inner_size(360.0, 480.0)
         .min_inner_size(300.0, 300.0)
         .resizable(true)
         .visible(true)
-        .build();
+        .build()
+    {
+        log::error!("open trash window error: {}", e);
+    }
 }
 
 // ── Bring All Notes to Front ────────────────────────────────


### PR DESCRIPTION
## 背景

配布ビルドでは標準エラー出力を誰も見ないため、保存・ウィンドウ生成・メニュー構築の失敗が起きても手元で何が起きたか追えない。起動時にデータファイルが読めない場合もダイアログにファイル名が出るだけで、原因は残らない。

## 仕様

- エラーは `~/Library/Logs/com.hattotto.app/` のログファイルに残る（上限 1MB・直近 1 世代ローテーション）
- 依存クレートのログは Warn 以上、アプリ自身は Info 以上を通す
- 付箋の本文はログに載せない。JSON の型不一致など serde エラーは種別と行・列位置だけを残す
- ログ初期化に失敗しても起動は継続する（ログは補助機能のため）

## やったこと

- ログ基盤: `tauri-plugin-log` を導入。初期化失敗で起動を止めないため、プラグインの setup 内でロガーを装着する構成にした
- ログ出力: 保存・メニュー構築・ウィンドウ生成の失敗をエラーログに出力する。起動時のデータファイル読み込み失敗は、失敗理由を読み込み結果に保持してロガー装着後に出力する
- ドキュメント: DEVELOPMENT.md にログの節を追加

## 確認したこと

`cargo test` 93 件、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check`、`cargo check` が通る。

## 関連リンク

- Closes #12
