### PR TITLE
✨ 画像を貼れるようにする｜1｜クリップボードの画像を付箋にペーストできるようにする

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1717,6 +1717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,6 +4070,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "unstable", "macos-private-api"] }
+tauri = { version = "2", features = ["tray-icon", "unstable", "macos-private-api", "protocol-asset"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use tauri::ipc::{InvokeBody, Request};
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
@@ -9,7 +10,10 @@ use crate::model::{
     clamp_opacity, clamp_zoom, is_valid_color_key, is_valid_default_color, resolve_color, AppState,
     LanguageSetting, Note, RecoverMutex, Settings, TRASH_MAX,
 };
-use crate::persistence::{enforce_trash_limit, save_notes, save_settings, save_trash};
+use crate::persistence::{
+    self, enforce_trash_limit, extract_image_paths, gc_images, save_notes, save_settings,
+    save_trash,
+};
 use crate::window::{
     create_note_with_window, open_note_window, open_settings_window, open_trash_window,
 };
@@ -173,10 +177,12 @@ pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, Strin
         }
         save_notes(state, &notes_snapshot)?;
         *state.notes.recover() = notes_snapshot;
+        // note.is_empty() は content.trim() が空であることを意味し、画像記法（非空白）を
+        // 含む content では成立しない。この経路に画像 GC は不要（呼んでも常に空振りする）
         return Ok(true);
     }
 
-    let trash_snapshot = {
+    let (trash_snapshot, drained) = {
         note.deleted_at = Some(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -188,8 +194,8 @@ pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, Strin
         // ゴミ箱に同じ id が並ばないようにする
         trash_snap.retain(|n| n.id != id);
         trash_snap.push(note);
-        enforce_trash_limit(&mut trash_snap);
-        trash_snap
+        let drained = enforce_trash_limit(&mut trash_snap);
+        (trash_snap, drained)
     };
     // 付箋側を先に消すと、間で中断したときにどちらのファイルからも消える。
     // この順なら両方に残るので捨て直せる
@@ -199,6 +205,19 @@ pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, Strin
     *state.notes.recover() = notes_snapshot.clone();
     *state.trash.recover() = trash_snapshot.clone();
     save_notes(state, &notes_snapshot)?;
+    // FIFO で溢れて完全に消えた付箋（trash からも drop 済み）が参照していた画像を GC する
+    let candidates: Vec<String> = drained
+        .iter()
+        .flat_map(|n| extract_image_paths(&n.content))
+        .collect();
+    if !candidates.is_empty() {
+        gc_images(
+            &state.data_dir,
+            &candidates,
+            &notes_snapshot,
+            &trash_snapshot,
+        );
+    }
     Ok(true)
 }
 
@@ -326,8 +345,18 @@ pub(crate) fn restore_note(
 /// 保存が成功してからメモリを clear する。先に clear すると、保存失敗時に
 /// メモリだけ空になりディスクの trash.json には付箋が残ったままになる。
 pub(crate) fn empty_trash_data(state: &AppState) -> Result<(), String> {
+    let old_trash = state.trash.recover().clone();
     save_trash(state, &[])?;
     state.trash.recover().clear();
+    // ゴミ箱ごと消えた付箋が参照していた画像を GC する
+    let candidates: Vec<String> = old_trash
+        .iter()
+        .flat_map(|n| extract_image_paths(&n.content))
+        .collect();
+    if !candidates.is_empty() {
+        let notes_snapshot = state.notes.recover().clone();
+        gc_images(&state.data_dir, &candidates, &notes_snapshot, &[]);
+    }
     Ok(())
 }
 
@@ -337,13 +366,15 @@ pub(crate) fn empty_trash(state: State<AppState>) -> Result<(), String> {
     empty_trash_data(&state)
 }
 
-/// `get_settings` の戻り値。`Settings` に OS ロケールから解決した表示言語を添える。
-/// `Settings` 本体には持たせない（`settings.json` へ解決結果が永続化されるのを防ぐため）。
+/// `get_settings` の戻り値。`Settings` に OS ロケールから解決した表示言語と、
+/// 貼り付け画像の asset protocol URL 組み立てに使うデータディレクトリを添える。
+/// いずれも `Settings` 本体には持たせない（`settings.json` への永続化を防ぐため）。
 #[derive(serde::Serialize)]
 pub(crate) struct SettingsResponse {
     #[serde(flatten)]
     settings: Settings,
     system_language: i18n::Lang,
+    data_dir: String,
 }
 
 /// 現在の設定を返す。フロントエンドの `auto` 解決は OS ロケールを直接参照せず、
@@ -353,7 +384,22 @@ pub(crate) fn get_settings(state: State<AppState>) -> SettingsResponse {
     SettingsResponse {
         settings: state.settings.recover().clone(),
         system_language: i18n::system_language(),
+        data_dir: state.data_dir.to_string_lossy().into_owned(),
     }
+}
+
+/// クリップボードから貼り付けられた画像を `images/<uuid v4>.png` として保存し、
+/// content に埋め込む相対パスを返す。JS 側は `Uint8Array` を渡し、raw payload
+/// (`InvokeBody::Raw`) として届く。
+#[tauri::command]
+pub(crate) fn save_pasted_image(
+    request: Request<'_>,
+    state: State<AppState>,
+) -> Result<String, String> {
+    let InvokeBody::Raw(bytes) = request.body() else {
+        return Err("save_pasted_image expects a raw byte payload".to_string());
+    };
+    persistence::save_pasted_image(&state.data_dir, bytes)
 }
 
 /// 設定を更新して保存する。数値は範囲内にクランプされる。
@@ -497,6 +543,29 @@ mod tests {
         serde_json::from_str(&s).unwrap()
     }
 
+    /// テスト用の有効な uuid 形状パス（`persistence::is_valid_image_rel_path` の形状に一致）。
+    fn uuid_image_path(n: u8) -> String {
+        format!("images/00000000-0000-4000-8000-00000000000{}.png", n)
+    }
+
+    /// `dir/images/<filename>` にダミーの画像ファイルを置く。
+    fn write_dummy_image(dir: &TempDir, image_path: &str) {
+        let images_dir = dir.path().join("images");
+        std::fs::create_dir_all(&images_dir).unwrap();
+        std::fs::write(
+            images_dir.join(image_path.strip_prefix("images/").unwrap()),
+            b"data",
+        )
+        .unwrap();
+    }
+
+    fn image_exists(dir: &TempDir, image_path: &str) -> bool {
+        dir.path()
+            .join("images")
+            .join(image_path.strip_prefix("images/").unwrap())
+            .exists()
+    }
+
     // ── SettingsResponse ──────────────────────────────────────
 
     #[test]
@@ -504,12 +573,14 @@ mod tests {
         let response = SettingsResponse {
             settings: Settings::default(),
             system_language: i18n::Lang::Ja,
+            data_dir: "/tmp/hattotto".to_string(),
         };
 
         let value = serde_json::to_value(&response).unwrap();
 
         assert_eq!(value["language"], serde_json::json!("auto"));
         assert_eq!(value["system_language"], serde_json::json!("ja"));
+        assert_eq!(value["data_dir"], serde_json::json!("/tmp/hattotto"));
     }
 
     // ── delete_note_data ──────────────────────────────────────
@@ -568,6 +639,43 @@ mod tests {
         assert_eq!(trash.len(), TRASH_MAX);
         assert_eq!(trash[0].id, "1"); // oldest ("0") dropped
         assert_eq!(trash.last().unwrap().id, "new");
+    }
+
+    /// FIFO で完全にゴミ箱から溢れた付箋（＝もうどこにも残らない）が参照していた画像は消える。
+    #[test]
+    fn delete_note_data_fifo_overflow_gc_removes_drained_notes_image() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(1);
+        write_dummy_image(&dir, &image_path);
+
+        let mut existing_trash: Vec<Note> = (0..TRASH_MAX)
+            .map(|i| make_note(&i.to_string(), ""))
+            .collect();
+        existing_trash[0].content = format!("![]({})", image_path); // oldest → FIFO で drop される
+        let state = make_state(&dir, vec![make_note("new", "hello")], existing_trash);
+
+        delete_note_data(&state, "new").unwrap();
+
+        assert!(!image_exists(&dir, &image_path));
+    }
+
+    /// drop された付箋の画像でも、残っている別の付箋がまだ参照していれば消さない。
+    #[test]
+    fn delete_note_data_fifo_overflow_gc_keeps_image_referenced_by_remaining_note() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(2);
+        write_dummy_image(&dir, &image_path);
+
+        let mut existing_trash: Vec<Note> = (0..TRASH_MAX)
+            .map(|i| make_note(&i.to_string(), ""))
+            .collect();
+        existing_trash[0].content = format!("![]({})", image_path); // drop される
+        existing_trash[1].content = format!("![]({})", image_path); // drop されずに残る
+        let state = make_state(&dir, vec![make_note("new", "hello")], existing_trash);
+
+        delete_note_data(&state, "new").unwrap();
+
+        assert!(image_exists(&dir, &image_path));
     }
 
     #[test]
