### PR TITLE
✨ 画像を貼れるようにする｜3｜リッチテキストペーストの HTML 内画像を取り込む

### DIFF
--- a/src/note.js
+++ b/src/note.js
@@ -438,27 +438,123 @@ function indentLine(ed, outdent) {
 }
 
 // ── Paste: rich text links → markdown, otherwise plain ──
-function htmlToMarkdown(html) {
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  let result = '';
-  for (const node of doc.body.childNodes) {
-    result += nodeToMd(node);
+const EMPTY_IMAGE_MAP = new Map();
+
+// Rust 側 save_pasted_image の上限（src-tauri/src/persistence.rs の MAX_IMAGE_BYTES）と揃える。
+// atob() でのデコードは全体をメモリ上に展開するため、送る前に base64 の文字数から概算して弾く。
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const DATA_URI_TOO_LARGE = Symbol('data-uri-too-large');
+
+/**
+ * alt / リンクテキストとして使う HTML 属性値を Markdown として安全な形に無害化する。
+ * `]` を残すと `![alt](src)` / `[alt](src)` の終端と衝突し記法ごと壊れるため取り除く
+ * （エスケープではなく除去。markdown.js の `[^\]]*` も Rust 側の extract_image_paths も
+ * バックスラッシュエスケープを解釈しない）。改行は 1 行の記法を壊すため空白に置換する。
+ */
+function sanitizeAltText(text) {
+  return text.replace(/\r\n|\r|\n/g, ' ').replace(/]/g, '');
+}
+
+/** URL 側（href / src）に改行が入ると Markdown 記法が複数行に割れるため取り除く。 */
+function sanitizeUrl(url) {
+  return url.replace(/\r\n|\r|\n/g, '');
+}
+
+/** `src` 属性値が `data:` スキームかどうか（大文字小文字を無視）。 */
+function isDataUri(src) {
+  return /^data:/i.test(src);
+}
+
+/**
+ * `data:<media-type>;base64,<data>` 形式をデコードする（`;charset=...;base64,` のような
+ * 追加パラメータや `BASE64,` / `DATA:` の大文字小文字表記も許容）。
+ * 戻り値: 成功時は Uint8Array、base64 でない・デコード不能なら null（無言で alt にフォールバック）、
+ * デコード後サイズが Rust 側の上限を超える見込みなら DATA_URI_TOO_LARGE（呼び出し側でトースト対象）。
+ */
+function decodeDataUri(src) {
+  const match = /^data:([^,]*);base64,([\s\S]*)$/i.exec(src);
+  if (!match) return null;
+  const base64 = match[2];
+  if (Math.floor((base64.length * 3) / 4) > MAX_IMAGE_BYTES) return DATA_URI_TOO_LARGE;
+  try {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
   }
+}
+
+/**
+ * `<img src="data:...">` を `save_pasted_image` へ流し、src → 相対パスの Map を返す。
+ * 同じ src が複数回出てきても保存は 1 回だけ。デコード不能（URL エンコード形式等）な src は
+ * 無言で null を積み、呼び出し側で alt テキストのみのフォールバックに回す。サイズ超過・保存失敗は
+ * 件数をまとめて数え、ループ終了後にトーストを 1 回だけ出す（画像ごとに出すとうるさいため）。
+ */
+async function resolveDataImages(srcs) {
+  const map = new Map();
+  let failures = 0;
+  for (const src of srcs) {
+    if (map.has(src)) continue;
+    const decoded = decodeDataUri(src);
+    if (decoded === null) {
+      map.set(src, null);
+      continue;
+    }
+    if (decoded === DATA_URI_TOO_LARGE) {
+      console.error('data: image exceeds size limit, skipping:', src.slice(0, 32));
+      failures++;
+      map.set(src, null);
+      continue;
+    }
+    try {
+      map.set(src, await invoke('save_pasted_image', decoded));
+    } catch (err) {
+      console.error('save_pasted_image failed:', err);
+      failures++;
+      map.set(src, null);
+    }
+  }
+  if (failures) showToast(I18N.t('toastSaveFailed'));
+  return map;
+}
+
+function renderNodesToMd(nodes, imageMap) {
+  let result = '';
+  for (const node of nodes) result += nodeToMd(node, imageMap);
   return result;
 }
 
-function nodeToMd(node) {
+/**
+ * HTML 内に `<img src="data:...">` が無ければ同期で文字列を返す。ある場合だけ
+ * `save_pasted_image` の待ち合わせが必要になるため Promise<string> を返す。
+ * 呼び出し側（toMarkdown 経由）は戻り値が Promise かどうかで同期/非同期を分岐する。
+ */
+function htmlToMarkdown(html) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const dataImgSrcs = Array.from(doc.querySelectorAll('img'))
+    .map(img => img.getAttribute('src') || '')
+    .filter(isDataUri);
+  if (!dataImgSrcs.length) {
+    return renderNodesToMd(doc.body.childNodes, EMPTY_IMAGE_MAP);
+  }
+  return resolveDataImages(dataImgSrcs).then(map => renderNodesToMd(doc.body.childNodes, map));
+}
+
+function nodeToMd(node, imageMap) {
   if (node.nodeType === Node.TEXT_NODE) return node.textContent;
   if (node.nodeType !== Node.ELEMENT_NODE) return '';
   const tag = node.tagName.toLowerCase();
   // Strip script/style tags entirely — their text content is never useful
   if (tag === 'script' || tag === 'style') return '';
-  const inner = Array.from(node.childNodes).map(nodeToMd).join('');
+  const inner = Array.from(node.childNodes).map(child => nodeToMd(child, imageMap)).join('');
   switch (tag) {
     case 'a': {
       const href = node.getAttribute('href') || '';
       if (!href || /^javascript:/i.test(href)) return inner;
-      return `[${inner.trim() || href}](${href})`;
+      const url = sanitizeUrl(href);
+      return `[${inner.trim() || url}](${url})`;
     }
     case 'strong': case 'b':  return inner ? `**${inner}**` : '';
     case 'em': case 'i':      return inner ? `*${inner}*` : '';
@@ -479,15 +575,40 @@ function nodeToMd(node) {
     }
     case 'br':                 return '\n';
     case 'p': case 'div':     return inner + '\n';
+    // CSP の img-src が https を許可していないため、リモート URL は画像記法にせずリンクにする。
+    // data: は resolveDataImages が保存済みの相対パスに解決済み（未解決なら alt のみ残す）。
+    // blob: / file: 等はそもそも取り込まず alt のみ残す。
+    case 'img': {
+      const alt = sanitizeAltText(node.getAttribute('alt') || '');
+      const src = node.getAttribute('src') || '';
+      if (isDataUri(src)) {
+        const relPath = imageMap.get(src);
+        return relPath ? `![${alt}](${relPath})` : alt;
+      }
+      if (/^https?:\/\//i.test(src)) {
+        const url = sanitizeUrl(src);
+        return `[${alt || url}](${url})`;
+      }
+      return alt;
+    }
     default:                   return inner;
   }
 }
 
-/** リッチテキストなら markdown に変換し、そうでなければプレーンテキストを返す。 */
+/**
+ * リッチテキストなら markdown に変換し、そうでなければプレーンテキストを返す。
+ * 変換結果が空／空白のみ（blob: / file: 画像だけで alt も無い等）になった場合は、
+ * 挿入が完全に消えてしまわないよう text にフォールバックする（同期・非同期どちらの経路でも）。
+ */
 function toMarkdown(text, html) {
-  return html && /<(?:a|strong|b|em|i|del|s|code|h[1-3]|blockquote|[uo]l|li)\b/i.test(html)
-    ? htmlToMarkdown(html)
-    : text;
+  if (!html || !/<(?:a|strong|b|em|i|del|s|code|h[1-3]|blockquote|[uo]l|li|img)\b/i.test(html)) {
+    return text;
+  }
+  const converted = htmlToMarkdown(html);
+  if (converted instanceof Promise) {
+    return converted.then(md => (md.trim() ? md : text));
+  }
+  return converted.trim() ? converted : text;
 }
 
 /**
@@ -547,6 +668,31 @@ async function pasteImage(ed, file, fallbackLine) {
   await saveNow();
 }
 
+/**
+ * toMarkdown() の戻り値（同期 string か非同期 Promise<string>）を生エディタへ挿入する。
+ * 非同期経路（HTML に data: 画像を含む場合）は await の間に生表示が閉じる／別行へ移ることが
+ * あり得るため、pasteImage と同じガードで ed の生存を確認し、ずれていれば fallbackLine
+ * （無ければ元の行）へ直接書き戻す。画像を含まない同期経路は await を挟まない。
+ */
+async function insertConverted(ed, converted, fallbackLine) {
+  if (!(converted instanceof Promise)) {
+    insertIntoEditor(ed, converted);
+    return;
+  }
+  const lineAtPaste = activeStart;
+  const markdown = await converted;
+  if (ed?.isConnected && activeStart === lineAtPaste) {
+    insertIntoEditor(ed, markdown);
+    return;
+  }
+  const lines = getLines();
+  const target = Math.min(Math.max(fallbackLine ?? lineAtPaste ?? lines.length - 1, 0), lines.length - 1);
+  lines[target] += markdown;
+  rawContent = lines.join('\n');
+  renderAll();
+  await saveNow();
+}
+
 async function onEditorPaste(e) {
   e.preventDefault();
   const ed = e.currentTarget;
@@ -571,7 +717,7 @@ async function onEditorPaste(e) {
     }
   }
 
-  insertIntoEditor(ed, toMarkdown(text, e.clipboardData.getData('text/html')));
+  await insertConverted(ed, toMarkdown(text, e.clipboardData.getData('text/html')));
 }
 
 /** 画像 File を順番どおりに挿入する。挿入のたびに行番号がずれるため並列にはできない。 */
