### PR TITLE
✨ 画像を貼れるようにする｜2｜Finder やブラウザから画像をドラッグ&ドロップで貼れるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: Rust Build
 on:
   push:
     branches: [main]
+  # base を絞らない（main 宛だけに絞ると、スタック PR（base が別 PR のブランチ）で CI が走らない）
   pull_request:
-    branches: [main]
 
 # 同じブランチへ push を重ねたら古い実行を打ち切る
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Frontend Checks
 on:
   push:
     branches: [main]
+  # base を絞らない（main 宛だけに絞ると、スタック PR（base が別 PR のブランチ）で CI が走らない）
   pull_request:
-    branches: [main]
 
 # 同じブランチへ push を重ねたら古い実行を打ち切る
 concurrency:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -3,8 +3,8 @@ name: Visual Regression Tests
 on:
   push:
     branches: [main]
+  # base を絞らない（main 宛だけに絞ると、スタック PR（base が別 PR のブランチ）で CI が走らない）
   pull_request:
-    branches: [main]
 
 # 同じブランチへ push を重ねたら古い実行を打ち切る
 concurrency:

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -177,8 +177,7 @@ pub(crate) fn delete_note_data(state: &AppState, id: &str) -> Result<bool, Strin
         }
         save_notes(state, &notes_snapshot)?;
         *state.notes.recover() = notes_snapshot;
