### PR TITLE
💚 ビルドした .app の起動確認を CI に追加する

### DIFF
--- a/.github/scripts/smoke-launch.sh
+++ b/.github/scripts/smoke-launch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ビルドした .app が実際に起動できるかを確認する。
+# cargo tauri build --debug 実行後、CI から呼び出される想定。
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq が見つかりません" >&2
+  exit 1
+fi
+
+# notes.json 2 件の判定は初回起動でしか成立しないため、実ユーザーの $HOME から分離する
+SMOKE_HOME="$(mktemp -d)"
+export HOME="$SMOKE_HOME"
+
+APP_BIN="src-tauri/target/debug/bundle/macos/Hattotto.app/Contents/MacOS/hattotto"
+CAPTURE_FILE="$(mktemp -t hattotto-smoke-capture)"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/com.hattotto.app"
+LOG_DIR="$HOME/Library/Logs/com.hattotto.app"
+
+if [[ ! -x "$APP_BIN" ]]; then
+  echo "ERROR: 実行バイナリが見つかりません: $APP_BIN" >&2
+  exit 1
+fi
+
+echo "起動確認: $APP_BIN をバックグラウンドで起動する"
+"$APP_BIN" >"$CAPTURE_FILE" 2>&1 &
+APP_PID=$!
+
+echo "起動確認: 初回起動のウェルカム付箋保存とログ出力を待つため 10 秒待機する"
+sleep 10
+
+echo "起動確認: プロセスが生存しているか確認する"
+if ! kill -0 "$APP_PID" 2>/dev/null; then
+  echo "ERROR: アプリが 10 秒以内に終了しました" >&2
+  echo "--- capture ---" >&2
+  cat "$CAPTURE_FILE" >&2
+  exit 1
+fi
+
+FAILED=0
+
+echo "起動確認: notes.json に初回起動のウェルカム付箋 2 件があるか確認する"
+NOTES_FILE="$APP_SUPPORT_DIR/notes.json"
+if [[ ! -f "$NOTES_FILE" ]]; then
+  echo "ERROR: notes.json が生成されていません: $NOTES_FILE" >&2
+  FAILED=1
+elif [[ "$(jq 'length' "$NOTES_FILE")" != "2" ]]; then
+  echo "ERROR: notes.json の付箋数が 2 件ではありません" >&2
+  cat "$NOTES_FILE" >&2
+  FAILED=1
+fi
+
+echo "起動確認: capture に ERROR ログが無いか確認する"
+if grep -n "ERROR" "$CAPTURE_FILE" >/dev/null 2>&1; then
+  echo "ERROR: capture に ERROR ログがあります" >&2
+  grep -n "ERROR" "$CAPTURE_FILE" >&2
+  FAILED=1
+fi
+
+echo "起動確認: capture にロガー初期化失敗が無いか確認する"
+if grep -nE "Failed to (attach|initialize) logger" "$CAPTURE_FILE" >/dev/null 2>&1; then
+  echo "ERROR: ロガーの初期化に失敗しています" >&2
+  grep -nE "Failed to (attach|initialize) logger" "$CAPTURE_FILE" >&2
+  FAILED=1
+fi
+
+echo "起動確認: ログファイルが生成され ERROR が無いか確認する"
+if [[ ! -d "$LOG_DIR" ]] || [[ -z "$(ls -A "$LOG_DIR" 2>/dev/null)" ]]; then
+  echo "ERROR: ログファイルが生成されていません: $LOG_DIR" >&2
+  FAILED=1
+else
+  if grep -rn "ERROR" "$LOG_DIR" >/dev/null 2>&1; then
+    echo "ERROR: ログファイルに ERROR 行があります" >&2
+    grep -rn "ERROR" "$LOG_DIR" >&2
+    FAILED=1
+  fi
+fi
+
+if [[ "$FAILED" != "0" ]]; then
+  echo "--- capture ---" >&2
+  cat "$CAPTURE_FILE" >&2
+  echo "--- logs ---" >&2
+  if [[ -d "$LOG_DIR" ]]; then
+    cat "$LOG_DIR"/* >&2 2>/dev/null || true
+  fi
+  kill -TERM "$APP_PID" 2>/dev/null || true
+  exit 1
+fi
+
+echo "起動確認: プロセスを終了して終了コードを確認する"
+kill -TERM "$APP_PID" || true
+set +e
+wait "$APP_PID"
+EXIT_CODE=$?
+set -e
+
+if [[ "$EXIT_CODE" != "0" && "$EXIT_CODE" != "143" ]]; then
+  echo "ERROR: 終了コードが 0 でも 143 でもありません: $EXIT_CODE" >&2
+  cat "$CAPTURE_FILE" >&2
+  exit 1
+fi
+
+echo "起動確認: 成功"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,40 @@ jobs:
 
       - name: Test
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  smoke:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # build ジョブと同じキー系列を使う。debug プロファイル同士で成果物が大きく重なるため、
+      # 別系列にすると 10GB のキャッシュ上限を圧迫して他ワークフローのキャッシュを追い出す
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-v2-
+
+      # cargo install はバイナリの有無を見ないので、cargo-tauri の実体だけ別途キャッシュしてスキップ判定する
+      - uses: actions/cache@v6
+        id: tauri-cli-cache
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: ${{ runner.os }}-${{ runner.arch }}-tauri-cli-v2
+
+      - name: Install tauri-cli
+        if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version "^2" --locked
+
+      - name: Build (debug bundle)
+        run: cargo tauri build --debug --bundles app
+        working-directory: src-tauri
+
+      - name: Launch smoke test
+        run: bash .github/scripts/smoke-launch.sh


### PR DESCRIPTION
## 背景

CI はビルド・テスト・VRT を回しているが、どのワークフローもビルドしたアプリを起動しない。Playwright は `window.__TAURI__` を丸ごとモックするため Rust 側は動かず、「ビルドは通るが起動即クラッシュ」を検出できないまま、依存更新のマージからリリースまで一度も起動確認が挟まらない。

## 仕様

push / PR ごとに、macOS ランナー上でデバッグビルドの `.app` を実際に起動して確かめる。成功条件:

- 起動 10 秒後にプロセスが生存している
- 初回起動のウェルカム付箋 2 件が notes.json に書かれている（`setup` が最後まで到達した証拠）
- 標準出力・ログファイルに ERROR 行が無く、ロガー初期化失敗の文言も無い（`setup` が握りつぶす失敗はここで拾う）
- SIGTERM で終了コード 0 または 143 で終了する

`$HOME` を一時ディレクトリに差し替えて実行するため、手元で実行しても実データに触れない。

## やったこと

- build.yml: `smoke` ジョブを追加（build と並列）。`cargo tauri build --debug --bundles app` で単一アーキの `.app` だけを作る。cargo キャッシュは build ジョブと同じキー系列を共有し、tauri-cli のバイナリはアーキ入りキーで別キャッシュ
- `.github/scripts/smoke-launch.sh`: 上記の起動・確認・終了を行うスクリプト。失敗時は capture とログファイルの内容を CI ログへ出す

## 確認したこと

`shellcheck` 指摘ゼロ、YAML 構文チェック通過。GitHub ランナー上で GUI アプリ（トレイ・メニュー構築を含む）が起動するかはこの PR の CI 実行が初回の実測になる。

## 関連リンク

- Closes #38