@@ -807,6 +915,35 @@ mod tests {
 
         assert!(state.trash.recover().is_empty());
         assert!(read_trash_json(&dir).is_empty());
+    }
+
+    /// ゴミ箱ごと消えた付箋が参照していた画像は GC される。
+    #[test]
+    fn empty_trash_data_gc_removes_unreferenced_image() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(3);
+        write_dummy_image(&dir, &image_path);
+        let trash = vec![make_note("t", &format!("![]({})", image_path))];
+        let state = make_state(&dir, vec![], trash);
+
+        empty_trash_data(&state).unwrap();
+
+        assert!(!image_exists(&dir, &image_path));
+    }
+
+    /// notes 側にまだ参照が残っていれば、ゴミ箱を空にしても画像は消さない。
+    #[test]
+    fn empty_trash_data_gc_keeps_image_still_referenced_by_notes() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(4);
+        write_dummy_image(&dir, &image_path);
+        let notes = vec![make_note("n", &format!("![]({})", image_path))];
+        let trash = vec![make_note("t", &format!("![]({})", image_path))];
+        let state = make_state(&dir, notes, trash);
+
+        empty_trash_data(&state).unwrap();
+
+        assert!(image_exists(&dir, &image_path));
     }
 
     // ── delete → restore round-trip ───────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,7 @@ pub fn run() {
             commands::empty_trash,
             commands::open_trash,
             commands::show_context_menu,
