### PR TITLE
✨ 画像を貼れるようにする｜5｜付箋上の画像をドラッグでリサイズできるようにする

### DIFF
--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -525,6 +525,14 @@ mod tests {
     }
 
     #[test]
+    fn extract_image_paths_finds_reference_with_width_syntax() {
+        // `![alt|300](...)` — alt 内の `|` はスキャンに影響しない（alt は最初の `]` までを丸ごと読むだけ）
+        let path = uuid_image_path(1);
+        let content = format!("![alt|300]({})", path);
+        assert_eq!(extract_image_paths(&content), vec![path]);
+    }
+
+    #[test]
     fn extract_image_paths_ignores_non_image_links() {
         let content = "[link](https://example.com) and ![alt](https://example.com/pic.png)";
         assert!(extract_image_paths(content).is_empty());

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -16,6 +16,22 @@ function escapeAttr(s) {
   return s.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+// Obsidian 方式の表示幅指定（`![alt|300](...)`）の下限・上限。範囲外・0 は指定なし扱いにする。
+const IMAGE_WIDTH_MIN = 40;
+const IMAGE_WIDTH_MAX = 2000;
+
+/**
+ * alt 末尾の `|数字` を表示幅として分離する。末尾セグメントが数字のみのときだけ幅指定とみなし、
+ * `![a|b]` のような非数値サフィックスは alt をそのまま返す（幅なし）。
+ */
+function parseImageAlt(altRaw) {
+  const m = altRaw.match(/^(.*)\|(\d+)$/);
+  if (!m) return { alt: altRaw, width: null };
+  const n = parseInt(m[2], 10);
+  const width = (n >= IMAGE_WIDTH_MIN && n <= IMAGE_WIDTH_MAX) ? n : null;
+  return { alt: m[1], width };
+}
+
 function inlineMarkdown(escaped) {
   // `code` → placeholder (protect from bold/italic/strikethrough)
   const codeBlocks = [];
@@ -32,13 +48,15 @@ function inlineMarkdown(escaped) {
   // ![alt](src) → <img> (before the link regex; `!` prefix distinguishes it from a link)
   // data-rel-src は resolve 前の相対パス。ダブルクリック・右クリックのハンドラは
   // asset URL 化された src ではなくこちらから元の相対パスを取り出す
-  escaped = escaped.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, alt, src) => {
+  escaped = escaped.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, altRaw, src) => {
     const resolved = (typeof window !== 'undefined' && typeof window.resolveImageSrc === 'function')
       ? window.resolveImageSrc(src)
       : src;
     // title はダブルクリックで開けることを伝えるアフォーダンス（クリックしても反応が無いため）
     const hint = (typeof window !== 'undefined' && window.I18N) ? window.I18N.t('imageOpenHint') : 'ダブルクリックで開く';
-    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}" data-rel-src="${escapeAttr(src)}" title="${escapeAttr(hint)}">`;
+    const { alt, width } = parseImageAlt(altRaw);
+    const widthAttr = width != null ? ` width="${width}"` : '';
+    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}" data-rel-src="${escapeAttr(src)}" title="${escapeAttr(hint)}"${widthAttr}>`;
   });
   // [text](url) → <a>
   escaped = escaped.replace(

--- a/src/note.html
+++ b/src/note.html
@@ -205,6 +205,21 @@
     cursor: pointer;
     filter: brightness(0.94);
   }
+  /* 画像ホバー時に右下へ出すリサイズハンドル。共有 1 要素を画像ごとに位置だけ動かして使い回す。
+     mdView.innerHTML の再描画（renderAll）で消されないよう、mdView の外（body 直下）に置く。
+     position: fixed でビューポート座標に直接置くので、mdView のスクロール位置の影響を受けない */
+  .img-resize-handle {
+    position: fixed;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--bar);
+    border: 1px solid rgba(0,0,0,0.3);
+    cursor: nwse-resize;
+    z-index: 1;
+    display: none;
+  }
+  .img-resize-handle.visible { display: block; }
   .md-h1 { font-size: 17px; font-weight: 700; line-height: 1.4; margin: 4px 0 2px; }
   .md-h2 { font-size: 15px; font-weight: 600; line-height: 1.4; margin: 3px 0 1px; }
   .md-h3 { font-size: 14px; font-weight: 600; line-height: 1.4; margin: 2px 0 1px; }

