### PR TITLE
✨ 画像を貼れるようにする｜4｜付箋上の画像を開く・Finder で表示・コピーできるようにする

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -65,6 +65,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +531,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +661,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1064,6 +1111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1141,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1400,6 +1459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1514,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1596,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,7 +1710,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 name = "hattotto"
 version = "0.4.0"
 dependencies = [
+ "arboard",
  "dirs 6.0.0",
+ "image",
  "log",
  "rand 0.10.2",
  "serde",
@@ -1631,6 +1723,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tempfile",
@@ -1918,6 +2011,35 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2328,6 +2450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2582,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -3113,6 +3246,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4262,6 +4407,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,6 +4638,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5203,6 +5384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,6 +5989,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5973,6 +6177,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-log = "2"
+tauri-plugin-opener = "2"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -18,6 +19,8 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 rand = "0.10"
 sys-locale = "0.3"
+arboard = "3"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
 use crate::context_menu::build_context_menu;
 use crate::i18n::{self, Msg};
+use crate::image_actions;
 use crate::model::{
     clamp_opacity, clamp_zoom, is_valid_color_key, is_valid_default_color, resolve_color, AppState,
     LanguageSetting, Note, RecoverMutex, Settings, TRASH_MAX,
@@ -475,6 +476,7 @@ pub(crate) fn show_context_menu(
     id: String,
     is_pinned: bool,
     current_color: String,
+    image_path: Option<String>,
     app: AppHandle,
     state: State<AppState>,
 ) {
@@ -486,10 +488,31 @@ pub(crate) fn show_context_menu(
     // Store note ID so on_menu_event knows which note to target
     *state.context_menu_note_id.recover() = id;
 
+    // フロント側の data 属性は DOM 改変で偽装され得るため、ここでも形状を検証してから保留する
+    let validated_image_path = image_path.filter(|p| persistence::is_valid_image_rel_path(p));
+    *state.context_menu_image_path.recover() = validated_image_path.clone();
+
     let lang = i18n::resolve(state.settings.recover().language);
-    if let Err(e) = build_context_menu(&app, &webview_win, is_pinned, &current_color, lang) {
+    if let Err(e) = build_context_menu(
+        &app,
+        &webview_win,
+        is_pinned,
+        &current_color,
+        validated_image_path.as_deref(),
+        lang,
+    ) {
         log::error!("context menu error: {}", e);
     }
+}
+
+/// 画像を OS の既定アプリで開く。
+#[tauri::command]
+pub(crate) fn open_image(
+    image_path: String,
+    app: AppHandle,
+    state: State<AppState>,
+) -> Result<(), String> {
+    image_actions::open_image(&app, &state.data_dir, &image_path)
 }
 
 #[cfg(test)]
@@ -522,6 +545,7 @@ mod tests {
             trash: Mutex::new(trash),
             last_bring_to_front: Mutex::new(Instant::now()),
             context_menu_note_id: Mutex::new(String::new()),
+            context_menu_image_path: Mutex::new(None),
             data_dir: dir.path().to_path_buf(),
             notes_loaded: true,
             settings_loaded: true,

--- a/src-tauri/src/context_menu.rs
+++ b/src-tauri/src/context_menu.rs
@@ -4,6 +4,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::{confirm_delete_if_needed, do_delete_note};
 use crate::i18n::{self, Lang, Msg};
+use crate::image_actions;
 use crate::model::{is_valid_color_key, AppState, RecoverMutex, COLOR_DEFS};
 use crate::persistence::save_notes;
 use crate::window::{create_note_with_window, open_settings_window, open_trash_window};
@@ -35,6 +36,7 @@ pub(crate) fn build_context_menu(
     webview_win: &tauri::WebviewWindow,
     is_pinned: bool,
     current_color: &str,
+    image_path: Option<&str>,
     lang: Lang,
 ) -> tauri::Result<()> {
     let color_items: Vec<IconMenuItem<tauri::Wry>> = COLOR_DEFS
@@ -58,6 +60,35 @@ pub(crate) fn build_context_menu(
 
     let copy = PredefinedMenuItem::copy(app, None)?;
     let paste = PredefinedMenuItem::paste(app, None)?;
+    // 画像上で開いたときだけ「画像を開く」「Finder で表示」「画像をコピー」を足す
+    let image_items = image_path
+        .map(|_| {
+            Ok::<_, tauri::Error>((
+                PredefinedMenuItem::separator(app)?,
+                MenuItem::with_id(
+                    app,
+                    "ctx_open_image",
+                    i18n::text(lang, Msg::CtxOpenImage),
+                    true,
+                    None::<&str>,
+                )?,
+                MenuItem::with_id(
+                    app,
+                    "ctx_reveal_image",
+                    i18n::text(lang, Msg::CtxRevealImage),
+                    true,
+                    None::<&str>,
+                )?,
+                MenuItem::with_id(
+                    app,
+                    "ctx_copy_image",
+                    i18n::text(lang, Msg::CtxCopyImage),
+                    true,
+                    None::<&str>,
+                )?,
+            ))
+        })
+        .transpose()?;
     let sep0 = PredefinedMenuItem::separator(app)?;
     let pin_label = if is_pinned {
         Msg::CtxUnpin
@@ -128,10 +159,15 @@ pub(crate) fn build_context_menu(
     )?;
     let sep3 = PredefinedMenuItem::separator(app)?;
 
-    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![
-        &copy,
-        &paste,
-        &sep0,
+    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&copy, &paste];
+    if let Some((sep_img, open_image, reveal_image, copy_image)) = &image_items {
+        items.push(sep_img);
+        items.push(open_image);
+        items.push(reveal_image);
+        items.push(copy_image);
+    }
+    items.extend([
+        &sep0 as &dyn tauri::menu::IsMenuItem<tauri::Wry>,
         &pin,
         &sep1,
         &new_note,
@@ -144,7 +180,7 @@ pub(crate) fn build_context_menu(
         &sep2,
         &settings,
         &sep3,
-    ];
+    ]);
     for ci in &color_items {
         items.push(ci as &dyn tauri::menu::IsMenuItem<tauri::Wry>);
     }
@@ -201,6 +237,27 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
         "ctx_zoom_reset" => {
             if let Some(w) = &win {
                 let _ = w.emit_to(w.label(), "ctx-zoom", "reset");
+            }
+        }
+        "ctx_open_image" => {
+            if let Some(path) = state.context_menu_image_path.recover().clone() {
+                if let Err(e) = image_actions::open_image(app, &state.data_dir, &path) {
+                    log::error!("open image error: {}", e);
+                }
+            }
+        }
+        "ctx_reveal_image" => {
+            if let Some(path) = state.context_menu_image_path.recover().clone() {
+                if let Err(e) = image_actions::reveal_image_in_finder(app, &state.data_dir, &path) {
+                    log::error!("reveal image error: {}", e);
+                }
+            }
+        }
+        "ctx_copy_image" => {
+            if let Some(path) = state.context_menu_image_path.recover().clone() {
+                if let Err(e) = image_actions::copy_image_to_clipboard(&state.data_dir, &path) {
+                    log::error!("copy image error: {}", e);
+                }
             }
         }
         _ if event_id.starts_with("ctx_color_") => {

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -56,6 +56,9 @@ pub(crate) enum Msg {
     CtxOpenTrash,
     CtxZoomReset,
     CtxOpenSettings,
+    CtxOpenImage,
+    CtxRevealImage,
+    CtxCopyImage,
 
     ColorYellow,
     ColorBlue,
@@ -103,6 +106,9 @@ pub(crate) fn text(lang: Lang, msg: Msg) -> &'static str {
         Msg::CtxOpenTrash => ("ゴミ箱を開く", "Open Trash"),
         Msg::CtxZoomReset => ("ズームリセット", "Reset Zoom"),
         Msg::CtxOpenSettings => ("設定を開く", "Open Settings"),
+        Msg::CtxOpenImage => ("画像を開く", "Open Image"),
+        Msg::CtxRevealImage => ("Finder で表示", "Show in Finder"),
+        Msg::CtxCopyImage => ("画像をコピー", "Copy Image"),
 
         Msg::ColorYellow => ("イエロー", "Yellow"),
         Msg::ColorBlue => ("ブルー", "Blue"),

--- a/src-tauri/src/image_actions.rs
+++ b/src-tauri/src/image_actions.rs
@@ -1,0 +1,165 @@
+//! 付箋内の画像に対する「開く」「Finder で表示」「コピー」の実処理。
+//! パスの検証・実在確認は `persistence::resolve_existing_image_path` に委ねる。
+
+use std::io::Cursor;
+use std::path::Path;
+
+use image::{ImageReader, Limits};
+use tauri::AppHandle;
+use tauri_plugin_opener::OpenerExt;
+
+use crate::persistence::resolve_existing_image_path;
+
+/// デコード時の上限。貼り付け画像は `MAX_IMAGE_BYTES`（10MB）止まりだが、伸張後の
+/// メモリ確保と画素数はバイト数と別に制限しないと、小さいファイルでも巨大な
+/// ビットマップに展開される画像爆弾（decompression bomb）を防げない
+const MAX_DECODE_ALLOC_BYTES: u64 = 128 * 1024 * 1024;
+const MAX_IMAGE_DIMENSION: u32 = 20_000;
+
+/// 画像を OS の既定アプリで開く。
+pub(crate) fn open_image(app: &AppHandle, data_dir: &Path, rel_path: &str) -> Result<(), String> {
+    let full = resolve_existing_image_path(data_dir, rel_path)?;
+    app.opener()
+        .open_path(full.to_string_lossy(), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+/// 画像を Finder で選択状態で表示する。
+pub(crate) fn reveal_image_in_finder(
+    app: &AppHandle,
+    data_dir: &Path,
+    rel_path: &str,
+) -> Result<(), String> {
+    let full = resolve_existing_image_path(data_dir, rel_path)?;
+    app.opener()
+        .reveal_item_in_dir(full)
+        .map_err(|e| e.to_string())
+}
+
+/// 画像ファイルのバイト列を RGBA8 にデコードする。`copy_image_to_clipboard` と
+/// テストから共有するために切り出している（クリップボード書き込み自体はテストできないため）。
+pub(crate) fn decode_image_rgba(bytes: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
+    let mut reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|e| e.to_string())?;
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_DECODE_ALLOC_BYTES);
+    reader.limits(limits);
+    let img = reader.decode().map_err(|e| e.to_string())?;
+    let rgba = img.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    Ok((width, height, rgba.into_raw()))
+}
+
+/// 画像をクリップボードに RGBA 画像として書き込む。
+///
+/// `tauri-plugin-clipboard-manager` ではなく `arboard` を直接使う。
+/// 公式プラグインは macOS で NSPasteboard をメインスレッド外から操作してクラッシュする
+/// 報告（tauri-apps/plugins-workspace#3205）があり、メニューイベントハンドラ
+/// （メインスレッドで同期的に走る）から直接呼べる arboard の方が安全なため。
+pub(crate) fn copy_image_to_clipboard(data_dir: &Path, rel_path: &str) -> Result<(), String> {
+    let full = resolve_existing_image_path(data_dir, rel_path)?;
+    let bytes = std::fs::read(&full).map_err(|e| e.to_string())?;
+    let (width, height, rgba) = decode_image_rgba(&bytes)?;
+    let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
+    clipboard
+        .set_image(arboard::ImageData {
+            width: width as usize,
+            height: height as usize,
+            bytes: rgba.into(),
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// テスト用の 1x1 PNG バイト列。`image` クレート自身でエンコードして作る
+    /// （手書きのマジックバイトだけでは `load_from_memory` を通せないため）。
+    fn tiny_png_bytes() -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(1, 1, image::Rgba([10, 20, 30, 255]));
+        let mut bytes = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(
+                &mut std::io::Cursor::new(&mut bytes),
+                image::ImageFormat::Png,
+            )
+            .unwrap();
+        bytes
+    }
+
+    // ── decode_image_rgba ────────────────────────────────────
+
+    #[test]
+    fn decode_image_rgba_decodes_valid_png() {
+        let (width, height, rgba) = decode_image_rgba(&tiny_png_bytes()).unwrap();
+        assert_eq!((width, height), (1, 1));
+        assert_eq!(rgba, vec![10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn decode_image_rgba_rejects_unsupported_data() {
+        assert!(decode_image_rgba(b"not an image").is_err());
+    }
+
+    // ── copy_image_to_clipboard: パス検証部分 ──────────────────
+    // クリップボードへの実書き込みは CI 環境で検証できないため、その手前の
+    // resolve_existing_image_path 呼び出しがエラーになる経路だけを確認する。
+
+    #[test]
+    fn copy_image_to_clipboard_rejects_invalid_path() {
+        let dir = TempDir::new().unwrap();
+        let result = copy_image_to_clipboard(dir.path(), "images/../notes.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn copy_image_to_clipboard_rejects_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let result = copy_image_to_clipboard(
+            dir.path(),
+            "images/00000000-0000-4000-8000-000000000001.png",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn open_image_rejects_invalid_path() {
+        // AppHandle が要る経路には到達しない（resolve が先に失敗する）ため、
+        // ここでは resolve_existing_image_path 単体で検証する
+        let dir = TempDir::new().unwrap();
+        assert!(resolve_existing_image_path(dir.path(), "images/../notes.json").is_err());
+    }
+
+    #[test]
+    fn resolve_existing_image_path_accepts_existing_valid_file() {
+        let dir = TempDir::new().unwrap();
+        let images = dir.path().join("images");
+        fs::create_dir_all(&images).unwrap();
+        let rel = "images/00000000-0000-4000-8000-000000000001.png";
+        fs::write(dir.path().join(rel), tiny_png_bytes()).unwrap();
+
+        let resolved = resolve_existing_image_path(dir.path(), rel).unwrap();
+        assert_eq!(resolved, dir.path().join(rel));
+    }
+
+    /// `images/` 配下に置かれたシンボリックリンクは、リンク先が実ファイルでも拒否する。
+    /// data_dir の外を指すリンク経由でファイルを開いたりコピーしたりできないようにする防御。
+    #[test]
+    fn resolve_existing_image_path_rejects_symlink() {
+        let dir = TempDir::new().unwrap();
+        let images = dir.path().join("images");
+        fs::create_dir_all(&images).unwrap();
+        let target = dir.path().join("outside.png");
+        fs::write(&target, tiny_png_bytes()).unwrap();
+        let rel = "images/00000000-0000-4000-8000-000000000001.png";
+        std::os::unix::fs::symlink(&target, dir.path().join(rel)).unwrap();
+
+        assert!(resolve_existing_image_path(dir.path(), rel).is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod context_menu;
 mod i18n;
+mod image_actions;
 mod menu;
 pub mod model;
 mod persistence;
@@ -45,6 +46,7 @@ pub fn run() {
         trash: Mutex::new(trash),
         last_bring_to_front: Mutex::new(Instant::now() - std::time::Duration::from_secs(10)),
         context_menu_note_id: Mutex::new(String::new()),
+        context_menu_image_path: Mutex::new(None),
         data_dir,
         notes_loaded,
         settings_loaded,
@@ -67,6 +69,7 @@ pub fn run() {
         ))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
         // ログは補助機能なので、初期化に失敗しても起動は止めない。
         // `tauri_plugin_log::Builder::build()` は内部で失敗を setup の Err として
         // 伝播させ、`app.build().expect(...)` の panic につながる。`split()` +
@@ -121,6 +124,7 @@ pub fn run() {
             commands::open_trash,
             commands::show_context_menu,
             commands::save_pasted_image,
+            commands::open_image,
         ])
         .setup(|app| {
             // Set up app menu and system tray

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -217,6 +217,9 @@ pub struct AppState {
     pub(crate) last_bring_to_front: Mutex<Instant>,
     /// Note ID that last opened the context menu (for routing menu events)
     pub(crate) context_menu_note_id: Mutex<String>,
+    /// 直近にメニューを開いた画像の相対パス（`images/...`）。画像上以外で開いた場合は `None`。
+    /// `context_menu_note_id` と同じパターンで、メニューイベント側から参照する
+    pub(crate) context_menu_image_path: Mutex<Option<String>>,
     /// notes.json / settings.json / trash.json を置くディレクトリ。テストでは `TempDir` を指す
     pub(crate) data_dir: PathBuf,
     /// 対応するファイルを起動時に読み込めたか。`false` は「ファイルはあるが読めなかった」を

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -242,6 +242,26 @@ pub(crate) fn is_valid_image_rel_path(path: &str) -> bool {
         && IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
 }
 
+/// 相対パスを検証したうえで `data_dir` と結合し、実在確認まで済ませた絶対パスを返す。
+/// 「画像を開く」「Finder で表示」「画像をコピー」の 3 コマンド共通の関所で、
+/// `is_valid_image_rel_path` の形状チェックに加えてファイルの実在も確認する。
+pub(crate) fn resolve_existing_image_path(dir: &Path, rel_path: &str) -> Result<PathBuf, String> {
+    if !is_valid_image_rel_path(rel_path) {
+        return Err(format!("invalid image path: {}", rel_path));
+    }
+    let full = dir.join(rel_path);
+    // シンボリックリンクは追わない。`images/` 配下に細工したリンクを置かれても、
+    // リンク先が data_dir の外を指す実ファイルを開いたりコピーしたりできないようにする
+    let is_regular_file = full
+        .symlink_metadata()
+        .map(|m| m.is_file())
+        .unwrap_or(false);
+    if !is_regular_file {
+        return Err(format!("image not found: {}", full.display()));
+    }
+    Ok(full)
+}
+
 /// クリップボード画像を `images/<uuid v4>.<ext>` として保存し、相対パスを返す。
 /// 拡張子はマジックバイトから判定する（クライアントの MIME 型は信用しない）。
 pub(crate) fn save_pasted_image(dir: &Path, bytes: &[u8]) -> Result<String, String> {
@@ -365,6 +385,7 @@ mod tests {
             trash: Mutex::new(Vec::new()),
             last_bring_to_front: Mutex::new(Instant::now()),
             context_menu_note_id: Mutex::new(String::new()),
+            context_menu_image_path: Mutex::new(None),
             data_dir: data_dir.to_path_buf(),
             notes_loaded,
             settings_loaded,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -111,6 +111,8 @@ const I18N_TABLE = {
   toastCreateFailed: { ja: '付箋の作成に失敗しました', en: 'Failed to create note' },
   toastDeleteFailed: { ja: '付箋の削除に失敗しました', en: 'Failed to delete note' },
   toastImageDropUnsupported: { ja: '画像として扱えないファイルです', en: 'This file cannot be added as an image' },
+  toastOpenImageFailed: { ja: '画像を開けませんでした', en: 'Failed to open the image' },
+  imageOpenHint: { ja: 'ダブルクリックで開く', en: 'Double-click to open' },
 };
 
 // 訳の付け忘れ検出（キーを増やしたときに片方の言語が抜けていたら気づけるように）

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -30,11 +30,15 @@ function inlineMarkdown(escaped) {
   // ~~strikethrough~~ → <del>
   escaped = escaped.replace(/~~([^~]+)~~/g, '<del>$1</del>');
   // ![alt](src) → <img> (before the link regex; `!` prefix distinguishes it from a link)
+  // data-rel-src は resolve 前の相対パス。ダブルクリック・右クリックのハンドラは
+  // asset URL 化された src ではなくこちらから元の相対パスを取り出す
   escaped = escaped.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, alt, src) => {
     const resolved = (typeof window !== 'undefined' && typeof window.resolveImageSrc === 'function')
       ? window.resolveImageSrc(src)
       : src;
-    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}">`;
+    // title はダブルクリックで開けることを伝えるアフォーダンス（クリックしても反応が無いため）
+    const hint = (typeof window !== 'undefined' && window.I18N) ? window.I18N.t('imageOpenHint') : 'ダブルクリックで開く';
+    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}" data-rel-src="${escapeAttr(src)}" title="${escapeAttr(hint)}">`;
   });
   // [text](url) → <a>
   escaped = escaped.replace(

--- a/src/note.html
+++ b/src/note.html
@@ -198,6 +198,13 @@
   .md-placeholder { color: var(--text-muted); }
   .md-line, .md-empty { min-height: 21px; word-break: break-word; }
   #markdown-view img { max-width: 100%; }
+  /* クリックでは編集に入らない（ダブルクリックで開く）ため、操作できることをホバーで示す */
+  #markdown-view img:hover {
+    outline: 2px solid var(--bar);
+    outline-offset: -2px;
+    cursor: pointer;
+    filter: brightness(0.94);
+  }
   .md-h1 { font-size: 17px; font-weight: 700; line-height: 1.4; margin: 4px 0 2px; }
   .md-h2 { font-size: 15px; font-weight: 600; line-height: 1.4; margin: 3px 0 1px; }
   .md-h3 { font-size: 14px; font-weight: 600; line-height: 1.4; margin: 2px 0 1px; }

--- a/src/note.js
+++ b/src/note.js
@@ -288,7 +288,7 @@ function rawColFromPoint(el, line, e) {
 // mouseup で拾う（mousedown を潰すとドラッグでの範囲選択ができなくなるため）
 mdView.addEventListener('mouseup', (e) => {
   if (e.target.closest('.raw-editor')) return;
-  if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]')) return;
+  if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]') || e.target.closest('img')) return;
   // 範囲選択したときは生表示に入らない（コピーの邪魔をしない）
   if (!window.getSelection().isCollapsed) return;
 
@@ -309,6 +309,18 @@ mdView.addEventListener('click', (e) => {
   if (!link) return;
   e.preventDefault();
   window.__TAURI__.shell.open(link.dataset.url);
+});
+
+// 画像ダブルクリック → OS の既定アプリで開く
+mdView.addEventListener('dblclick', (e) => {
+  const img = e.target.closest('img[data-rel-src]');
+  if (!img) return;
+  // リンクの中の画像（[![alt](img)](url)）はリンク側のクリック処理に一本化する。
+  // ここで開くと open_image とブラウザでのリンク遷移が同時に走ってしまう
+  if (img.closest('a[data-url]')) return;
+  const relSrc = img.dataset.relSrc;
+  if (!isValidImageRelPath(relSrc)) return;
+  fireInvoke('open_image', { imagePath: relSrc }, I18N.t('toastOpenImageFailed'));
 });
 
 // Checkbox toggle
@@ -1059,10 +1071,14 @@ document.addEventListener('contextmenu', async (e) => {
   e.preventDefault();
   // メニューから削除が選ばれてもよいように、開く前に保存を済ませておく
   await flushContent();
+  const img = e.target.closest('img[data-rel-src]');
+  const relSrc = img?.dataset.relSrc;
+  const imagePath = relSrc && isValidImageRelPath(relSrc) ? relSrc : undefined;
   invoke('show_context_menu', {
     id: noteId,
     isPinned: pinBtn.classList.contains('active'),
     currentColor: currentColor,
+    imagePath,
   }).catch(e => console.error('context menu failed:', e));
 });
 

--- a/tests/unit/render-markdown.test.js
+++ b/tests/unit/render-markdown.test.js
@@ -219,17 +219,17 @@ describe("renderMarkdown — edge cases", () => {
 describe("renderMarkdown — image syntax", () => {
   test("image without alt", () => {
     const html = renderMarkdown("![](images/a.png)");
-    assert.match(html, /<img alt="" src="images\/a\.png">/);
+    assert.match(html, /<img alt="" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
   });
 
   test("image with alt", () => {
     const html = renderMarkdown("![説明](images/a.png)");
-    assert.match(html, /<img alt="説明" src="images\/a\.png">/);
+    assert.match(html, /<img alt="説明" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
   });
 
   test("image mixed with link on the same line", () => {
     const html = renderMarkdown("![](images/a.png) [text](https://example.com)");
-    assert.match(html, /<img alt="" src="images\/a\.png">/);
+    assert.match(html, /<img alt="" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
     assert.match(html, /<a href="https:\/\/example\.com"/);
   });
 
@@ -242,7 +242,8 @@ describe("renderMarkdown — image syntax", () => {
     global.window = { resolveImageSrc: (src) => `asset://localhost/${src}` };
     try {
       const html = renderMarkdown("![](images/a.png)");
-      assert.match(html, /<img alt="" src="asset:\/\/localhost\/images\/a\.png">/);
+      // src は resolve 後の asset URL、data-rel-src は resolve 前の相対パスのまま
+      assert.match(html, /<img alt="" src="asset:\/\/localhost\/images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
     } finally {
       delete global.window;
     }
@@ -252,7 +253,7 @@ describe("renderMarkdown — image syntax", () => {
     const html = renderMarkdown("[![alt](images/a.png)](https://example.com)");
     assert.match(
       html,
-      /<a href="https:\/\/example\.com" data-url="https:\/\/example\.com"><img alt="alt" src="images\/a\.png"><\/a>/
+      /<a href="https:\/\/example\.com" data-url="https:\/\/example\.com"><img alt="alt" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く"><\/a>/
     );
   });
 
@@ -261,7 +262,7 @@ describe("renderMarkdown — image syntax", () => {
     // The payload text survives as inert data, but the `"` that would break out of the
     // attribute is escaped — no unescaped `"` appears right before `onerror=`.
     assert.doesNotMatch(html, /alt="[^"]*"[^>]*onerror=/);
-    assert.match(html, /<img alt="&quot; onerror=alert\(1\) x=&quot;" src="images\/a\.png">/);
+    assert.match(html, /<img alt="&quot; onerror=alert\(1\) x=&quot;" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
   });
 
   test("image src attribute injection attempt is neutralized", () => {

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -50,6 +50,8 @@ export async function injectNoteMock(
         case "delete_note":           return null;
         case "create_note":           return null;
         case "save_pasted_image":     return "images/00000000-0000-4000-8000-000000000001.png";
+        case "show_context_menu":     return null;
+        case "open_image":            return null;
         default:                      return null;
       }
     };

--- a/tests/visual/image-open-e2e.spec.ts
+++ b/tests/visual/image-open-e2e.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, injectNoteMock, enterEdit } from "./fixtures";
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+const CONTENT = `![](${IMAGE_PATH})`;
+
+// asset:// URL はテスト環境では実在しないため <img> は読み込みに失敗し、
+// alt="" の壊れた画像は Chromium 上でレイアウトサイズ 0 になる。
+// Playwright のマウス操作は座標依存で 0 サイズの要素を扱えないため、
+// note.js のリスナーが拾うイベントを img 要素へ直接 dispatch する。
+function dispatchOnImage(type: string, options: MouseEventInit = {}) {
+  const img = document.querySelector("img")!;
+  img.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, ...options }));
+}
+
+test.describe("画像のダブルクリック・右クリックメニュー", () => {
+  test("画像のシングルクリック → 生表示に入らない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: CONTENT }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dispatchOnImage, "mouseup");
+
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("画像のダブルクリック → open_image が正しい相対パスで呼ばれる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: CONTENT }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dispatchOnImage, "dblclick");
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image").length,
+      ),
+    ).toBe(1);
+
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image"),
+    );
+    expect(calls[0].args).toEqual({ imagePath: IMAGE_PATH });
+
+    await ctx.close();
+  });
+
+  test("画像上での右クリック → show_context_menu に imagePath が渡る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: CONTENT }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dispatchOnImage, "contextmenu");
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu").length,
+      ),
+    ).toBe(1);
+
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu"),
+    );
+    expect(calls[0].args.imagePath).toBe(IMAGE_PATH);
+
+    await ctx.close();
+  });
+
+  test("画像以外での右クリック → show_context_menu に imagePath が渡らない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "plain text" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator("#markdown-view").click({ button: "right" });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu").length,
+      ),
+    ).toBe(1);
+
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu"),
+    );
+    expect(calls[0].args.imagePath).toBeUndefined();
+
+    await ctx.close();
+  });
+
+  test("画像行を含む付箋の余白クリック → 画像以外の行が生表示になる（画像行が編集不能になる退行の固定）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${CONTENT}\nテキスト行` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 余白クリック（enterEdit の line 省略）は最終行の生表示に入る
+    await enterEdit(page);
+
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("テキスト行");
+
+    await ctx.close();
+  });
+
+  test("img の data-rel-src を DOM 改変してからダブルクリック → open_image は invoke されない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: CONTENT }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dataset.relSrc = "images/../notes.json";
+    });
+    await page.evaluate(dispatchOnImage, "dblclick");
+
+    // invoke されないことを確定させるため、明示的に待ってから0件であることを確認する
+    await page.waitForTimeout(100);
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image"),
+    );
+    expect(calls.length).toBe(0);
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## 背景

付箋上の画像は表示するだけで、原寸で見る・ファイルとして取り出すといった操作ができない。

## 仕様

- 画像のダブルクリックで既定アプリ（プレビュー等）で開く。シングルクリックでは編集に入らず、ホバーの枠とポインタカーソル、title の「ダブルクリックで開く」で操作できることを示す
- 画像の上の右クリックメニューに「画像を開く」「Finder で表示」「画像をコピー」の 3 項目が加わる（画像以外の場所では出ない）
- 開けない・コピーできない場合（ファイル欠損等）はダブルクリック経由ではトーストで知らせる

## やったこと

- BE: tauri-plugin-opener（開く / Finder 表示）と arboard + image クレート（クリップボードへの RGBA 書き込み。デコードは PNG/JPEG/GIF/WebP のみ・上限つき）を追加。実ファイルに触る前に相対パスの形状検証 + 実在確認（シンボリックリンクは拒否）を通す関所を全経路に置く
- 右クリックメニュー: メニュー構築時に画像の相対パスを state に保留し、画像の上のときだけ 3 項目を出す（note id と同じパターン）。文言は日英
- FE: 描画した img に resolve 前の相対パスを data 属性で持たせ、ダブルクリック時は JS 側でも形状検証してから invoke（最終防衛線は Rust 側）。生表示切替のクリック除外に img を追加し、リンク内画像はリンク側の挙動を優先
- テスト: パス検証・シンボリックリンク拒否・デコードの Rust ユニットテスト、ダブルクリック / 右クリック / data 属性偽装 / 画像行の編集手段の E2E 6 ケース

## 確認したこと

- cargo test 135 件 / clippy / fmt、eslint、Playwright 234 件（VRT ベースライン差分なし）
- 実機でダブルクリックで開く・Finder で表示・他アプリへの画像ペースト・メニューの出し分け・ホバー表示を確認

## 関連リンク

- issue: #63
- 先行 PR: #66

- 後続 PR: #72