+            commands::save_pasted_image,
         ])
         .setup(|app| {
             // Set up app menu and system tray

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -206,7 +206,7 @@ pub(crate) fn enforce_trash_limit(trash: &mut Vec<Note>) -> Vec<Note> {
 const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
 
 /// 対応する画像形式の拡張子一覧。`is_valid_image_rel_path` の形状チェックと対応させる。
-const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif"];
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp"];
 
 /// 先頭バイト（マジックバイト）から画像形式を判定し、拡張子を返す。
 /// 対応外の形式（TIFF 等）は `None`。WKWebView は TIFF を `<img>` として描画できないため対応しない。
@@ -217,6 +217,8 @@ fn detect_image_ext(bytes: &[u8]) -> Option<&'static str> {
         Some("jpg")
     } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
         Some("gif")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Some("webp")
     } else {
         None
     }
@@ -653,6 +655,31 @@ mod tests {
 
         assert!(rel_path.ends_with(".gif"));
         assert!(is_valid_image_rel_path(&rel_path));
+    }
+
+    #[test]
+    fn save_pasted_image_detects_webp_extension() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = b"RIFF".to_vec();
+        bytes.extend_from_slice(&[0x24, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(b"WEBP");
+        bytes.extend_from_slice(b"rest-of-the-fake-webp-data");
+
+        let rel_path = save_pasted_image(dir.path(), &bytes).unwrap();
+
+        assert!(rel_path.ends_with(".webp"));
+        assert!(is_valid_image_rel_path(&rel_path));
+    }
+
+    #[test]
+    fn save_pasted_image_rejects_riff_without_webp_marker() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = b"RIFF".to_vec();
+        bytes.extend_from_slice(&[0x24, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"this-is-audio-not-an-image");
+
+        assert!(save_pasted_image(dir.path(), &bytes).is_err());
     }
 
     #[test]

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use serde::de::DeserializeOwned;
+use uuid::Uuid;
 
 use crate::model::{is_valid_default_color, AppState, Note, Settings, TRASH_MAX};
 
@@ -38,6 +40,10 @@ fn settings_file(dir: &Path) -> PathBuf {
 
 fn trash_file(dir: &Path) -> PathBuf {
     dir.join("trash.json")
+}
+
+fn images_dir(dir: &Path) -> PathBuf {
+    dir.join("images")
 }
 
 /// tmp へ書き、fsync してから rename する。
@@ -182,11 +188,142 @@ pub(crate) fn save_trash(state: &AppState, trash: &[Note]) -> Result<(), String>
     save_trash_to(trash, &trash_file(&state.data_dir))
 }
 
-/// ゴミ箱のFIFO制限: TRASH_MAXを超えた分を先頭から削除
-pub(crate) fn enforce_trash_limit(trash: &mut Vec<Note>) {
+/// ゴミ箱のFIFO制限: TRASH_MAXを超えた分を先頭から削除し、削除した付箋を返す。
+/// 呼び出し元はこれを使って、その付箋が参照していた画像の GC 候補を判定する。
+#[must_use]
+pub(crate) fn enforce_trash_limit(trash: &mut Vec<Note>) -> Vec<Note> {
     let overflow = trash.len().saturating_sub(TRASH_MAX);
     if overflow > 0 {
-        trash.drain(0..overflow);
+        trash.drain(0..overflow).collect()
+    } else {
+        Vec::new()
+    }
+}
+
+// ── Pasted Images ───────────────────────────────────────────
+
+/// クリップボード画像の許容上限（10MB）。これを超えるペイロードは保存しない。
+const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
+/// 対応する画像形式の拡張子一覧。`is_valid_image_rel_path` の形状チェックと対応させる。
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif"];
+
+/// 先頭バイト（マジックバイト）から画像形式を判定し、拡張子を返す。
+/// 対応外の形式（TIFF 等）は `None`。WKWebView は TIFF を `<img>` として描画できないため対応しない。
+fn detect_image_ext(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("png")
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("jpg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("gif")
+    } else {
+        None
+    }
+}
+
+/// `save_pasted_image` が生成する相対パスの形状（`images/<uuid v4>.<ext>`）と一致するか検証する。
+/// content からの抽出時・GC の削除直前・フロントエンドの asset URL 変換時、いずれもこの形状
+/// だけを許可する。`images/../notes.json` のようなパストラバーサルを塞ぐための唯一の関所。
+pub(crate) fn is_valid_image_rel_path(path: &str) -> bool {
+    let Some(name) = path.strip_prefix("images/") else {
+        return false;
+    };
+    // 単一パスコンポーネントであること（`/`・`\` を含まない = 親ディレクトリへ抜けられない）
+    if name.is_empty() || name.contains('/') || name.contains('\\') {
+        return false;
+    }
+    let Some((stem, ext)) = name.rsplit_once('.') else {
+        return false;
+    };
+    uuid::Uuid::parse_str(stem).is_ok()
+        && IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+}
+
+/// クリップボード画像を `images/<uuid v4>.<ext>` として保存し、相対パスを返す。
+/// 拡張子はマジックバイトから判定する（クライアントの MIME 型は信用しない）。
+pub(crate) fn save_pasted_image(dir: &Path, bytes: &[u8]) -> Result<String, String> {
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return Err(format!(
+            "image too large: {} bytes (max {} bytes)",
+            bytes.len(),
+            MAX_IMAGE_BYTES
+        ));
+    }
+    let ext = detect_image_ext(bytes).ok_or_else(|| "unsupported image format".to_string())?;
+    let images = images_dir(dir);
+    fs::create_dir_all(&images).map_err(|e| format!("Failed to create images dir: {}", e))?;
+    let filename = format!("{}.{}", Uuid::new_v4(), ext);
+    fs::write(images.join(&filename), bytes).map_err(|e| format!("Failed to save image: {}", e))?;
+    Ok(format!("images/{}", filename))
+}
+
+/// content 中の `![alt](images/...)` が参照する相対パス（`images/...`）を抽出する。
+/// `is_valid_image_rel_path` の形状に一致するものだけを採用し、パストラバーサルを狙った
+/// 記法（`images/../notes.json` 等）は候補にすら入れない。
+/// Markdown パーサ全体は導入せず、この記法だけを手書きでスキャンする。
+pub(crate) fn extract_image_paths(content: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    // `!` と `[` は ASCII なので、一致した位置は常に UTF-8 の文字境界にある
+    while i + 1 < bytes.len() {
+        if bytes[i] != b'!' || bytes[i + 1] != b'[' {
+            i += 1;
+            continue;
+        }
+        let after_alt_start = i + 2;
+        let Some(alt_end) = content[after_alt_start..].find(']') else {
+            i += 1;
+            continue;
+        };
+        let paren_pos = after_alt_start + alt_end + 1;
+        if content.as_bytes().get(paren_pos) != Some(&b'(') {
+            i += 1;
+            continue;
+        }
+        let src_start = paren_pos + 1;
+        let Some(src_len) = content[src_start..].find(')') else {
+            i += 1;
+            continue;
+        };
+        let src = &content[src_start..src_start + src_len];
+        if is_valid_image_rel_path(src) {
+            paths.push(src.to_string());
+        }
+        i = src_start + src_len + 1;
+    }
+    paths
+}
+
+/// notes / trash の全 content が参照している画像相対パスの集合。
+fn referenced_image_paths(notes: &[Note], trash: &[Note]) -> HashSet<String> {
+    notes
+        .iter()
+        .chain(trash.iter())
+        .flat_map(|n| extract_image_paths(&n.content))
+        .collect()
+}
+
+/// GC 候補パスのうち、notes / trash のどこからも参照されなくなったものだけ削除する。
+/// 削除失敗は致命的ではないので warn ログに残すだけで処理は続ける。
+pub(crate) fn gc_images(data_dir: &Path, candidates: &[String], notes: &[Note], trash: &[Note]) {
+    if candidates.is_empty() {
+        return;
+    }
+    let referenced = referenced_image_paths(notes, trash);
+    for path in candidates {
+        // candidates は呼び出し元が extract_image_paths で作るので既に形状検証済みのはずだが、
+        // 削除という不可逆操作の直前でもう一段検証する（多層防御）
+        if !is_valid_image_rel_path(path) || referenced.contains(path) {
+            continue;
+        }
+        let full = data_dir.join(path);
+        if let Err(e) = fs::remove_file(&full) {
+            if e.kind() != io::ErrorKind::NotFound {
+                log::warn!("failed to remove orphaned image {}: {}", full.display(), e);
+            }
+        }
     }
 }
 
@@ -250,7 +387,7 @@ mod tests {
         let mut trash: Vec<Note> = (0..TRASH_MAX)
             .map(|i| make_note(&i.to_string(), "yellow", ""))
             .collect();
-        enforce_trash_limit(&mut trash);
+        let _ = enforce_trash_limit(&mut trash);
         assert_eq!(trash.len(), TRASH_MAX);
     }
 
@@ -259,7 +396,7 @@ mod tests {
         let mut trash: Vec<Note> = (0..TRASH_MAX + 1)
             .map(|i| make_note(&i.to_string(), "yellow", ""))
             .collect();
-        enforce_trash_limit(&mut trash);
+        let _ = enforce_trash_limit(&mut trash);
         assert_eq!(trash.len(), TRASH_MAX);
         // oldest (id "0") should be removed
         assert_eq!(trash[0].id, "1");
@@ -270,10 +407,300 @@ mod tests {
         let mut trash: Vec<Note> = (0..TRASH_MAX + 5)
             .map(|i| make_note(&i.to_string(), "yellow", ""))
             .collect();
-        enforce_trash_limit(&mut trash);
+        let _ = enforce_trash_limit(&mut trash);
         assert_eq!(trash.len(), TRASH_MAX);
         assert_eq!(trash[0].id, "5");
         assert_eq!(trash[TRASH_MAX - 1].id, (TRASH_MAX + 4).to_string());
+    }
+
+    #[test]
+    fn trash_fifo_returns_drained_notes() {
+        let mut trash: Vec<Note> = (0..TRASH_MAX + 2)
+            .map(|i| make_note(&i.to_string(), "yellow", ""))
+            .collect();
+        let drained = enforce_trash_limit(&mut trash);
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id, "0");
+        assert_eq!(drained[1].id, "1");
+    }
+
+    #[test]
+    fn trash_fifo_within_limit_drains_nothing() {
+        let mut trash: Vec<Note> = (0..TRASH_MAX)
+            .map(|i| make_note(&i.to_string(), "yellow", ""))
+            .collect();
+        assert!(enforce_trash_limit(&mut trash).is_empty());
+    }
+
+    // テスト用の有効な uuid 形状パス。1〜9 の連番を末尾に埋め込み、テストごとに使い分ける
+    fn uuid_image_path(n: u8) -> String {
+        format!("images/00000000-0000-4000-8000-00000000000{}.png", n)
+    }
+
+    // ── is_valid_image_rel_path ──
+
+    #[test]
+    fn is_valid_image_rel_path_accepts_generated_shape() {
+        assert!(is_valid_image_rel_path(&uuid_image_path(1)));
+        assert!(is_valid_image_rel_path(
+            "images/00000000-0000-4000-8000-000000000001.jpg"
+        ));
+        assert!(is_valid_image_rel_path(
+            "images/00000000-0000-4000-8000-000000000001.jpeg"
+        ));
+        assert!(is_valid_image_rel_path(
+            "images/00000000-0000-4000-8000-000000000001.gif"
+        ));
+    }
+
+    #[test]
+    fn is_valid_image_rel_path_rejects_path_traversal() {
+        assert!(!is_valid_image_rel_path("images/../notes.json"));
+        assert!(!is_valid_image_rel_path("images/../../etc/passwd"));
+        assert!(!is_valid_image_rel_path("images/sub/dir.png"));
+        assert!(!is_valid_image_rel_path("images/..\\notes.json"));
+    }
+
+    #[test]
+    fn is_valid_image_rel_path_rejects_non_uuid_stem() {
+        assert!(!is_valid_image_rel_path("images/a.png"));
+        assert!(!is_valid_image_rel_path("images/notes.json"));
+    }
+
+    #[test]
+    fn is_valid_image_rel_path_rejects_unsupported_extension() {
+        assert!(!is_valid_image_rel_path(
+            "images/00000000-0000-4000-8000-000000000001.tiff"
+        ));
+        assert!(!is_valid_image_rel_path(
+            "images/00000000-0000-4000-8000-000000000001"
+        ));
+    }
+
+    #[test]
+    fn is_valid_image_rel_path_rejects_missing_images_prefix() {
+        assert!(!is_valid_image_rel_path(
+            "00000000-0000-4000-8000-000000000001.png"
+        ));
+        assert!(!is_valid_image_rel_path(""));
+    }
+
+    // ── extract_image_paths ──
+
+    #[test]
+    fn extract_image_paths_finds_single_reference() {
+        let path = uuid_image_path(1);
+        let content = format!("見出し\n![]({})\n本文", path);
+        assert_eq!(extract_image_paths(&content), vec![path]);
+    }
+
+    #[test]
+    fn extract_image_paths_finds_multiple_references_with_alt() {
+        let (p1, p2) = (uuid_image_path(1), uuid_image_path(2));
+        let content = format!("![alt1]({}) text ![alt2]({})", p1, p2);
+        assert_eq!(extract_image_paths(&content), vec![p1, p2]);
+    }
+
+    #[test]
+    fn extract_image_paths_ignores_non_image_links() {
+        let content = "[link](https://example.com) and ![alt](https://example.com/pic.png)";
+        assert!(extract_image_paths(content).is_empty());
+    }
+
+    #[test]
+    fn extract_image_paths_empty_content_returns_empty() {
+        assert!(extract_image_paths("").is_empty());
+    }
+
+    #[test]
+    fn extract_image_paths_does_not_panic_on_multibyte_content() {
+        let path = uuid_image_path(1);
+        let content = format!("日本語のテキスト ![説明]({}) さらに続く文章", path);
+        let found = extract_image_paths(&content);
+        assert_eq!(found, vec![path]);
+    }
+
+    /// パストラバーサル細工（issue で指摘された `images/../notes.json` 系）は候補にすら
+    /// 入らない。extract_image_paths → gc_images の両方が同じ `is_valid_image_rel_path`
+    /// を通るため、ここで弾ければ GC の削除対象にもならない。
+    #[test]
+    fn extract_image_paths_rejects_path_traversal_payload() {
+        let content = "![](images/../notes.json)";
+        assert!(extract_image_paths(content).is_empty());
+    }
+
+    #[test]
+    fn extract_image_paths_rejects_nested_path_payload() {
+        let content = "![](images/../../etc/passwd)";
+        assert!(extract_image_paths(content).is_empty());
+    }
+
+    #[test]
+    fn extract_image_paths_rejects_backslash_traversal_payload() {
+        let content = "![](images/..\\notes.json)";
+        assert!(extract_image_paths(content).is_empty());
+    }
+
+    // ── gc_images ──
+
+    #[test]
+    fn gc_images_removes_unreferenced_image() {
+        let dir = TempDir::new().unwrap();
+        let path = uuid_image_path(1);
+        let images = dir.path().join("images");
+        fs::create_dir_all(&images).unwrap();
+        let filename = path.strip_prefix("images/").unwrap();
+        fs::write(images.join(filename), b"data").unwrap();
+
+        gc_images(dir.path(), std::slice::from_ref(&path), &[], &[]);
+
+        assert!(!images.join(filename).exists());
+    }
+
+    /// 他の付箋が同じ画像を参照していたら消さない。
+    #[test]
+    fn gc_images_keeps_image_still_referenced_by_another_note() {
+        let dir = TempDir::new().unwrap();
+        let path = uuid_image_path(1);
+        let images = dir.path().join("images");
+        fs::create_dir_all(&images).unwrap();
+        let filename = path.strip_prefix("images/").unwrap();
+        fs::write(images.join(filename), b"data").unwrap();
+        let notes = vec![make_note("a", "yellow", &format!("![]({})", path))];
+
+        gc_images(dir.path(), std::slice::from_ref(&path), &notes, &[]);
+
+        assert!(images.join(filename).exists());
+    }
+
+    /// trash 側の参照でも残す。
+    #[test]
+    fn gc_images_keeps_image_still_referenced_by_trash() {
+        let dir = TempDir::new().unwrap();
+        let path = uuid_image_path(1);
+        let images = dir.path().join("images");
+        fs::create_dir_all(&images).unwrap();
+        let filename = path.strip_prefix("images/").unwrap();
+        fs::write(images.join(filename), b"data").unwrap();
+        let trash = vec![make_note("t", "yellow", &format!("![]({})", path))];
+
+        gc_images(dir.path(), std::slice::from_ref(&path), &[], &trash);
+
+        assert!(images.join(filename).exists());
+    }
+
+    #[test]
+    fn gc_images_missing_file_does_not_error() {
+        let dir = TempDir::new().unwrap();
+        // ファイルが既に無くても panic しない
+        gc_images(dir.path(), &[uuid_image_path(1)], &[], &[]);
+    }
+
+    /// 呼び出し元の検証をすり抜けて渡ってきても、削除直前の多層防御で弾かれる
+    /// （data_dir の外や notes.json 自体を指すパスは、そもそも削除対象にしない）。
+    #[test]
+    fn gc_images_defends_against_path_traversal_candidate() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("notes.json"), r#"[{"id":"a"}]"#).unwrap();
+
+        gc_images(dir.path(), &["images/../notes.json".to_string()], &[], &[]);
+
+        assert!(dir.path().join("notes.json").exists());
+    }
+
+    // ── save_pasted_image ──
+
+    const PNG_MAGIC: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    const JPEG_MAGIC: &[u8] = &[0xFF, 0xD8, 0xFF];
+    const GIF_MAGIC: &[u8] = b"GIF89a";
+
+    #[test]
+    fn save_pasted_image_writes_bytes_and_returns_uuid_png_path() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = PNG_MAGIC.to_vec();
+        bytes.extend_from_slice(b"rest-of-the-fake-png-data");
+
+        let rel_path = save_pasted_image(dir.path(), &bytes).unwrap();
+
+        assert!(is_valid_image_rel_path(&rel_path));
+        assert!(rel_path.ends_with(".png"));
+        let filename = rel_path.strip_prefix("images/").unwrap();
+        assert_eq!(
+            fs::read(dir.path().join("images").join(filename)).unwrap(),
+            bytes
+        );
+    }
+
+    #[test]
+    fn save_pasted_image_detects_jpeg_extension() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = JPEG_MAGIC.to_vec();
+        bytes.extend_from_slice(b"rest-of-the-fake-jpeg-data");
+
+        let rel_path = save_pasted_image(dir.path(), &bytes).unwrap();
+
+        assert!(rel_path.ends_with(".jpg"));
+        assert!(is_valid_image_rel_path(&rel_path));
+    }
+
+    #[test]
+    fn save_pasted_image_detects_gif_extension() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = GIF_MAGIC.to_vec();
+        bytes.extend_from_slice(b"rest-of-the-fake-gif-data");
+
+        let rel_path = save_pasted_image(dir.path(), &bytes).unwrap();
+
+        assert!(rel_path.ends_with(".gif"));
+        assert!(is_valid_image_rel_path(&rel_path));
+    }
+
+    #[test]
+    fn save_pasted_image_creates_images_dir_if_missing() {
+        let dir = TempDir::new().unwrap();
+        assert!(!dir.path().join("images").exists());
+
+        save_pasted_image(dir.path(), PNG_MAGIC).unwrap();
+
+        assert!(dir.path().join("images").is_dir());
+    }
+
+    #[test]
+    fn save_pasted_image_rejects_oversized_payload() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = vec![0u8; MAX_IMAGE_BYTES + 1];
+        bytes[..PNG_MAGIC.len()].copy_from_slice(PNG_MAGIC);
+
+        let result = save_pasted_image(dir.path(), &bytes);
+
+        assert!(result.is_err());
+        assert!(!dir.path().join("images").exists());
+    }
+
+    #[test]
+    fn save_pasted_image_accepts_payload_at_exactly_the_limit() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = vec![0u8; MAX_IMAGE_BYTES];
+        bytes[..PNG_MAGIC.len()].copy_from_slice(PNG_MAGIC);
+
+        assert!(save_pasted_image(dir.path(), &bytes).is_ok());
+    }
+
+    #[test]
+    fn save_pasted_image_rejects_unsupported_format() {
+        let dir = TempDir::new().unwrap();
+        let bytes = b"BM-this-looks-like-a-bitmap-not-png-jpeg-or-gif".to_vec();
+
+        let result = save_pasted_image(dir.path(), &bytes);
+
+        assert!(result.is_err());
+        assert!(!dir.path().join("images").exists());
+    }
+
+    #[test]
+    fn save_pasted_image_rejects_empty_payload() {
+        let dir = TempDir::new().unwrap();
+        assert!(save_pasted_image(dir.path(), &[]).is_err());
     }
 
     // ── JSON persistence roundtrip ──

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,11 @@
     "withGlobalTauri": true,
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ipc: tauri:"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: tauri:",
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$APPDATA/images/**/*"]
+      }
     },
     "macOSPrivateApi": true
   },

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -7,6 +7,15 @@
 // This is intentional — HTML entities (e.g. &amp;) are treated as plain text
 // within Markdown syntax, and code blocks store the escaped form as-is,
 // avoiding double-escaping when placed inside <code> tags.