--- a/src/note.js
+++ b/src/note.js
@@ -155,6 +155,9 @@ const activeEditor = () => mdView.querySelector('.raw-editor');
 const editorText = (ed) => ed.textContent.replace(/\u00A0/g, ' ');
 
 function renderAll() {
+  // 描画済み DOM を丸ごと差し替えるため、直前まで指していた画像の参照ごとハンドルを消す
+  // （放置すると detached な img へ書き込む・別画像の上にハンドルが残る事故になる）
+  hideHandle();
   mdView.innerHTML = renderMarkdown(rawContent);
 }
 
@@ -287,6 +290,8 @@ function rawColFromPoint(el, line, e) {
 
 // mouseup で拾う（mousedown を潰すとドラッグでの範囲選択ができなくなるため）
 mdView.addEventListener('mouseup', (e) => {
+  // 画像リサイズのドラッグ確定はここでは扱わない（別のリスナーが担当。生表示に入らせない）
+  if (dragState) return;
   if (e.target.closest('.raw-editor')) return;
   if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]') || e.target.closest('img')) return;
   // 範囲選択したときは生表示に入らない（コピーの邪魔をしない）
@@ -313,6 +318,8 @@ mdView.addEventListener('click', (e) => {
 
 // 画像ダブルクリック → OS の既定アプリで開く
 mdView.addEventListener('dblclick', (e) => {
+  // 画像リサイズのドラッグ中は open_image を発火させない
+  if (dragState) return;
   const img = e.target.closest('img[data-rel-src]');
   if (!img) return;
   // リンクの中の画像（[![alt](img)](url)）はリンク側のクリック処理に一本化する。
@@ -348,6 +355,8 @@ mdView.addEventListener('change', (e) => {
 // ── Zoom ──────────────────────────────────────────
 function applyZoom(zoom) {
   document.getElementById('note').style.zoom = zoom / 100;
+  // ズーム変更でハンドルの座標系（rect と画面 px の対応）が変わるので位置合わせをやり直す
+  hideHandle();
 }
 
 let currentZoom = 100;
@@ -359,6 +368,164 @@ async function changeZoom(delta) {
   applyZoom(next);
   fireInvoke('update_note_zoom', { id: noteId, zoom: next }, I18N.t('toastSaveFailed'));
 }
+
+// ── Image Resize ──────────────────────────────────
+// markdown.js の IMAGE_WIDTH_MIN/MAX（40〜2000）と揃える。ここより広い値を保存すると
+// markdown.js が幅指定を無視し、再描画のたびに幅が消えてしまう
+const IMAGE_RESIZE_MIN = 40;
+const IMAGE_RESIZE_MAX = 2000;
+
+// 共有 1 要素を画像ごとに位置だけ動かして使い回す（img 自体は置換要素で ::after が使えない）。
+// mdView.innerHTML を丸ごと差し替える renderAll() で消えないよう mdView の外（body 直下）に置き、
+// position: fixed でビューポート座標に直接置く（mdView のスクロールの影響を受けない）。
+const resizeHandle = document.createElement('div');
+resizeHandle.className = 'img-resize-handle';
+document.body.appendChild(resizeHandle);
+
+let dragState = null; // { img, relSrc, startX, startWidth, zoomFactor, maxWidth, currentWidth }
+let hoverImg = null; // ハンドル表示中に位置合わせした画像（ドラッグ対象の特定に使う）
+
+function positionHandle(img) {
+  const rect = img.getBoundingClientRect();
+  resizeHandle.style.left = `${rect.right - 5}px`;
+  resizeHandle.style.top = `${rect.bottom - 5}px`;
+}
+
+function hideHandle() {
+  hoverImg = null;
+  resizeHandle.classList.remove('visible');
+}
+
+// mouseenter/leave は bubble しないので、mdView での委譲は mouseover を使う
+mdView.addEventListener('mouseover', (e) => {
+  if (dragState) return;
+  const img = e.target.closest('img[data-rel-src]');
+  // リモート URL 等、書き戻し先を特定できない画像にはハンドルを出さない
+  if (!img || !isValidImageRelPath(img.dataset.relSrc)) return;
+  hoverImg = img;
+  positionHandle(img);
+  resizeHandle.classList.add('visible');
+});
+
+// mdView から出た場合の隠し忘れをケアする。ハンドルは mdView の外（body 直下）にあるので、
+// 画像の右下からハンドルへ移動する経路は mdView を一度離れる（relatedTarget がハンドルならまだ隠さない）
+mdView.addEventListener('mouseleave', (e) => {
+  if (dragState || e.relatedTarget === resizeHandle) return;
+  hideHandle();
+});
+
+// ハンドルから離れた先が画像でなければ隠す（mdView の mouseover では拾えない遷移）
+resizeHandle.addEventListener('mouseleave', (e) => {
+  if (dragState) return;
+  if (e.relatedTarget?.closest?.('img[data-rel-src]')) return;
+  hideHandle();
+});
+
+// スクロールすると画像とハンドルの対応がずれるので、位置合わせをやり直す前提で一旦隠す
+mdView.addEventListener('scroll', () => hideHandle());
+
+/** 行 lineIdx の Markdown 記法のうち、relSrc と一致する occurrence 番目（0始まり）の画像記法だけ `|width` を追加・置換する。 */
+function rewriteImageWidth(line, relSrc, width, occurrence) {
+  let seen = -1;
+  return line.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (whole, alt, src) => {
+    if (src !== relSrc) return whole;
+    seen++;
+    if (seen !== occurrence) return whole;
+    const base = alt.replace(/\|\d+$/, '');
+    return `![${base}|${width}](${src})`;
+  });
+}
+
+/** 行 lineEl 内で、relSrc が一致する img のうち img が何番目か（0始まり）。 */
+function imageOccurrenceInLine(lineEl, img, relSrc) {
+  const sameSrcImages = Array.from(lineEl.querySelectorAll('img[data-rel-src]'))
+    .filter(el => el.dataset.relSrc === relSrc);
+  return Math.max(0, sameSrcImages.indexOf(img));
+}
+
+/** ドラッグ確定時の書き戻し。別行が生表示中なら先に確定してから該当行を書き換える。 */
+function applyImageWidth(img, relSrc, width) {
+  const lineEl = img.closest('[data-line]');
+  const lineIdx = lineEl ? Number(lineEl.dataset.line) : null;
+  const occurrence = lineEl ? imageOccurrenceInLine(lineEl, img, relSrc) : 0;
+  commitActive();
+  if (lineIdx == null) return;
+  const lines = getLines();
+  if (lineIdx < 0 || lineIdx >= lines.length) return;
+  const rewritten = rewriteImageWidth(lines[lineIdx], relSrc, width, occurrence);
+  if (rewritten === lines[lineIdx]) return;
+  lines[lineIdx] = rewritten;
+  rawContent = lines.join('\n');
+  renderAll();
+  saveNow();
+}
+
+/**
+ * 画像の現在の canonical 幅（ズーム影響を除いた値）。width 属性を優先しつつ、
+ * max-width: 100% で実表示が切り詰められている場合は実測幅（の canonical 換算）を使う。
+ * ここがずれるとハンドルの表示位置とドラッグ開始幅が食い違い、ドラッグ開始直後に
+ * 画像が無反応/ジャンプして見える。
+ */
+function currentImageWidth(img, zoomFactor) {
+  const attrWidth = parseInt(img.getAttribute('width'), 10);
+  const rect = img.getBoundingClientRect();
+  const renderedWidth = rect.width > 0 ? rect.width / zoomFactor : null;
+  if (Number.isFinite(attrWidth) && attrWidth > 0) {
+    return renderedWidth != null ? Math.min(attrWidth, renderedWidth) : attrWidth;
+  }
+  if (renderedWidth != null) return renderedWidth;
+  return 200; // 読み込み前・壊れた画像などで実測幅が取れない場合のフォールバック
+}
+
+function onResizeMouseMove(e) {
+  if (!dragState) return;
+  // mouseup を取りこぼした（ウィンドウ外での release 等）場合の自己回復。
+  // 残ったままだと dragState 非 null のガードでクリック・dblclick・ホバーが全部無反応になる
+  if (e.buttons === 0) {
+    onResizeMouseUp();
+    return;
+  }
+  const dx = e.clientX - dragState.startX;
+  const raw = dragState.startWidth + dx / dragState.zoomFactor;
+  dragState.currentWidth = Math.round(Math.min(Math.max(raw, IMAGE_RESIZE_MIN), dragState.maxWidth));
+  dragState.img.style.width = `${dragState.currentWidth}px`;
+  positionHandle(dragState.img);
+}
+
+function onResizeMouseUp() {
+  const state = dragState;
+  document.removeEventListener('mousemove', onResizeMouseMove);
+  dragState = null;
+  hideHandle();
+  if (!state || state.currentWidth == null) return; // 実質的な移動が無ければ書き換えない
+  applyImageWidth(state.img, state.relSrc, state.currentWidth);
+}
+
+// ウィンドウ外へドラッグしたまま release される等で mouseup が届かないケースの保険
+window.addEventListener('blur', () => {
+  if (dragState) onResizeMouseUp();
+});
+
+resizeHandle.addEventListener('mousedown', (e) => {
+  if (!hoverImg) return;
+  const relSrc = hoverImg.dataset.relSrc;
+  if (!isValidImageRelPath(relSrc)) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const zoomFactor = currentZoom / 100;
+  dragState = {
+    img: hoverImg,
+    relSrc,
+    startX: e.clientX,
+    startWidth: currentImageWidth(hoverImg, zoomFactor),
+    zoomFactor,
+    // 付箋が極端に狭いとき clientWidth が下限を割り込むことがあるため、上限は必ず下限以上にする
+    maxWidth: Math.max(IMAGE_RESIZE_MIN, Math.min(mdView.clientWidth || IMAGE_RESIZE_MAX, IMAGE_RESIZE_MAX)),
+    currentWidth: null,
+  };
+  document.addEventListener('mousemove', onResizeMouseMove);
+  document.addEventListener('mouseup', onResizeMouseUp, { once: true });
+});
 
 // ── Markdown auto-continue on Enter ─────────────
 /** Enter で行を分割する。リスト・引用の途中なら次の行へプレフィックスを引き継ぐ。 */
@@ -465,6 +632,16 @@ const DATA_URI_TOO_LARGE = Symbol('data-uri-too-large');
  */
 function sanitizeAltText(text) {
   return text.replace(/\r\n|\r|\n/g, ' ').replace(/]/g, '');
+}
+
+/**
+ * 画像記法（`![alt](src)`）の alt にだけ適用する追加の無害化。末尾が `|数字` になると
+ * markdown.js の parseImageAlt が表示幅指定と誤解釈するため `|` を除去する。
+ * リンクテキストとして使う場合（https 画像のフォールバックなど）は幅記法と無関係なので
+ * sanitizeAltText のみを使い、`|` はそのまま残す。
+ */
+function sanitizeImageAlt(text) {
+  return sanitizeAltText(text).replace(/\|/g, '');
 }
 
 /** URL 側（href / src）に改行が入ると Markdown 記法が複数行に割れるため取り除く。 */
@@ -591,17 +768,19 @@ function nodeToMd(node, imageMap) {
     // data: は resolveDataImages が保存済みの相対パスに解決済み（未解決なら alt のみ残す）。
     // blob: / file: 等はそもそも取り込まず alt のみ残す。
     case 'img': {
-      const alt = sanitizeAltText(node.getAttribute('alt') || '');
+      const rawAlt = node.getAttribute('alt') || '';
       const src = node.getAttribute('src') || '';
       if (isDataUri(src)) {
         const relPath = imageMap.get(src);
-        return relPath ? `![${alt}](${relPath})` : alt;
+        // 画像記法として出す場合のみ `|` も除去する（幅指定との誤解釈を防ぐため）
+        return relPath ? `![${sanitizeImageAlt(rawAlt)}](${relPath})` : sanitizeAltText(rawAlt);
       }
       if (/^https?:\/\//i.test(src)) {
         const url = sanitizeUrl(src);
+        const alt = sanitizeAltText(rawAlt);
         return `[${alt || url}](${url})`;
       }
-      return alt;
+      return sanitizeAltText(rawAlt);
     }
     default:                   return inner;
   }

--- a/tests/unit/render-markdown.test.js
+++ b/tests/unit/render-markdown.test.js
@@ -278,6 +278,74 @@ describe("renderMarkdown — image syntax", () => {
   });
 });
 
+describe("renderMarkdown — image width syntax (![alt|300](src))", () => {
+  test("alt末尾が |数字 → width 属性を出し、alt から除去する", () => {
+    const html = renderMarkdown("![説明|300](images/a.png)");
+    assert.match(html, /<img alt="説明" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く" width="300">/);
+  });
+
+  test("alt が |数字 のみ（ベースなし） → alt は空、width だけ付く", () => {
+    const html = renderMarkdown("![|300](images/a.png)");
+    assert.match(html, /<img alt="" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く" width="300">/);
+  });
+
+  test("末尾セグメントが数字以外 → 幅指定とみなさず alt をそのまま残す", () => {
+    const html = renderMarkdown("![a|b](images/a.png)");
+    assert.match(html, /<img alt="a\|b" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く">/);
+    assert.doesNotMatch(html, /width=/);
+  });
+
+  test("alt に | が複数（![a|b|300]） → 末尾の |300 だけを幅として分離し alt は 'a|b'", () => {
+    const html = renderMarkdown("![a|b|300](images/a.png)");
+    assert.match(html, /<img alt="a\|b" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く" width="300">/);
+  });
+
+  test("|0 は無視される（width 属性なし）", () => {
+    const html = renderMarkdown("![説明|0](images/a.png)");
+    assert.doesNotMatch(html, /width=/);
+  });
+
+  test("下限未満（|39）は無視される", () => {
+    const html = renderMarkdown("![説明|39](images/a.png)");
+    assert.doesNotMatch(html, /width=/);
+  });
+
+  test("下限（|40）は採用される", () => {
+    const html = renderMarkdown("![説明|40](images/a.png)");
+    assert.match(html, /width="40"/);
+  });
+
+  test("上限（|2000）は採用される", () => {
+    const html = renderMarkdown("![説明|2000](images/a.png)");
+    assert.match(html, /width="2000"/);
+  });
+
+  test("上限超過（|2001）は無視される", () => {
+    const html = renderMarkdown("![説明|2001](images/a.png)");
+    assert.doesNotMatch(html, /width=/);
+  });
+
+  test("width 指定と data-rel-src・title は共存する", () => {
+    global.window = { resolveImageSrc: (src) => `asset://localhost/${src}` };
+    try {
+      const html = renderMarkdown("![説明|300](images/a.png)");
+      assert.match(
+        html,
+        /<img alt="説明" src="asset:\/\/localhost\/images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く" width="300">/
+      );
+    } finally {
+      delete global.window;
+    }
+  });
+
+  test("エスケープ対象の alt に |数字 が付いていても、幅分離後の属性エスケープは維持される", () => {
+    const html = renderMarkdown('!["x|300](images/a.png)');
+    // `"` はそのまま alt に残り（末尾は数字だが直前が \| ではなく通常文字なので幅指定として分離される）
+    // その上で属性値としてエスケープされていることを確認する
+    assert.match(html, /<img alt="&quot;x" src="images\/a\.png" data-rel-src="images\/a\.png" title="ダブルクリックで開く" width="300">/);
+  });
+});
+
 describe("renderMarkdown — NBSP (U+00A0) normalization", () => {
   test("checkbox with NBSP: - [ ] task", () => {
     const html = renderMarkdown("- [ ] task");

--- a/tests/visual/html-to-markdown.spec.ts
+++ b/tests/visual/html-to-markdown.spec.ts
@@ -219,6 +219,20 @@ test.describe("htmlToMarkdown", () => {
       .toBe("[https://example.com/cat.png](https://example.com/cat.png)");
   });
 
+  // https image は `[alt](url)` というリンク記法になり画像記法（![alt|300](...)）にはならないため、
+  // alt に | が含まれていても幅指定と誤解釈されない。除去してはいけない
+  test("alt に | を含む https image → リンクテキストの | は保持される", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="https://example.com/cat.png" alt="cat|300">'))
+      .toBe("[cat|300](https://example.com/cat.png)");
+  });
+
+  // 一方、data: image は `![alt](path)` という画像記法になるため、alt 末尾の |数字 は
+  // markdown.js の parseImageAlt に幅指定と誤解釈される。ここでは除去して意図しない幅指定を防ぐ
+  test("alt に | を含む data: image → 画像記法の | は除去される", async ({ notePage }) => {
+    expect(await convert(notePage, '<img src="data:image/png;base64,iVBORw0KGgo=" alt="cat|300">'))
+      .toBe("![cat300](images/00000000-0000-4000-8000-000000000001.png)");
+  });
+
   // ── img: blob: / file: など → alt テキストのみ残す ───────
   test("blob: image → alt テキストのみ", async ({ notePage }) => {
     expect(await convert(notePage, '<img src="blob:https://example.com/xyz" alt="cat">'))

--- a/tests/visual/image-resize-e2e.spec.ts
+++ b/tests/visual/image-resize-e2e.spec.ts
@@ -1,0 +1,366 @@
+import { test, expect, injectNoteMock, getContent } from "./fixtures";
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+
+// asset:// URL はテスト環境では解決できないため <img alt=""> は読み込みに失敗し、
+// Chromium 上でレイアウトサイズ 0 になる。
+// リサイズのドラッグ量は dx（マウス移動量）だけで決まるので、実座標に依存せず
+// mouseover → handle への mousedown → document への mousemove/mouseup を直接 dispatch する。
+// note.js の onResizeMouseMove は取りこぼした mouseup からの自己回復のため e.buttons を見る。
+// 合成 MouseEvent は buttons を明示しないと既定で 0（ボタン release 相当）になり、
+// mousemove を送った瞬間に自己回復が働いてドラッグが即終了してしまうため必ず 1 を指定する。
+function dragHandle([startX, endX]: [number, number]) {
+  const img = document.querySelector("img")!;
+  const handle = document.querySelector(".img-resize-handle")!;
+  img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, clientX: startX, clientY: 0 }));
+  handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: startX, clientY: 0, buttons: 1 }));
+  document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: endX, clientY: 0, buttons: 1 }));
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: endX, clientY: 0 }));
+}
+
+// index 番目の img（0始まり）を対象にドラッグする。同一行に同じ画像が複数あるケースの検証用。
+function dragHandleOnImage([index, startX, endX]: [number, number, number]) {
+  const img = document.querySelectorAll("img")[index];
+  const handle = document.querySelector(".img-resize-handle")!;
+  img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, clientX: startX, clientY: 0 }));
+  handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: startX, clientY: 0, buttons: 1 }));
+  document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: endX, clientY: 0, buttons: 1 }));
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: endX, clientY: 0 }));
+}
+
+test.describe("画像のリサイズハンドル", () => {
+  test("ハンドルをドラッグ → alt に |幅 が付き update_note_content が呼ばれる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // alt="" の壊れた画像は幅 0 扱い（フォールバック幅 200px）から dx=50 分だけ広がる
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+
+    expect(await getContent(page)).toBe(`![|250](${IMAGE_PATH})`);
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length,
+      ),
+    ).toBeGreaterThan(0);
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content"),
+    );
+    expect(calls.at(-1).args.content).toBe(`![|250](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("既存の幅指定をドラッグで置き換える", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    // alt は空にする。alt を非空にすると、asset:// が読み込めないテスト環境では
+    // 壊れた画像アイコン + alt テキストの実測サイズが width 属性より小さくなり、
+    // currentImageWidth の Math.min(width属性, 実測幅) が実測側で丸められてしまう
+    await injectNoteMock(page, { content: `![|100](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+
+    expect(await getContent(page)).toBe(`![|150](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("縮小方向のドラッグでも幅が更新される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![|150](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandle, [50, 10] as [number, number]);
+
+    expect(await getContent(page)).toBe(`![|110](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("ズーム 50% では画面上の dx が 2 倍換算で幅に反映される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(
+      page,
+      { content: `![|100](${IMAGE_PATH})`, zoom: 50 },
+      {},
+      { captureInvokes: true },
+    );
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // dx=50（画面上のマウス移動量）÷ (zoom 50% = 0.5) = canonical 幅では +100
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+
+    expect(await getContent(page)).toBe(`![|200](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("付箋が極端に狭くても、書き込まれる幅は下限（40）を下回らない", async ({ browser }) => {
+    // mdView.clientWidth（上限として使う値）が下限 40 を割り込む状況を再現する。
+    // 上限を下限未満のまま使うと Math.min が Math.max を上書きし、40 未満の幅を
+    // 書き込んでしまう（markdown.js 側は 40 未満を無視するため、次の描画で幅が消える）。
+    const ctx = await browser.newContext({ viewport: { width: 20, height: 200 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![|100](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+
+    const content = await getContent(page);
+    expect(content).toBe(`![|40](${IMAGE_PATH})`);
+
+    // markdown.js の下限（40）ちょうどなので、次の描画でも width 属性が残ることを確認する
+    // （39 以下だと markdown.js が無視し width 属性が消える）
+    const widthAttr = await page.evaluate(() => document.querySelector("img")!.getAttribute("width"));
+    expect(widthAttr).toBe("40");
+
+    await ctx.close();
+  });
+
+  test("画像からハンドルへ実際にポインタを移動してもドラッグが成立する（hover 経路の退行防止）", async ({ browser }) => {
+    // handle は mdView の外（body 直下）に position: fixed で置かれているため、画像から
+    // ハンドルへポインタが移動する際に mdView からは実際に out する。この遷移を
+    // mouseleave が誤って「ホバー終了」と扱うと hoverImg が消え、mousedown してもドラッグが
+    // 始まらない（dispatchEvent での直接発火では再現しない、実ポインタ移動でのみ踏む経路）。
+    //
+    // Playwright の locator.hover() は要素が実サイズ（bounding box が非ゼロ）でないと
+    // actionable と判定しないため、alt を空にできない（alt="" は asset:// 読み込み失敗時に
+    // 0 サイズになる）。alt を非空にすると逆に、
+    // 壊れた画像アイコン + alt テキストの実測幅が width 属性より小さくなりうるため、
+    // 期待値は note.js の currentImageWidth と同じ規則で実測して動的に求める
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![説明|100](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator("img").hover();
+    await page.waitForFunction(() =>
+      document.querySelector(".img-resize-handle")?.classList.contains("visible"),
+    );
+
+    const startWidth = await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      const attrWidth = parseInt(img.getAttribute("width") || "", 10);
+      const rect = img.getBoundingClientRect();
+      const renderedWidth = rect.width > 0 ? rect.width : null; // zoom 100% なので換算不要
+      if (Number.isFinite(attrWidth) && attrWidth > 0) {
+        return renderedWidth != null ? Math.min(attrWidth, renderedWidth) : attrWidth;
+      }
+      return renderedWidth ?? 200;
+    });
+
+    const box = await page.locator(".img-resize-handle").boundingBox();
+    if (!box) throw new Error("handle has no bounding box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 50, y, { steps: 5 });
+    await page.mouse.up();
+
+    expect(await getContent(page)).toBe(`![説明|${Math.round(startWidth + 50)}](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("同一行に同じ画像が2回 → 2個目をドラッグすると2個目だけ幅が付く", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    const content = `![](${IMAGE_PATH}) ![](${IMAGE_PATH})`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandleOnImage, [1, 0, 50] as [number, number, number]);
+
+    expect(await getContent(page)).toBe(`![](${IMAGE_PATH}) ![|250](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("同一行に同じ画像が2回 → 1個目をドラッグすると1個目だけ幅が付く", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    const content = `![](${IMAGE_PATH}) ![](${IMAGE_PATH})`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandleOnImage, [0, 0, 50] as [number, number, number]);
+
+    expect(await getContent(page)).toBe(`![|250](${IMAGE_PATH}) ![](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("ドラッグ確定後にもう一度 document へ mousemove しても content は変わらない（リスナー解除の確認）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+    const afterDrag = await getContent(page);
+    expect(afterDrag).toBe(`![|250](${IMAGE_PATH})`);
+
+    // mouseup で mousemove リスナーは removeEventListener 済みのはず。
+    // 取りこぼしていれば、この mousemove だけで img.style.width が動いてしまう
+    await page.evaluate(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 999, clientY: 0 }));
+    });
+
+    expect(await getContent(page)).toBe(afterDrag);
+
+    await ctx.close();
+  });
+
+  test("連続ドラッグ（1回目→renderAll→2回目）が正しく効く", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(dragHandle, [0, 50] as [number, number]);
+    expect(await getContent(page)).toBe(`![|250](${IMAGE_PATH})`);
+
+    // 1回目の renderAll() で作り直された新しい img/handle に対して再度ドラッグする
+    await page.evaluate(dragHandle, [0, 30] as [number, number]);
+    // 2回目は 1回目で書き込まれた width 属性（250）を起点に +30
+    expect(await getContent(page)).toBe(`![|280](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("ズーム 50% で実際のポインタ操作によるドラッグも正しく換算される", async ({ browser }) => {
+    // locator.hover() は bounding box が非ゼロでないと actionable にならないので alt は非空にする。
+    // 壊れた画像アイコン + alt の実測幅は width 属性とずれうるので、期待値は実測から動的に求める
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(
+      page,
+      { content: `![説明|100](${IMAGE_PATH})`, zoom: 50 },
+      {},
+      { captureInvokes: true },
+    );
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator("img").hover();
+    await page.waitForFunction(() =>
+      document.querySelector(".img-resize-handle")?.classList.contains("visible"),
+    );
+
+    const zoomFactor = 0.5;
+    const startWidth = await page.evaluate((zf) => {
+      const img = document.querySelector("img")!;
+      const attrWidth = parseInt(img.getAttribute("width") || "", 10);
+      const rect = img.getBoundingClientRect();
+      const renderedWidth = rect.width > 0 ? rect.width / zf : null;
+      if (Number.isFinite(attrWidth) && attrWidth > 0) {
+        return renderedWidth != null ? Math.min(attrWidth, renderedWidth) : attrWidth;
+      }
+      return renderedWidth ?? 200;
+    }, zoomFactor);
+
+    const box = await page.locator(".img-resize-handle").boundingBox();
+    if (!box) throw new Error("handle has no bounding box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 50, y, { steps: 5 });
+    await page.mouse.up();
+
+    // dx=50（画面上のマウス移動量）÷ zoomFactor(0.5) = canonical 幅では +100
+    expect(await getContent(page)).toBe(`![説明|${Math.round(startWidth + 50 / zoomFactor)}](${IMAGE_PATH})`);
+
+    await ctx.close();
+  });
+
+  test("ドラッグ中に dblclick が発火しても open_image は invoke されない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      const handle = document.querySelector(".img-resize-handle")!;
+      img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 0, clientY: 0 }));
+      // ドラッグ中（mouseup 前）に dblclick が届いても open_image を発火させない
+      img.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 0, clientY: 0 }));
+    });
+
+    await page.waitForTimeout(100);
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image"),
+    );
+    expect(calls.length).toBe(0);
+
+    await ctx.close();
+  });
+
+  test("ハンドルへの mousedown のみ（移動なし）では content が変わらない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    const content = `![](${IMAGE_PATH})`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      const handle = document.querySelector(".img-resize-handle")!;
+      img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 0, clientY: 0 }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 0, clientY: 0 }));
+    });
+
+    expect(await getContent(page)).toBe(content);
+
+    await ctx.close();
+  });
+
+  test("リモート URL 等 data-rel-src が無効な形状の画像にはハンドルが出ない", async ({ browser }) => {
+    // 書き戻し先を特定できない画像（isValidImageRelPath が弾く形状）にリサイズ UI を出すと、
+    // 掴めるのにドラッグが機能しない（mousedown 側は既に isValidImageRelPath で弾いている）
+    // 見た目だけの矛盾になる
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    const content = "![cat](https://example.com/cat.png)";
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    const visible = await page.evaluate(() =>
+      document.querySelector(".img-resize-handle")!.classList.contains("visible"),
+    );
+    expect(visible).toBe(false);
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## 背景

付箋上の画像は常に原寸（付箋幅が上限）で表示され、大きすぎる画像が付箋を占領しても縮められない。

## 仕様

- 画像のホバーで右下にリサイズハンドルが出て、ドラッグで表示幅を変更できる。ドラッグ中はプレビューが追従し、離すと確定する
- 幅は `![alt|300](images/...)` の Obsidian 方式で content に記録する（40〜2000 px にクランプ、範囲外は指定なし扱い）。生表示で数値を直接編集してもよい
- ズーム中のドラッグは表示倍率を補正して換算する

## やったこと

- 描画: alt 末尾の `|数字` を幅として分離し width 属性に出す。alt に `|` を複数含む場合は最後のセグメントだけを幅と解釈
- リサイズ操作: ハンドルは共有 1 要素を画像ごとに使い回す。ドラッグ確定時に該当行の記法へ幅を追加 / 置換（同一行に同じ画像が複数あっても出現順で対象を特定）。mouseup の取りこぼしからの自己回復、スクロール・ズーム変更・再描画でのハンドル追従も対応
- リッチテキスト変換: 画像 alt の `|` は幅記法と誤解釈されるため除去（リンクテキストの `|` は保持）
- テスト: 幅記法のパースの UT、ドラッグ操作・重複画像・連続ドラッグ・ズーム換算の E2E を追加

## 確認したこと

- cargo test 136 件 / clippy / fmt、eslint、Playwright 250 件（VRT ベースライン差分なし）
- 実機でドラッグリサイズ・記法への書き戻し・再ドラッグでの置換・ズーム中の追従を確認

## 関連リンク

- issue: #63
- 先行 PR: #71

- 後続 PR: #74