@@ -599,7 +745,7 @@ async function onEditorDrop(e) {
   const text = e.dataTransfer.getData('text/plain');
   if (!text) return;
   // drop 位置ではなく現在のキャレット位置へ入れる
-  insertIntoEditor(ed, toMarkdown(text, e.dataTransfer.getData('text/html')));
+  await insertConverted(ed, toMarkdown(text, e.dataTransfer.getData('text/html')));
 }
 
 /** ドロップ先の要素から挿入対象の行番号を求める。フェンスは行単位のマッピングを持たないので末尾に置く。 */

--- a/tests/visual/html-to-markdown.spec.ts
+++ b/tests/visual/html-to-markdown.spec.ts
@@ -174,4 +174,97 @@ test.describe("htmlToMarkdown", () => {
     expect(await convert(notePage, "<blockquote><p>line1</p><p>line2</p></blockquote>"))
       .toBe("> line1\n> line2\n");
   });
+
+  // ── img: data: URI → save_pasted_image 経由で画像記法 ────
+  test("data: image → save_pasted_image で保存した相対パスの画像記法", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat">'))
+      .toBe("![cat](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
+  test("data: image (URL エンコード形式) → alt テキストのみ", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="data:image/png,%89PNG" alt="cat">'))
+      .toBe("cat");
+  });
+
+  test("data: image に charset パラメータが付いていても base64 部分をデコードする", async ({ notePage }) => {
+    expect(await convert(
+      notePage,
+      '<img src="data:image/png;charset=utf-8;base64,iVBORw0KGgo=" alt="cat">',
+    )).toBe("![cat](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
+  test("BASE64,（大文字）も base64 部分をデコードする", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="data:image/png;BASE64,iVBORw0KGgo=" alt="cat">'))
+      .toBe("![cat](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
+  test("DATA:（大文字接頭辞）も data: URI として扱う", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="DATA:image/png;base64,iVBORw0KGgo=" alt="cat">'))
+      .toBe("![cat](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
+  // ── img: https:// URL → 通常リンク（画像記法にしない） ───
+  test("https image → 通常リンク", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="https://example.com/cat.png" alt="cat">'))
+      .toBe("[cat](https://example.com/cat.png)");
+  });
+
+  test("http image → 通常リンク", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="http://example.com/cat.png" alt="cat">'))
+      .toBe("[cat](http://example.com/cat.png)");
+  });
+
+  test("alt が空の https image → URL 自体をリンクテキストにする", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="https://example.com/cat.png">'))
+      .toBe("[https://example.com/cat.png](https://example.com/cat.png)");
+  });
+
+  // ── img: blob: / file: など → alt テキストのみ残す ───────
+  test("blob: image → alt テキストのみ", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="blob:https://example.com/xyz" alt="cat">'))
+      .toBe("cat");
+  });
+
+  test("blob: image で alt も無ければ何も残さない", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="blob:https://example.com/xyz">'))
+      .toBe("");
+  });
+
+  test("file: image → alt テキストのみ", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="file:///tmp/cat.png" alt="cat">'))
+      .toBe("cat");
+  });
+
+  // ── img: alt の無害化（] は下流が \] を解釈しないため除去する） ──
+  test("alt に ] を含む data: image → ] を除去する", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="data:image/png;base64,iVBORw0KGgo=" alt="a[b]c">'))
+      .toBe("![a[bc](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
+  test("alt に ] を含む data: image → renderMarkdown が <img> を描画する", async ({ notePage }) => {
+    const markdown = await convert(notePage, '<img src="data:image/png;base64,iVBORw0KGgo=" alt="a[b]c">');
+    const html = await notePage.evaluate(
+      (md: string) => (window as any).renderMarkdown(md),
+      markdown,
+    );
+    // `]` をエスケープではなく除去しているので alt="a[bc" として <img> が描画される
+    // （\] のまま残すと markdown.js の `[^\]]*` が途中で終端と誤認し <img> にならない）
+    expect(html).toContain("<img");
+    expect(html).toContain('alt="a[bc"');
+  });
+
+  test("alt に改行を含む https image → 空白に置換", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="https://example.com/cat.png" alt="line1\nline2">'))
+      .toBe("[line1 line2](https://example.com/cat.png)");
+  });
+
+  // ── img: 同一 data: URI の重複 ────────────────────────────
+  test("同じ data: URI が複数回出てきても1回だけ保存し同じパスを使い回す", async ({ notePage }) => {
+    const html = '<img src="data:image/png;base64,iVBORw0KGgo=" alt="a">'
+      + '<img src="data:image/png;base64,iVBORw0KGgo=" alt="b">';
+    expect(await convert(notePage, html)).toBe(
+      "![a](images/00000000-0000-4000-8000-000000000001.png)"
+      + "![b](images/00000000-0000-4000-8000-000000000001.png)",
+    );
+  });
 });

--- a/tests/visual/paste-e2e.spec.ts
+++ b/tests/visual/paste-e2e.spec.ts
@@ -191,4 +191,289 @@ test.describe("ペースト処理", () => {
 
     await ctx.close();
   });
+
+  test("リッチテキスト内の data: 画像ペースト → save_pasted_image 経由で画像記法が挿入される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "caption");
+      dt.setData(
+        "text/html",
+        '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat">caption',
+      );
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("![cat](images/00000000-0000-4000-8000-000000000001.png)caption");
+
+    await ctx.close();
+  });
+
+  test("リッチテキスト内の https 画像ペースト → リンクに変換され save_pasted_image は呼ばれない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "cat");
+      dt.setData("text/html", '<img src="https://example.com/cat.png" alt="cat">');
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    const content = await getContent(page);
+    expect(content).toBe("[cat](https://example.com/cat.png)");
+
+    const saveCalls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+    );
+    expect(saveCalls).toBe(0);
+
+    await ctx.close();
+  });
+
+  test("画像を含まないリッチテキストペースト → Markdown に変換される", async ({ openNote }) => {
+    const page = await openNote({ content: "" });
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "bold text");
+      dt.setData("text/html", "<strong>bold text</strong>");
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    const content = await getContent(page);
+    expect(content).toBe("**bold text**");
+  });
+
+  test("1回のペースト内で同じ data: URI が複数回出てきても保存は1回だけ", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    const html = '<img src="data:image/png;base64,iVBORw0KGgo=" alt="a">'
+      + '<img src="data:image/png;base64,iVBORw0KGgo=" alt="b">';
+    await page.evaluate((h) => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "ab");
+      dt.setData("text/html", h);
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    }, html);
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe(
+      "![a](images/00000000-0000-4000-8000-000000000001.png)"
+      + "![b](images/00000000-0000-4000-8000-000000000001.png)",
+    );
+
+    await ctx.close();
+  });
+
+  test("同じ data: URI を2回ペースト → ペーストのたびに保存し直す（重複排除はペースト単位）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    const dispatchPaste = () => page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "cat");
+      dt.setData("text/html", '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat">');
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await dispatchPaste();
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    await dispatchPaste();
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(2);
+
+    const content = await getContent(page);
+    expect(content).toBe(
+      "![cat](images/00000000-0000-4000-8000-000000000001.png)".repeat(2),
+    );
+
+    await ctx.close();
+  });
+
+  test("blob: 画像のみ（alt無し）+ text/plain が非空 → 変換結果が空にならず text が挿入される", async ({ openNote }) => {
+    const page = await openNote({ content: "" });
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "pasted from google docs");
+      dt.setData("text/html", '<img src="blob:https://docs.google.com/xyz">');
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    const content = await getContent(page);
+    expect(content).toBe("pasted from google docs");
+  });
+
+  test("data: 画像を含むペースト中に生表示が閉じる → fallbackLine（元の行）へ書き戻される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "line0" }, {}, { captureInvokes: true });
+    // save_pasted_image を遅延させ、resolve 前に生表示を閉じる猶予を作る
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === "save_pasted_image") {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        return prevInvoke(cmd, args);
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page, 0);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "cat");
+      dt.setData("text/html", '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat">');
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    // save_pasted_image の resolve を待たず、生表示を閉じて確定させる
+    // （relatedTarget が null になるように blur を発火し、生表示のクローズ処理を確定させる）
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      editor.dispatchEvent(new FocusEvent("blur", { relatedTarget: null }));
+    });
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await expect.poll(() => getContent(page), { timeout: 3000 }).toBe(
+      "line0![cat](images/00000000-0000-4000-8000-000000000001.png)",
+    );
+
+    await ctx.close();
+  });
+
+  test("data: 画像の保存が失敗 → alt テキストのみ挿入されトーストが出る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === "save_pasted_image") throw new Error("disk full");
+        return prevInvoke(cmd, args);
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "cat");
+      dt.setData("text/html", '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat">');
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await expect(page.locator(".toast")).toBeVisible();
+
+    const content = await getContent(page);
+    expect(content).toBe("cat");
+
+    await ctx.close();
+  });
 });


