### PR TITLE
♻️ 表示言語の auto 解決を Rust 側に一本化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ HTML はマークアップと `<style>` だけを持ち、スクリプトは同�
 - `Note`: id, content, color, x, y, width, height, zoom, pinned, deleted_at
 - `Settings`: default_color, opacity, bring_all_to_front, show_pin_button, show_new_button, show_color_button, confirm_before_delete, language
 
-表示言語は `Settings.language`（`auto` / `ja` / `en`）で決まる。`auto` は OS のロケール（フロントエンドは `navigator.language`）の primary subtag が `ja` なら日本語、それ以外はすべて英語。文言テーブルはネイティブ側 `src-tauri/src/i18n.rs` とフロントエンド側 `src/i18n.js` に分かれて存在する。
+表示言語は `Settings.language`（`auto` / `ja` / `en`）で決まる。OS ロケールの解釈は Rust 側の `i18n::system_language()` に一本化されており、`get_settings` コマンドが `Settings` に `system_language`（`"ja"` / `"en"`）を添えて返す。フロントエンドは `navigator.language` を直接見ず、`I18N.resolve(language, systemLanguage)` にこの値を渡して `auto` を解決する。文言テーブルはネイティブ側 `src-tauri/src/i18n.rs` とフロントエンド側 `src/i18n.js` に分かれて存在する。
 
 ### データフロー
 - 各付箋は独立したウィンドウ（`note-{uuid}` ラベル）として開かれる

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -337,10 +337,23 @@ pub(crate) fn empty_trash(state: State<AppState>) -> Result<(), String> {
     empty_trash_data(&state)
 }
 
-/// 現在の設定を返す。
+/// `get_settings` の戻り値。`Settings` に OS ロケールから解決した表示言語を添える。
+/// `Settings` 本体には持たせない（`settings.json` へ解決結果が永続化されるのを防ぐため）。
+#[derive(serde::Serialize)]
+pub(crate) struct SettingsResponse {
+    #[serde(flatten)]
+    settings: Settings,
+    system_language: i18n::Lang,
+}
+
+/// 現在の設定を返す。フロントエンドの `auto` 解決は OS ロケールを直接参照せず、
+/// ここで返す `system_language`（Rust 側の解決結果）に一本化している。
 #[tauri::command]