-        // note.is_empty() は content.trim() が空であることを意味し、画像記法（非空白）を
-        // 含む content では成立しない。この経路に画像 GC は不要（呼んでも常に空振りする）
+        // 画像記法を含む content は空白のみにならず、この分岐には来ないため画像 GC は不要
         return Ok(true);
     }
 

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -117,6 +117,10 @@ pub(crate) fn open_note_window(app: &AppHandle, note: &Note) {
         .always_on_top(note.pinned)
         .accept_first_mouse(true)
         .visible(true)
+        // Tauri の既定 drag-drop ハンドラは WKWebView 標準の HTML5 drag/drop を握りつぶし、
+        // Finder / ブラウザからドラッグした画像が DataTransfer.files に届かなくなる。
+        // 付箋ウィンドウだけ無効化し、ドロップは note.js 側の HTML5 API で処理する
+        .disable_drag_drop_handler()
         .build()
     {
         Ok(win) => win,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -110,6 +110,7 @@ const I18N_TABLE = {
   toastSaveFailed: { ja: '保存に失敗しました', en: 'Failed to save' },
   toastCreateFailed: { ja: '付箋の作成に失敗しました', en: 'Failed to create note' },
   toastDeleteFailed: { ja: '付箋の削除に失敗しました', en: 'Failed to delete note' },
+  toastImageDropUnsupported: { ja: '画像として扱えないファイルです', en: 'This file cannot be added as an image' },
 };
 
 // 訳の付け忘れ検出（キーを増やしたときに片方の言語が抜けていたら気づけるように）

--- a/src/note.js
+++ b/src/note.js
@@ -15,6 +15,18 @@ const pinBtn    = document.getElementById('btn-pin');
 const newBtn    = document.getElementById('btn-new');
 const colorBtn  = document.getElementById('btn-color');
 
+/** File を含むドラッグかどうか。dragover 時点でも `types` は（protected mode でも）参照できる。 */
+function isFileDrag(e) {
+  return e.dataTransfer.types.includes('Files');
+}
+
+// Tauri の drag-drop ハンドラは付箋ウィンドウだけ無効化している（src-tauri/src/window.rs）ため、
+// ファイルドラッグは HTML5 API に委ねられる。preventDefault が無いと WKWebView がドロップされた
+// ファイルを file:// として開いてしまう。ファイル以外のドラッグ（テキスト選択など）の既定動作は
+// 奪わないよう、File を含むドラッグだけを止める。挿入処理の本体は別の場所にある
+document.addEventListener('dragover', (e) => { if (isFileDrag(e)) e.preventDefault(); });
+document.addEventListener('drop', (e) => { if (isFileDrag(e)) e.preventDefault(); });
+
 let saveTimer = null;
 
 // ── Editor State ──────────────────────────────────
@@ -505,12 +517,13 @@ function insertIntoEditor(ed, inserted) {
 }
 
 /**
- * クリップボード画像を保存し、生成された相対パスを Markdown 画像記法として挿入する。
+ * クリップボード画像・ドロップ画像を保存し、生成された相対パスを Markdown 画像記法として挿入する。
  * 保存待ちの `await` 中に生表示が閉じられる／別行へ移ることがあり得るため、戻ってきた時点で
- * ed がまだ同じ行の生表示のままかを確認する。ずれていたら ed への挿入を諦め、元の行
- * （無ければ末尾）へ直接書き戻して保存する。黙って捨てると保存先の無い孤児画像になる。
+ * ed がまだ同じ行の生表示のままかを確認する。ずれていたら ed への挿入を諦め、fallbackLine
+ * （無ければ元の行、それも無ければ末尾）へ直接書き戻して保存する。黙って捨てると保存先の無い
+ * 孤児画像になる。ed は null 許容（最初からフォールバック挿入になる）。
  */
-async function pasteImage(ed, file) {
+async function pasteImage(ed, file, fallbackLine) {
   const lineAtPaste = activeStart;
   let relPath;
   try {
@@ -522,12 +535,12 @@ async function pasteImage(ed, file) {
     return;
   }
   const markdown = `![](${relPath})`;
-  if (ed.isConnected && activeStart === lineAtPaste) {
+  if (ed?.isConnected && activeStart === lineAtPaste) {
     insertIntoEditor(ed, markdown);
     return;
   }
   const lines = getLines();
-  const target = Math.min(Math.max(lineAtPaste ?? lines.length - 1, 0), lines.length - 1);
+  const target = Math.min(Math.max(fallbackLine ?? lineAtPaste ?? lines.length - 1, 0), lines.length - 1);
   lines[target] += markdown;
   rawContent = lines.join('\n');
   renderAll();
@@ -561,14 +574,60 @@ async function onEditorPaste(e) {
   insertIntoEditor(ed, toMarkdown(text, e.clipboardData.getData('text/html')));
 }
 
-function onEditorDrop(e) {
+/** 画像 File を順番どおりに挿入する。挿入のたびに行番号がずれるため並列にはできない。 */
+async function pasteImageFiles(ed, files, fallbackLine) {
+  for (const file of files) {
+    await pasteImage(ed, file, fallbackLine);
+  }
+}
+
+async function onEditorDrop(e) {
   e.preventDefault();
   const ed = e.currentTarget;
+  const imageFiles = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/'));
+  if (imageFiles.length) {
+    await pasteImageFiles(ed, imageFiles);
+    return;
+  }
+  // File を含むのに画像が無いドロップは、黙って無視すると無反応に見えるので知らせる
+  //（WKWebView は画像以外のファイルドラッグを drop イベントの発火前に拒否するため、
+  // この分岐に届くのはブラウザ由来など File はあるが画像でないドロップに限られる）
+  if (isFileDrag(e)) {
+    showToast(I18N.t('toastImageDropUnsupported'));
+    return;
+  }
   const text = e.dataTransfer.getData('text/plain');
   if (!text) return;
   // drop 位置ではなく現在のキャレット位置へ入れる
   insertIntoEditor(ed, toMarkdown(text, e.dataTransfer.getData('text/html')));
 }
+
+/** ドロップ先の要素から挿入対象の行番号を求める。フェンスは行単位のマッピングを持たないので末尾に置く。 */
+function dropTargetLine(target) {
+  const el = target.closest('[data-line]');
+  if (!el) return null;
+  return el.dataset.lineEnd != null ? Number(el.dataset.lineEnd) : Number(el.dataset.line);
+}
+
+// ── Drop on non-editing note area ─────────────────
+// 生表示中でない付箋（.raw-editor が無い状態）へのドロップも画像だけは受ける。
+// preventDefault（File ドラッグのみ）は先頭の dragover/drop リスナーが担う
+document.addEventListener('drop', async (e) => {
+  if (!isFileDrag(e)) return;
+  // 生エディタ上のドロップは onEditorDrop が処理する（二重処理を避ける）
+  if (e.target.closest('.raw-editor')) return;
+  const imageFiles = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/'));
+  // renderAll() で DOM が作り直される前に、ドロップ先の行番号を確定させておく
+  const fallbackLine = dropTargetLine(e.target);
+  // 別行が生表示中だった場合に備えて確定させる。これをしないと、生表示ブロックの
+  // 先頭行末へ誤挿入されたり、activeStart/composing が生表示 DOM ごと取り残されたりする
+  commitActive();
+  if (!imageFiles.length) {
+    showToast(I18N.t('toastImageDropUnsupported'));
+    return;
+  }
+  await pasteImageFiles(null, imageFiles, fallbackLine);
+});
 
 // ── Checkbox autocomplete ────────────────────────
 function autocompleteCheckbox(ed) {
@@ -724,6 +783,8 @@ document.addEventListener('keydown', (e) => {
 
 for (const type of ['cut', 'paste', 'drop']) {
   document.addEventListener(type, (e) => {
+    // 画像ドロップは行をまたぐ選択が残っていても許可する（選択範囲への破壊的な書き込みではない）
+    if (type === 'drop' && isFileDrag(e)) return;
     if (!selectionSpansLines()) return;
     e.preventDefault();
     e.stopPropagation();

--- a/tests/visual/image-drop-e2e.spec.ts
+++ b/tests/visual/image-drop-e2e.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, enterEdit, getContent, injectNoteMock } from "./fixtures";
+
+test.describe("ドラッグ&ドロップでの画像追加", () => {
+  test("生エディタへの画像ドロップ → save_pasted_image 経由でMarkdown画像記法が挿入される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "dropped.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      editor.dispatchEvent(dropEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)");
+
+    await ctx.close();
+  });
+
+  test("編集中でない表示領域への画像ドロップ → 末尾行に挿入される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "line1\nline2" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // enterEdit を呼ばない = 生表示に入っていない状態でドロップする
+    await page.evaluate(() => {
+      const view = document.getElementById("markdown-view")!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "dropped.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      view.dispatchEvent(dropEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("line1\nline2![](images/00000000-0000-4000-8000-000000000001.png)");
+
+    await ctx.close();
+  });
+
+  test("複数ファイル同時ドロップ → 1件目の保存が終わるまで2件目の保存が始まらない（逐次性）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    // save_pasted_image の1件目だけ意図的に遅延させ、2件目の呼び出しが
+    // 1件目の resolve より後にしか始まらないことをタイムラインで検証する
+    // （並列化されていれば2件目は1件目の遅延を待たずに始まってしまう）
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      let saveCallCount = 0;
+      (window as any).__invoke_timeline = [];
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd !== "save_pasted_image") return prevInvoke(cmd, args);
+        const idx = saveCallCount++;
+        (window as any).__invoke_timeline.push(`start:${idx}`);
+        if (idx === 0) await new Promise((r) => setTimeout(r, 100));
+        const result = await prevInvoke(cmd, args);
+        (window as any).__invoke_timeline.push(`end:${idx}`);
+        return result;
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const file1 = new File([new Uint8Array([137, 80, 78, 71, 1])], "a.png", { type: "image/png" });
+      const file2 = new File([new Uint8Array([137, 80, 78, 71, 2])], "b.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file1);
+      dt.items.add(file2);
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      editor.dispatchEvent(dropEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() => (window as any).__invoke_timeline.length),
+      { timeout: 3000 },
+    ).toBe(4);
+
+    const timeline = await page.evaluate(() => (window as any).__invoke_timeline);
+    expect(timeline).toEqual(["start:0", "end:0", "start:1", "end:1"]);
+
+    // 挿入自体は2回行われている（モックは同一パスを返すため2回連結される）
+    const content = await getContent(page);
+    expect(content).toBe(
+      "![](images/00000000-0000-4000-8000-000000000001.png)".repeat(2),
+    );
+
+    await ctx.close();
+  });
+
+  test("生表示中の別行の描画エリアへ画像ドロップ → 生表示が commit されてから正しい行に挿入される", async ({ openNote }) => {
+    const page = await openNote({ content: "line0\nline1\nline2" });
+
+    // line0 を生表示にして未確定の編集を作る
+    await enterEdit(page, 0);
+    await page.locator("#editor").click();
+    await page.keyboard.press("End");
+    await page.keyboard.type("X");
+
+    // line0 の生表示中のまま、生表示していない line2 へドロップする
+    await page.evaluate(() => {
+      const target = document.querySelector('[data-line="2"]')!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "dropped.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      target.dispatchEvent(dropEvent);
+    });
+
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    // drop ハンドラは非同期（save_pasted_image → renderAll → saveNow）なので、
+    // dispatchEvent 自体は完了を待たない。保存が終わるまで content を待ち受ける
+    await expect.poll(() => getContent(page), { timeout: 3000 }).toBe(
+      "line0X\nline1\nline2![](images/00000000-0000-4000-8000-000000000001.png)",
+    );
+  });
+
+  test("画像以外のファイルのみのドロップ → トーストが出て内容は変わらない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "line1\nline2" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // enterEdit を呼ばない = 生表示に入っていない状態でドロップする
+    await page.evaluate(() => {
+      const view = document.getElementById("markdown-view")!;
+      const file = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], "doc.pdf", { type: "application/pdf" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      view.dispatchEvent(dropEvent);
+    });
+
+    await expect(page.locator(".toast")).toBeVisible();
+
+    const invokeCount = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+    );
+    expect(invokeCount).toBe(0);
+
+    const content = await getContent(page);
+    expect(content).toBe("line1\nline2");
+
+    await ctx.close();
+  });
+
+  test("生エディタ内のテキストドラッグ移動は退行しない", async ({ openNote }) => {
+    const page = await openNote({ content: "" });
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "dragged text");
+      const dropEvent = new DragEvent("drop", { dataTransfer: dt, bubbles: true, cancelable: true });
+      editor.dispatchEvent(dropEvent);
+    });
+
+    const content = await getContent(page);
+    expect(content).toBe("dragged text");
+  });
+});


### PR DESCRIPTION
## 背景

クリップボードの画像ペースト（#64）に続き、画像を付箋へ入れるもう一つの入口としてドラッグ&ドロップに対応する。保存・描画・GC の土台は先行 PR のものをそのまま使う。

## 仕様

Finder のファイルやブラウザ上の画像を付箋ウィンドウへドラッグ&ドロップすると、クリップボードペーストと同じ形（`images/` 保存 + `![](images/...)` 挿入）で貼れる。

- ドロップ先が編集中の行でもそれ以外の描画部分でもよい。編集中に別の行へドロップした場合は、編集内容を確定させてからドロップした行に挿入する
- 複数ファイルは並び順どおりに挿入する
- 画像以外のファイルは WKWebView がドラッグの受け入れ自体を拒否する（カーソルに「+」が付かない）。File は届いたが画像が無いドロップにはトーストで知らせる

## やったこと

- BE: 付箋ウィンドウの生成時のみ Tauri の drag-drop ハンドラを無効化（有効のままだと WebView 標準の HTML5 drop が抑止され、ファイルの中身が JS に届かない）
- FE: drop / dragover を File を含むドラッグだけ受けるハンドラで処理し、画像 File を既存の保存フローへ逐次流す。ドロップ先の行番号は描画済み要素の `data-line` から解決
- テスト: 生エディタへのドロップ・非編集領域へのドロップ・編集中の別行へのドロップ・複数ファイルの逐次性・非画像ドロップのトーストの E2E を追加

## 確認したこと

- cargo test 128 件 / clippy / fmt、eslint、Playwright 205 件（VRT ベースライン差分なし）
- 実機で Finder からのドラッグ、Safari / Chrome のページ上の画像のドラッグ、編集中の別行へのドロップ、テキスト選択のドラッグ移動と ⌘V ペーストの退行が無いことを確認

## 関連リンク

- issue: #63
- 先行 PR: #64

- 後続 PR: #66