+
+// escapeHtml() (utils.js) only escapes & < > — safe for element content, but an
+// attribute value (href, data-url, img alt/src) also needs " and ' escaped, or
+// a crafted markdown source (e.g. `!["  onerror=alert(1) x="](images/a.png)`)
+// can break out of the attribute and inject event handlers.
+function escapeAttr(s) {
+  return s.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 function inlineMarkdown(escaped) {
   // `code` → placeholder (protect from bold/italic/strikethrough)
   const codeBlocks = [];
@@ -20,15 +29,22 @@ function inlineMarkdown(escaped) {
   escaped = escaped.replace(/\*([^*]+)\*/g, '<em>$1</em>');
   // ~~strikethrough~~ → <del>
   escaped = escaped.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+  // ![alt](src) → <img> (before the link regex; `!` prefix distinguishes it from a link)
+  escaped = escaped.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, alt, src) => {
+    const resolved = (typeof window !== 'undefined' && typeof window.resolveImageSrc === 'function')
+      ? window.resolveImageSrc(src)
+      : src;
+    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}">`;
+  });
   // [text](url) → <a>
   escaped = escaped.replace(
     /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g,
-    '<a href="$2" data-url="$2">$1</a>'
+    (_, text, url) => `<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${text}</a>`
   );
   // Bare URLs → <a> (skip URLs already inside an <a> tag)
   escaped = escaped.replace(
     /((?:^|[^"=]))((https?:\/\/)[^\s<]+)/g,
-    (_, pre, url) => `${pre}<a href="${url}" data-url="${url}">${url}</a>`
+    (_, pre, url) => `${pre}<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${url}</a>`
   );
   // Restore code blocks
   // eslint-disable-next-line no-control-regex -- \x00 is the placeholder marker

--- a/src/note.html
+++ b/src/note.html
@@ -197,6 +197,7 @@
 
   .md-placeholder { color: var(--text-muted); }
   .md-line, .md-empty { min-height: 21px; word-break: break-word; }
+  #markdown-view img { max-width: 100%; }
   .md-h1 { font-size: 17px; font-weight: 700; line-height: 1.4; margin: 4px 0 2px; }
   .md-h2 { font-size: 15px; font-weight: 600; line-height: 1.4; margin: 3px 0 1px; }
   .md-h3 { font-size: 14px; font-weight: 600; line-height: 1.4; margin: 2px 0 1px; }

--- a/src/note.js
+++ b/src/note.js
@@ -25,6 +25,14 @@ let activeStart = null;
 let activeEnd = null;
 let composing = false;
 
+// `save_pasted_image`（Rust 側）が生成するパスの形状（`images/<uuid v4>.<ext>`）とだけ一致させる。
+// asset protocol の scope（$APPDATA/images/**/*）を信じきらず、`images/../notes.json` のような
+// 細工パスを resolveImageSrc で asset URL に変換してしまわないための最終防衛ライン。
+const IMAGE_REL_PATH_RE = /^images\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpe?g|gif)$/i;
+function isValidImageRelPath(path) {
+  return typeof path === 'string' && IMAGE_REL_PATH_RE.test(path);
+}
+
 /** 失敗を握り潰してよい操作向けの invoke。エラーはログとトーストに出す。 */
 function fireInvoke(cmd, args, failMessage) {
   return invoke(cmd, args).catch(e => {
@@ -100,6 +108,15 @@ async function loadNote() {
   }
 
   I18N.setLang(I18N.resolve(settings?.language, settings?.system_language));
+
+  // 貼り付け画像の asset protocol URL 組み立て。data_dir は起動のたびに変わらないので一度だけ設定する
+  if (settings?.data_dir) {
+    const { convertFileSrc } = window.__TAURI__.core;
+    // 形状が一致しないパスは asset URL に変換せずそのまま返す（存在しないファイルとして扱われるだけで済む）
+    window.resolveImageSrc = (relPath) => isValidImageRelPath(relPath)
+      ? convertFileSrc(`${settings.data_dir}/${relPath}`)
+      : relPath;
+  }
 
   rawContent = note.content;
   renderAll();
@@ -487,7 +504,37 @@ function insertIntoEditor(ed, inserted) {
   applyLines(lines, line + parts.length - 1, tailCol);
 }
 
-function onEditorPaste(e) {
+/**
+ * クリップボード画像を保存し、生成された相対パスを Markdown 画像記法として挿入する。
+ * 保存待ちの `await` 中に生表示が閉じられる／別行へ移ることがあり得るため、戻ってきた時点で
+ * ed がまだ同じ行の生表示のままかを確認する。ずれていたら ed への挿入を諦め、元の行
+ * （無ければ末尾）へ直接書き戻して保存する。黙って捨てると保存先の無い孤児画像になる。
+ */
+async function pasteImage(ed, file) {
+  const lineAtPaste = activeStart;
+  let relPath;
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    relPath = await invoke('save_pasted_image', bytes);
+  } catch (err) {
+    console.error('save_pasted_image failed:', err);
+    showToast(I18N.t('toastSaveFailed'));
+    return;
+  }
+  const markdown = `![](${relPath})`;
+  if (ed.isConnected && activeStart === lineAtPaste) {
+    insertIntoEditor(ed, markdown);
+    return;
+  }
+  const lines = getLines();
+  const target = Math.min(Math.max(lineAtPaste ?? lines.length - 1, 0), lines.length - 1);
+  lines[target] += markdown;
+  rawContent = lines.join('\n');
+  renderAll();
+  await saveNow();
+}
+
+async function onEditorPaste(e) {
   e.preventDefault();
   const ed = e.currentTarget;
   const text = e.clipboardData.getData('text/plain');
@@ -500,6 +547,15 @@ function onEditorPaste(e) {
     snapshotContent();
     scheduleSave();
     return;
+  }
+
+  if (!text) {
+    const imageItem = Array.from(e.clipboardData.items)
+      .find(item => item.kind === 'file' && item.type.startsWith('image/'));
+    if (imageItem) {
+      await pasteImage(ed, imageItem.getAsFile());
+      return;
+    }
   }
 
   insertIntoEditor(ed, toMarkdown(text, e.clipboardData.getData('text/html')));

--- a/src/note.js
+++ b/src/note.js
@@ -28,7 +28,7 @@ let composing = false;
 // `save_pasted_image`（Rust 側）が生成するパスの形状（`images/<uuid v4>.<ext>`）とだけ一致させる。
 // asset protocol の scope（$APPDATA/images/**/*）を信じきらず、`images/../notes.json` のような
 // 細工パスを resolveImageSrc で asset URL に変換してしまわないための最終防衛ライン。
-const IMAGE_REL_PATH_RE = /^images\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpe?g|gif)$/i;
+const IMAGE_REL_PATH_RE = /^images\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpe?g|gif|webp)$/i;
 function isValidImageRelPath(path) {
   return typeof path === 'string' && IMAGE_REL_PATH_RE.test(path);
 }

--- a/tests/unit/render-markdown.test.js
+++ b/tests/unit/render-markdown.test.js
@@ -216,6 +216,67 @@ describe("renderMarkdown — edge cases", () => {
   });
 });
 
+describe("renderMarkdown — image syntax", () => {
+  test("image without alt", () => {
+    const html = renderMarkdown("![](images/a.png)");
+    assert.match(html, /<img alt="" src="images\/a\.png">/);
+  });
+
+  test("image with alt", () => {
+    const html = renderMarkdown("![説明](images/a.png)");
+    assert.match(html, /<img alt="説明" src="images\/a\.png">/);
+  });
+
+  test("image mixed with link on the same line", () => {
+    const html = renderMarkdown("![](images/a.png) [text](https://example.com)");
+    assert.match(html, /<img alt="" src="images\/a\.png">/);
+    assert.match(html, /<a href="https:\/\/example\.com"/);
+  });
+
+  test("link is not mistaken for an image (no leading !)", () => {
+    const html = renderMarkdown("[text](https://example.com)");
+    assert.doesNotMatch(html, /<img/);
+  });
+
+  test("uses window.resolveImageSrc when defined", () => {
+    global.window = { resolveImageSrc: (src) => `asset://localhost/${src}` };
+    try {
+      const html = renderMarkdown("![](images/a.png)");
+      assert.match(html, /<img alt="" src="asset:\/\/localhost\/images\/a\.png">/);
+    } finally {
+      delete global.window;
+    }
+  });
+
+  test("image nested inside a link renders <img> inside <a>", () => {
+    const html = renderMarkdown("[![alt](images/a.png)](https://example.com)");
+    assert.match(
+      html,
+      /<a href="https:\/\/example\.com" data-url="https:\/\/example\.com"><img alt="alt" src="images\/a\.png"><\/a>/
+    );
+  });
+
+  test("image alt attribute injection attempt is neutralized", () => {
+    const html = renderMarkdown('![" onerror=alert(1) x="](images/a.png)');
+    // The payload text survives as inert data, but the `"` that would break out of the
+    // attribute is escaped — no unescaped `"` appears right before `onerror=`.
+    assert.doesNotMatch(html, /alt="[^"]*"[^>]*onerror=/);
+    assert.match(html, /<img alt="&quot; onerror=alert\(1\) x=&quot;" src="images\/a\.png">/);
+  });
+
+  test("image src attribute injection attempt is neutralized", () => {
+    const html = renderMarkdown('![](images/a.png"onerror=xss)');
+    assert.doesNotMatch(html, /src="images\/a\.png"onerror=xss"/);
+    assert.match(html, /src="images\/a\.png&quot;onerror=xss"/);
+  });
+
+  test("link href attribute injection attempt is neutralized", () => {
+    const html = renderMarkdown('[text](https://example.com/"onmouseover=xss x=")');
+    assert.doesNotMatch(html, /href="https:\/\/example\.com\/"onmouseover/);
+    assert.match(html, /href="https:\/\/example\.com\/&quot;onmouseover=xss x=&quot;"/);
+  });
+});
+
 describe("renderMarkdown — NBSP (U+00A0) normalization", () => {
   test("checkbox with NBSP: - [ ] task", () => {
     const html = renderMarkdown("- [ ] task");

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -12,6 +12,7 @@ const DEFAULT_SETTINGS = {
   confirm_before_delete: true,
   language: "ja",
   system_language: "ja",
+  data_dir: "/mock/data-dir",
 };
 
 // ── Note mock ──────────────────────────────────────────────
@@ -48,6 +49,7 @@ export async function injectNoteMock(
         case "update_settings":       return null;
         case "delete_note":           return null;
         case "create_note":           return null;
+        case "save_pasted_image":     return "images/00000000-0000-4000-8000-000000000001.png";
         default:                      return null;
       }
     };
@@ -70,7 +72,10 @@ export async function injectNoteMock(
     (window as any).__appWindowListeners = appWindowListeners;
 
     (window as any).__TAURI__ = {
-      core: { invoke },
+      core: {
+        invoke,
+        convertFileSrc: (path: string) => `asset://localhost/${path}`,
+      },
       event: {
         listen: async (event: string, handler: EventHandler) => {
           if (!globalListeners[event]) globalListeners[event] = [];

--- a/tests/visual/paste-e2e.spec.ts
+++ b/tests/visual/paste-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, enterEdit, getContent } from "./fixtures";
+import { test, expect, enterEdit, getContent, injectNoteMock } from "./fixtures";
 
 test.describe("ペースト処理", () => {
   test("空の選択状態でURLペースト → リンク変換されずプレーンURL挿入", async ({ openNote }) => {
@@ -155,5 +155,40 @@ test.describe("ペースト処理", () => {
 
     const content = await getContent(page);
     expect(content).toBe("[click here](https://example.com)");
+  });
+
+  test("クリップボード画像ペースト → save_pasted_image 経由でMarkdown画像記法が挿入される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "pasted.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)");
+
+    await ctx.close();
   });
 });


### PR DESCRIPTION
## 背景

付箋の代表的な使い方である「スクショをとりあえず貼っておく」ができない。macOS Stickies は画像を貼れるため、数少ない「Stickies にできて貼っとっとにできない」ことになっている。

## 仕様

⌘V でクリップボードの画像を付箋に貼れる（PNG / JPEG / GIF / WebP、上限 10MB。macOS のスクショは WebKit が PNG に変換して渡してくるのでそのまま通る）。

- 画像はデータディレクトリの `images/<uuid>.<ext>` に保存され、content には相対パスの `![](images/...)` が入る
- 画像行にキャレットを置くと生 Markdown になる（既存の行単位の生表示にそのまま乗る）
- 付箋が完全に消えるとき（ゴミ箱の上限超過・ゴミ箱を空にする）に、どの付箋からも参照されなくなった画像ファイルだけ削除される
- 対応外の形式・サイズ超過はトーストで知らせる

## やったこと

- BE: 画像保存コマンド（raw payload 受信・マジックバイトで形式判定）と未参照画像の GC。content 由来のパスは「`images/` 直下 + uuid 形状」だけを抽出・削除・表示の全経路で許可し、パストラバーサルを塞ぐ
- 設定: asset protocol の有効化（scope は `$APPDATA/images/**/*`）と CSP の `img-src` 追加
- FE: paste イベントの画像分岐、Markdown の `![alt](src)` 描画（img とリンクの属性値は専用エスケープを通す）
- テスト: 形式判定・パス検証・GC の Rust ユニットテスト、描画の UT、ペーストの E2E

## 確認したこと

- cargo test 128 件 / clippy / fmt、eslint、node UT 136 件 + Playwright 199 件（VRT ベースライン差分なし）
- 実機でスクショを ⌘V し、画像の描画・キャレット行の生 Markdown 化・`images/<uuid>.png` の生成を確認

## 関連リンク

- Closes #63

- 後続 PR: #65