-pub(crate) fn get_settings(state: State<AppState>) -> Settings {
-    state.settings.recover().clone()
+pub(crate) fn get_settings(state: State<AppState>) -> SettingsResponse {
+    SettingsResponse {
+        settings: state.settings.recover().clone(),
+        system_language: i18n::system_language(),
+    }
 }
 
 /// 設定を更新して保存する。数値は範囲内にクランプされる。
@@ -482,6 +495,21 @@ mod tests {
     fn read_trash_json(dir: &TempDir) -> Vec<Note> {
         let s = std::fs::read_to_string(dir.path().join("trash.json")).unwrap();
         serde_json::from_str(&s).unwrap()
+    }
+
+    // ── SettingsResponse ──────────────────────────────────────
+
+    #[test]
+    fn settings_response_flattens_system_language_alongside_settings() {
+        let response = SettingsResponse {
+            settings: Settings::default(),
+            system_language: i18n::Lang::Ja,
+        };
+
+        let value = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(value["language"], serde_json::json!("auto"));
+        assert_eq!(value["system_language"], serde_json::json!("ja"));
     }
 
     // ── delete_note_data ──────────────────────────────────────

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -8,7 +8,12 @@ use sys_locale::get_locale;
 use crate::model::LanguageSetting;
 
 /// 表示に使う言語。`LanguageSetting::Auto` を OS のロケールで解決した結果でもある。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// シリアライズ結果の `"ja"` / `"en"` は `get_settings` の `system_language` として
+/// フロントエンドへ渡り、`src/i18n.js` の `resolve` が文字列比較する。
+/// variant 名や rename 規則を変えるときはフロントエンド側も揃えること。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum Lang {
     Ja,
     En,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -121,11 +121,10 @@ for (const [key, entry] of Object.entries(I18N_TABLE)) {
 
 let currentLang = 'ja';
 
-/** setting（"auto" | "ja" | "en"）を表示言語へ解決する。auto は navigator.language の primary subtag が ja なら日本語、それ以外は英語。 */
-function resolve(setting) {
+/** setting（"auto" | "ja" | "en"）を表示言語へ解決する。auto は systemLanguage（get_settings が返す OS ロケールの解決結果）に従う。 */
+function resolve(setting, systemLanguage) {
   if (setting === 'ja' || setting === 'en') return setting;
-  const primary = (navigator.language || 'en').split('-')[0].toLowerCase();
-  return primary === 'ja' ? 'ja' : 'en';
+  return systemLanguage === 'ja' ? 'ja' : 'en';
 }
 
 function t(key) {

--- a/src/note.js
+++ b/src/note.js
@@ -99,7 +99,7 @@ async function loadNote() {
     return;
   }
 
-  I18N.setLang(I18N.resolve(settings?.language));
+  I18N.setLang(I18N.resolve(settings?.language, settings?.system_language));
 
   rawContent = note.content;
   renderAll();
@@ -770,7 +770,7 @@ unlisteners.push(appWindow.listen('ctx-apply-color', (e) => applyColor(e.payload
 // ── Listen for settings changes ──────────────────
 unlisteners.push(listen('settings-changed', (e) => {
   applySettings(e.payload);
-  I18N.setLang(I18N.resolve(e.payload.language));
+  I18N.setLang(e.payload.resolved_language);
   // ピンボタンはピン状態に応じてラベルを出し分けるため data-i18n* を持たず、
   // applyDom の対象外。ここで明示的にラベルを更新する
   applyPinState(pinBtn.classList.contains('active'));

--- a/src/settings.js
+++ b/src/settings.js
@@ -14,6 +14,7 @@ let currentShowColor = true;
 let currentConfirmDelete = true;
 let currentAutostart = false;
 let currentLanguage = 'auto';
+let systemLanguage = 'en'; // get_settings から届く。init で上書きされる
 
 // ── Change Detection ──────────────────────────────
 let saved = {
@@ -143,6 +144,7 @@ saveBtn.addEventListener('click', async () => {
       show_color_button: currentShowColor,
       confirm_before_delete: currentConfirmDelete,
       language: currentLanguage,
+      resolved_language: I18N.resolve(currentLanguage, systemLanguage),
     });
     snapshotSaved();
     getCurrentWebviewWindow().close();
@@ -210,7 +212,7 @@ autostartToggle.addEventListener('change', () => {
 const languageSelect = document.getElementById('language-select');
 languageSelect.addEventListener('change', () => {
   currentLanguage = languageSelect.value;
-  I18N.setLang(I18N.resolve(currentLanguage));
+  I18N.setLang(I18N.resolve(currentLanguage, systemLanguage));
   checkDirty();
 });
 
@@ -227,7 +229,8 @@ async function init() {
   ]);
 
   currentLanguage = s.language ?? 'auto';
-  I18N.setLang(I18N.resolve(currentLanguage));
+  systemLanguage = s.system_language ?? 'en';
+  I18N.setLang(I18N.resolve(currentLanguage, systemLanguage));
   languageSelect.value = currentLanguage;
 
   currentColor = s.default_color;

--- a/src/trash.js
+++ b/src/trash.js
@@ -90,7 +90,7 @@ document.addEventListener('keydown', (e) => {
 
 // ── Listen for settings changes ──────────────────
 listen('settings-changed', (e) => {
-  I18N.setLang(I18N.resolve(e.payload.language));
+  I18N.setLang(e.payload.resolved_language);
   // 復元ボタン・空メッセージ・日付書式は render() が生成する DOM なので
   // applyDom では届かない
   render();
@@ -104,7 +104,7 @@ async function init() {
   } catch (e) {
     console.error('get_settings failed:', e);
   }
-  I18N.setLang(I18N.resolve(settings?.language));
+  I18N.setLang(I18N.resolve(settings?.language, settings?.system_language));
   render();
 }
 

--- a/tests/unit/i18n.test.js
+++ b/tests/unit/i18n.test.js
@@ -4,8 +4,15 @@ const assert = require("node:assert/strict");
 const I18N = require("../../src/i18n.js");
 
 describe("I18N.resolve", () => {
-  test("'ja' / 'en' はそのまま解決される", () => {
-    assert.equal(I18N.resolve("ja"), "ja");
-    assert.equal(I18N.resolve("en"), "en");
+  test("'ja' / 'en' はそのまま解決される（systemLanguage を無視する）", () => {
+    assert.equal(I18N.resolve("ja", "en"), "ja");
+    assert.equal(I18N.resolve("en", "ja"), "en");
+  });
+
+  test("'auto' / undefined は systemLanguage に従う", () => {
+    assert.equal(I18N.resolve("auto", "ja"), "ja");
+    assert.equal(I18N.resolve("auto", "en"), "en");
+    assert.equal(I18N.resolve(undefined, "ja"), "ja");
+    assert.equal(I18N.resolve(undefined, "en"), "en");
   });
 });

--- a/tests/visual/checkbox-toggle.spec.ts
+++ b/tests/visual/checkbox-toggle.spec.ts
@@ -18,7 +18,7 @@ async function openNoteWithCapture(browser: Browser, content: string): Promise<{
             case "get_note":
               return { id: "test-note-id", content: noteContent, color: "yellow", x: 0, y: 0, width: 300, height: 350, zoom: 100 };
             case "get_settings":
-              return { default_color: "yellow", opacity: 100, language: "ja" };
+              return { default_color: "yellow", opacity: 100, language: "ja", system_language: "ja" };
             default:
               return null;
           }

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -11,6 +11,7 @@ const DEFAULT_SETTINGS = {
   show_color_button: true,
   confirm_before_delete: true,
   language: "ja",
+  system_language: "ja",
 };
 
 // ── Note mock ──────────────────────────────────────────────
@@ -112,6 +113,8 @@ async function injectSettingsMock(
   await page.addInitScript((data) => {
     const shellOpenCalls: string[] = [];
     (window as any).__shell_open_calls = shellOpenCalls;
+    const emittedEvents: { event: string; payload: unknown }[] = [];
+    (window as any).__emitted_events = emittedEvents;
 
     (window as any).__TAURI__ = {
       core: {
@@ -127,7 +130,7 @@ async function injectSettingsMock(
         },
       },
       event: {
-        emit: async () => {},
+        emit: async (event: string, payload: unknown) => { emittedEvents.push({ event, payload }); },
         listen: async () => () => {},
       },
       app: {

--- a/tests/visual/i18n.spec.ts
+++ b/tests/visual/i18n.spec.ts
@@ -32,6 +32,20 @@ test.describe("設定画面の英語化", () => {
     await settingsPage.selectOption("#language-select", "en");
     await expect(settingsPage.locator("#tab-settings")).toHaveText("Settings");
   });
+
+  test("language: auto + system_language: en で保存すると、settings-changed に resolved_language: en が乗る", async ({ openSettings }) => {
+    const page = await openSettings({ language: "auto", system_language: "en" });
+
+    // 未変更だと保存ボタンが disabled のまま。言語以外の設定を変えて有効化する
+    // （checkbox 本体は不可視なので、見えているトラック側をクリックする）
+    await page.click("#confirm-delete-toggle + .toggle-track");
+    await page.click("#save-btn");
+
+    const emitted = await page.evaluate(() => (window as any).__emitted_events);
+    const settingsChanged = emitted.find((e: any) => e.event === "settings-changed");
+    expect(settingsChanged.payload.language).toBe("auto");
+    expect(settingsChanged.payload.resolved_language).toBe("en");
+  });
 });
 
 test.describe("付箋の英語化", () => {
@@ -56,7 +70,7 @@ test.describe("付箋の英語化", () => {
         payload: {
           default_color: "yellow", opacity: 100, bring_all_to_front: true,
           show_pin_button: true, show_new_button: true, show_color_button: true,
-          confirm_before_delete: true, language: "en",
+          confirm_before_delete: true, language: "en", resolved_language: "en",
         },
       }));
     });
@@ -82,7 +96,7 @@ test.describe("ゴミ箱の英語化", () => {
 
     await page.evaluate(() => {
       const listeners = (window as any).__globalListeners["settings-changed"];
-      listeners?.forEach((fn: any) => fn({ payload: { language: "en" } }));
+      listeners?.forEach((fn: any) => fn({ payload: { language: "en", resolved_language: "en" } }));
     });
 
     await expect(page.locator(".header h1")).toContainText("Trash");
@@ -92,24 +106,20 @@ test.describe("ゴミ箱の英語化", () => {
 });
 
 test.describe("window.I18N.resolve()", () => {
-  test("'auto' と undefined は navigator.language の primary subtag で決まる", async ({ browser }) => {
-    const jaCtx = await browser.newContext({ locale: "ja-JP" });
-    const jaPage = await jaCtx.newPage();
-    await injectNoteMock(jaPage);
-    await jaPage.goto("/note.html?id=test-note-id");
-    await jaPage.waitForLoadState("networkidle");
-    expect(await jaPage.evaluate(() => (window as any).I18N.resolve("auto"))).toBe("ja");
-    expect(await jaPage.evaluate(() => (window as any).I18N.resolve(undefined))).toBe("ja");
-    await jaCtx.close();
+  test("'auto' と undefined は systemLanguage 引数で決まり、'ja'/'en' 指定はそれを無視する", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await injectNoteMock(page);
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
 
-    const frCtx = await browser.newContext({ locale: "fr-FR" });
-    const frPage = await frCtx.newPage();
-    await injectNoteMock(frPage);
-    await frPage.goto("/note.html?id=test-note-id");
-    await frPage.waitForLoadState("networkidle");
-    expect(await frPage.evaluate(() => (window as any).I18N.resolve("auto"))).toBe("en");
-    expect(await frPage.evaluate(() => (window as any).I18N.resolve(undefined))).toBe("en");
-    await frCtx.close();
+    expect(await page.evaluate(() => (window as any).I18N.resolve("auto", "ja"))).toBe("ja");
+    expect(await page.evaluate(() => (window as any).I18N.resolve(undefined, "ja"))).toBe("ja");
+    expect(await page.evaluate(() => (window as any).I18N.resolve("auto", "en"))).toBe("en");
+    expect(await page.evaluate(() => (window as any).I18N.resolve(undefined, "en"))).toBe("en");
+    expect(await page.evaluate(() => (window as any).I18N.resolve("ja", "en"))).toBe("ja");
+    expect(await page.evaluate(() => (window as any).I18N.resolve("en", "ja"))).toBe("en");
+    await ctx.close();
   });
 });
 

--- a/tests/visual/link-click-e2e.spec.ts
+++ b/tests/visual/link-click-e2e.spec.ts
@@ -32,6 +32,7 @@ test.describe("リンククリック", () => {
                   default_color: "yellow", opacity: 100,
                   bring_all_to_front: true, show_pin_button: true, show_new_button: true,
                   show_color_button: true, confirm_before_delete: true, language: "ja",
+                  system_language: "ja",
                 };
               default: return null;
             }

--- a/tests/visual/settings-apply-e2e.spec.ts
+++ b/tests/visual/settings-apply-e2e.spec.ts
@@ -55,6 +55,8 @@ test.describe("設定反映: settings-changed イベント", () => {
             show_new_button: true,
             show_color_button: true,
             confirm_before_delete: true,
+            language: "ja",
+            resolved_language: "ja",
           },
         }));
       }
@@ -83,6 +85,8 @@ test.describe("設定反映: settings-changed イベント", () => {
             show_new_button: true,
             show_color_button: true,
             confirm_before_delete: true,
+            language: "ja",
+            resolved_language: "ja",
           },
         }));
       }

--- a/tests/visual/trash-e2e.spec.ts
+++ b/tests/visual/trash-e2e.spec.ts
@@ -18,7 +18,7 @@ async function injectTrashMockWithCapture(
           switch (cmd) {
             case "get_trash":     return items;
             case "get_trash_max": return 200;
-            case "get_settings":  return { language: "ja" };
+            case "get_settings":  return { language: "ja", system_language: "ja" };
             case "restore_note": {
               items = items.filter((n: any) => n.id !== args?.id);
               return null;


### PR DESCRIPTION
## 背景

`Settings.language` が `auto` のときの表示言語の解決が、ネイティブ側（`sys_locale` の値を `src-tauri/src/i18n.rs` が解釈）とフロントエンド側（`navigator.language` を `src/i18n.js` が解釈）の 2 系統ある。区切り文字の解釈も違い、`ja_JP` のような値ではネイティブは日本語・フロントエンドは英語と食い違う。

## 仕様

- OS ロケールの解釈は Rust 側だけが行う。`get_settings` が `Settings` の全フィールドに `system_language`（`"ja"` / `"en"`）を添えて返し、フロントエンドは `navigator.language` を参照しない
- 設定画面で `auto` を選んだときのプレビューも `system_language` で解決する
- `settings-changed` イベントのペイロードに解決済みの `resolved_language` が入り、付箋・ゴミ箱はそれをそのまま表示言語にする

## やったこと

- バックエンド: `get_settings` の戻り値を `Settings` + `system_language` の型に変更（`Settings` 本体に持たせず、settings.json へ解決結果が永続化されない形にした）
- フロントエンド: `I18N.resolve(setting, systemLanguage)` の 2 引数にし、各画面の呼び出しと `settings-changed` の emit / listen を追随
- テスト: `navigator.language` 前提の spec を新シグネチャの検証に書き換え、`auto` × システム言語の単体テストと `resolved_language` が emit されることの spec を追加。`get_settings` モックに `system_language` を追加

## 確認したこと

`cargo test` 94 件、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check`、`npm run lint`、`npm test`（node 単体 + Playwright 198 件）が通る。

## 関連リンク

- Closes #14