### PR DESCRIPTION
## 背景

リッチテキストペーストの Markdown 変換は HTML 内の `<img>` を捨てている（src も alt も残らない）。画像を含む範囲をコピーして貼ると、画像があった痕跡ごと消える。

## 仕様

リッチテキストペースト時、HTML 内の `<img>` を src の種類に応じて取り込む。

- `data:` URI（base64 埋め込み）: 画像ファイルとして保存し `![alt](images/...)` に変換する。同じ画像が複数回出てきても保存は 1 回
- `https?://`: `[alt](URL)` の通常リンクとして残す（CSP が外部画像の読み込みを許可していないため、画像記法にすると壊れ画像になる）。Web ページの inline 画像の取り込みは対象外
- それ以外（blob: 等）: alt テキストのみ残す。変換結果が空になる場合はプレーンテキストへフォールバックする
- サイズ上限（10MB）超過や保存失敗はトーストで知らせる（複数失敗しても 1 回）

## やったこと

- FE のみ（Rust 無改修）: HTML 変換に img の分岐を追加。data: 画像の保存を先に済ませて src → 相対パスの対応表を作り、変換関数自体は同期・純粋に保つ。alt / URL は記法を壊す文字（`]`・改行）を無害化
- 画像を含まない HTML やテキストのペーストは同期のまま。await が挟まる data: 画像ありの経路だけ、クリップボード画像ペーストと同じ生存ガード（編集中の行が変わっていたら元の行へ書き戻す）を通す
- テスト: 変換の UT 14 ケース、ペーストの E2E 7 ケースを追加（https リンク化・重複排除・空変換フォールバック・保存失敗・await 中の行移動）

## 確認したこと

- cargo test 128 件 / clippy / fmt、eslint、Playwright 228 件（VRT ベースライン差分なし）
- 実機で data: 画像入り HTML のペースト（画像＋太字・リンク・箇条書きが変換される）を確認

## 関連リンク

- issue: #63
- 先行 PR: #65

- 後続 PR: #71
