### PR TITLE
✨ 画像を貼れるようにする｜6｜画像のペースト直後と編集中の見え方を整える

### DIFF
--- a/src/note.html
+++ b/src/note.html
@@ -195,6 +195,46 @@
     line-height: 1.4;
   }
 
+  /* プレビューが続くときだけ、ed の下側の角丸を落として 1 枚のカードに繋げる
+     （margin は元々 0 -2px で下側の隙間が無いので、角丸だけ合わせれば繋がって見える） */
+  .raw-editor.has-preview {
+    border-radius: 3px 3px 0 0;
+  }
+  /* atomic（横スクロール）のスクロールバーが太い帯に見えてカードの一体感を壊すため、
+     プレビューと繋がるとき（has-preview）だけ隠す。スクロール自体・キャレット追従の
+     自動スクロールは残る（overflow-x: auto のまま）。フェンスの atomic（has-preview
+     が付かない）には影響しない */
+  .raw-editor.has-preview.atomic {
+    scrollbar-width: none;
+  }
+  .raw-editor.has-preview.atomic::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* 画像を含む行を生表示にしたときだけ、ed の直下に出す編集不可のプレビュー。
+     生エディタへの差し替えで画像の高さぶん表示がずれるのを抑える（操作対象にはしない）。
+     背景・左右 padding/margin・角丸を ed と揃え、「この記法とこの画像は同じもの」と
+     分かる 1 枚のカードに見せる */
+  .raw-editor-preview {
+    background: rgba(0,0,0,0.04);
+    border-radius: 0 0 3px 3px;
+    padding: 0 2px;
+    margin: 0 -2px;
+    /* 自身はクリックを受け取り mdView の「余白クリック→最終行へ」分岐に落とさせない
+       （note.js の mouseup ハンドラで .raw-editor-preview 自体は無視する）。
+       子孫（img 等）は操作対象にしないため pointer-events: none を継承させる */
+    pointer-events: auto;
+    user-select: none;
+  }
+  .raw-editor-preview * {
+    pointer-events: none;
+  }
+  /* 淡さは画像そのものだけに掛ける。ラッパーに掛けると背景（カードの地の色）まで
+     淡くなってしまい、ed と繋がった 1 枚のカードに見えなくなる */
+  .raw-editor-preview img {
+    opacity: 0.55;
+  }
+
   .md-placeholder { color: var(--text-muted); }
   .md-line, .md-empty { min-height: 21px; word-break: break-word; }
   #markdown-view img { max-width: 100%; }

--- a/src/note.js
+++ b/src/note.js
@@ -211,6 +211,56 @@ function caretLineCol(ed) {
   return { line: activeStart + before.length - 1, col: before[before.length - 1].length };
 }
 
+/**
+ * block（差し替え前の描画済みブロック）が画像を含む場合、その描画結果を編集不可の
+ * プレビューとして複製する。data-line 系属性は自身だけでなく子孫（チェックボックスの
+ * input 等）にも付いており、残すと findBlock の誤マッチだけでなくチェックボックスが
+ * Tab 到達可能なまま change を発火させ得るため、複製全体から剥がす。
+ *
+ * inert は複製した中身（clone）にだけ立てる。ラッパー（preview）ごと inert にすると
+ * ポインタイベントのヒットテスト自体から外れ、CSS の pointer-events: auto（mdView の
+ * mouseup ハンドラでプレビュー自身へのクリックを識別するための仕掛け）が効かなくなり、
+ * クリックが背後の mdView へ抜けて「余白クリック→最終行へ」に誤爆する。
+ *
+ * block.el はまだ DOM に接続されたまま（置き換え前）なので、その img の実測サイズを
+ * clone 側の img へ固定で書き込む（詳細は下のコメント参照）。実測前（画像読み込み中）の
+ * block.el ではサイズが定まらないため何もしない。
+ */
+function buildImagePreview(block) {
+  if (!block || !block.el.querySelector('img[data-rel-src]')) return null;
+  const preview = document.createElement('div');
+  preview.className = 'raw-editor-preview';
+  const clone = block.el.cloneNode(true);
+  clone.removeAttribute('data-line');
+  clone.removeAttribute('data-line-end');
+  clone.querySelectorAll('[data-line], [data-line-end]').forEach((el) => {
+    el.removeAttribute('data-line');
+    el.removeAttribute('data-line-end');
+  });
+  // width・height の両方を明示指定して clone 側の img のボックスを固定する。片方
+  // （height）だけ固定すると、clone 自身の画像デコード・レイアウトのタイミングに
+  // width が左右され、結果的に高さもアスペクト比ごと揺れうる。幅も含めて数値で
+  // 固定してしまえば、clone の img が実際にいつ・どう読み込まれるかに一切依存しない。
+  //
+  // getBoundingClientRect() はズーム後（画面表示）のサイズを返す。CSS の width/height は
+  // ズーム前（ローカル座標）の値として解釈され、ズームは祖先の .note がまとめて
+  // 掛け直すため、画面表示のサイズをそのまま書き込むとズーム分が二重に掛かってしまう
+  // （例: 50% ズームなら本来の半分のサイズで描画される）。currentZoom で割り戻して
+  // ローカル座標に変換してから書き込む
+  const zoomFactor = currentZoom / 100;
+  const sourceImages = block.el.querySelectorAll('img[data-rel-src]');
+  const cloneImages = clone.querySelectorAll('img[data-rel-src]');
+  sourceImages.forEach((img, idx) => {
+    const rect = img.getBoundingClientRect();
+    if (rect.height <= 0 || rect.width <= 0) return;
+    cloneImages[idx].style.width = `${rect.width / zoomFactor}px`;
+    cloneImages[idx].style.height = `${rect.height / zoomFactor}px`;
+  });
+  clone.inert = true;
+  preview.appendChild(clone);
+  return preview;
+}
+
 /** 行 lineIdx を生 Markdown に差し替え、col 列にキャレットを置く（col が null なら行末）。 */
 function enterLine(lineIdx, col) {
   commitActive();
@@ -223,9 +273,17 @@ function enterLine(lineIdx, col) {
   activeStart = block ? block.start : i;
   activeEnd = block ? block.end : i;
 
+  const preview = buildImagePreview(block);
+
   const ed = document.createElement('div');
   ed.id = 'editor';
-  ed.className = 'raw-editor' + (activeEnd > activeStart ? ' atomic' : '');
+  // 画像を含む行も atomic（折り返さず横スクロール）にする。images/<uuid> の記法が
+  // 折り返して 2〜3 行になると、プレビューと合わせた高さで全体が下にずれるため、
+  // 高さの増加を 1 行分に抑える。has-preview は「同じ記法・画像だ」と分かるよう
+  // ed とプレビューを 1 枚のカードに見せるための CSS フック（下側の角丸を落とす）
+  ed.className = 'raw-editor'
+    + (activeEnd > activeStart || preview ? ' atomic' : '')
+    + (preview ? ' has-preview' : '');
   ed.contentEditable = 'true';
   ed.setAttribute('aria-label', I18N.t('noteContentAriaLabel'));
   ed.textContent = lines.slice(activeStart, activeEnd + 1).join('\n');
@@ -233,6 +291,7 @@ function enterLine(lineIdx, col) {
   // 空の付箋はプレースホルダしか無いので、差し替え先が無い
   if (block) block.el.replaceWith(ed);
   else { mdView.innerHTML = ''; mdView.appendChild(ed); }
+  if (preview) ed.after(preview);
 
   bindEditor(ed);
   ed.focus();
@@ -288,10 +347,20 @@ function rawColFromPoint(el, line, e) {
   return Math.min(markerLength(line) + visible, line.length);
 }
 
+// プレビューへの mousedown はフォーカス移動ごと止める。既定に任せると生エディタが blur →
+// commitActive の再描画でプレビューが消えてレイアウトが詰まり、mouseup 時に再ヒットテストする
+// エンジン（WebKit）では同じ画面座標に来た別の行へ編集が飛んでしまう
+mdView.addEventListener('mousedown', (e) => {
+  if (e.target.closest('.raw-editor-preview')) e.preventDefault();
+});
+
 // mouseup で拾う（mousedown を潰すとドラッグでの範囲選択ができなくなるため）
 mdView.addEventListener('mouseup', (e) => {
   // 画像リサイズのドラッグ確定はここでは扱わない（別のリスナーが担当。生表示に入らせない）
   if (dragState) return;
+  // プレビューは pointer-events: auto でヒットターゲットになるが、生表示への遷移対象ではない。
+  // 無視しないと「余白クリック」扱いになり、キャレットが最終行へ飛んでしまう
+  if (e.target.closest('.raw-editor-preview')) return;
   if (e.target.closest('.raw-editor')) return;
   if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]') || e.target.closest('img')) return;
   // 範囲選択したときは生表示に入らない（コピーの邪魔をしない）
@@ -848,7 +917,9 @@ async function pasteImage(ed, file, fallbackLine) {
   }
   const markdown = `![](${relPath})`;
   if (ed?.isConnected && activeStart === lineAtPaste) {
-    insertIntoEditor(ed, markdown);
+    // 画像記法の直後で行を割り、キャレットを次の行へ送る。画像行から
+    // キャレットが外れることで、貼った直後から生の記法ではなく画像として描画される
+    insertIntoEditor(ed, markdown + '\n');
     return;
   }
   const lines = getLines();
@@ -911,10 +982,16 @@ async function onEditorPaste(e) {
   await insertConverted(ed, toMarkdown(text, e.clipboardData.getData('text/html')));
 }
 
-/** 画像 File を順番どおりに挿入する。挿入のたびに行番号がずれるため並列にはできない。 */
+/**
+ * 画像 File を順番どおりに挿入する。挿入のたびに行番号がずれるため並列にはできない。
+ * pasteImage は画像記法の後で改行して次の行へ移るため、enterLine が ed を新しい DOM
+ * ノードに差し替える。次の画像もキャレット位置（＝新しい ed）へ続けて挿入できるよう、
+ * ループのたびに ed を取り直す。
+ */
 async function pasteImageFiles(ed, files, fallbackLine) {
   for (const file of files) {
     await pasteImage(ed, file, fallbackLine);
+    ed = activeEditor();
   }
 }
 

--- a/tests/visual/image-drop-e2e.spec.ts
+++ b/tests/visual/image-drop-e2e.spec.ts
@@ -26,8 +26,12 @@ test.describe("ドラッグ&ドロップでの画像追加", () => {
       { timeout: 3000 },
     ).toBe(1);
 
+    // 画像記法の直後で行が割れ、キャレットは次の（空の）行にある
     const content = await getContent(page);
-    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)");
+    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)\n");
+
+    const activeLine = await page.evaluate(() => document.getElementById("editor")!.textContent);
+    expect(activeLine).toBe("");
 
     await ctx.close();
   });
@@ -107,10 +111,11 @@ test.describe("ドラッグ&ドロップでの画像追加", () => {
     const timeline = await page.evaluate(() => (window as any).__invoke_timeline);
     expect(timeline).toEqual(["start:0", "end:0", "start:1", "end:1"]);
 
-    // 挿入自体は2回行われている（モックは同一パスを返すため2回連結される）
+    // 挿入自体は2回行われている（モックは同一パスを返すため2回連結される）。
+    // 画像ごとに改行して次の行へ移るため、2枚目の後にも空行が残る
     const content = await getContent(page);
     expect(content).toBe(
-      "![](images/00000000-0000-4000-8000-000000000001.png)".repeat(2),
+      "![](images/00000000-0000-4000-8000-000000000001.png)\n".repeat(2),
     );
 
     await ctx.close();

--- a/tests/visual/image-raw-preview-e2e.spec.ts
+++ b/tests/visual/image-raw-preview-e2e.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect, injectNoteMock, placeCaret, getContent } from "./fixtures";
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+
+// data:image/svg+xml;base64, の 240x60 の矩形。ネットワーク取得を経ないため初回描画までに
+// 確実に読み込みが終わっており、「生表示に入る時点では画像がすでに読み込み済み」という
+// 実運用で最も多いケース（ノートを開いてから編集する）を安定して再現できる
+const LOADED_IMG_SRC =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNDAiIGhlaWdodD0iNjAiPjxyZWN0IHdpZHRoPSIyNDAiIGhlaWdodD0iNjAiIGZpbGw9InJlZCIvPjwvc3ZnPg==";
+
+test.describe("画像行の生表示中プレビュー", () => {
+  test("画像行を生表示にすると #editor の直後にプレビューが出る（幅指定も反映）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![|150](${IMAGE_PATH})` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(1);
+    const isRightAfterEditor = await page.evaluate(() => {
+      const ed = document.getElementById("editor")!;
+      return ed.nextElementSibling?.classList.contains("raw-editor-preview") ?? false;
+    });
+    expect(isRightAfterEditor).toBe(true);
+
+    const previewImg = page.locator(".raw-editor-preview img");
+    await expect(previewImg).toHaveAttribute("width", "150");
+
+    await ctx.close();
+  });
+
+  test("画像を含まない行では生表示にしてもプレビューは出ない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "plain text" });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("別の行へ移るとプレビューが消える", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})\ntext` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(1);
+
+    await placeCaret(page, 1, 0);
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("生表示を抜ける（commit）とプレビューが消える", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(1);
+
+    await page.evaluate(() => {
+      document.getElementById("editor")!.dispatchEvent(new FocusEvent("blur", { relatedTarget: null }));
+    });
+    await expect(page.locator("#editor")).toHaveCount(0);
+    await expect(page.locator(".raw-editor-preview")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("プレビューは pointer-events: none で操作対象にならない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    const previewImg = page.locator(".raw-editor-preview img");
+    await expect(previewImg).toHaveCount(1);
+
+    const pointerEvents = await previewImg.evaluate((el) => getComputedStyle(el).pointerEvents);
+    expect(pointerEvents).toBe("none");
+
+    // 実座標でのダブルクリック → pointer-events: none によりヒットテストで
+    // プレビュー画像が対象にならず、open_image は発火しない
+    const box = await previewImg.boundingBox();
+    if (!box) throw new Error("preview image has no bounding box");
+    await page.mouse.dblclick(box.x + box.width / 2, box.y + box.height / 2);
+
+    const openImageCalls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image").length,
+    );
+    expect(openImageCalls).toBe(0);
+
+    // 同じ座標へマウスを乗せてもリサイズハンドルは出ない
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    const handleVisible = await page.evaluate(() =>
+      document.querySelector(".img-resize-handle")!.classList.contains("visible"),
+    );
+    expect(handleVisible).toBe(false);
+
+    await ctx.close();
+  });
+
+  test("プレビュー中央のクリックでは余白クリック扱いにならず最終行へ飛ばない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![](${IMAGE_PATH})\nline1\nline2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    const preview = page.locator(".raw-editor-preview");
+    await expect(preview).toHaveCount(1);
+
+    const box = await preview.boundingBox();
+    if (!box) throw new Error("preview has no bounding box");
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+    // プレビューへの mousedown は preventDefault でフォーカス移動ごと止めるので、
+    // 画像行の生表示が開いたまま変わらない（余白クリック扱いで別行へ飛ばない）
+    await expect(page.locator("#editor")).toContainText("![](images/");
+
+    const content = await getContent(page);
+    expect(content).toBe(`![](${IMAGE_PATH})\nline1\nline2`);
+
+    await ctx.close();
+  });
+
+  test("画像入りチェックボックス行のプレビュー: data-line が残らず checkbox はフォーカス不能", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `- [ ] ![](${IMAGE_PATH})` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    const previewCheckbox = page.locator(".raw-editor-preview input[type=checkbox]");
+    await expect(previewCheckbox).toHaveCount(1);
+
+    // クローン内のどの子孫にも data-line / data-line-end が残っていない
+    const staleDataLineCount = await page
+      .locator(".raw-editor-preview [data-line], .raw-editor-preview [data-line-end]")
+      .count();
+    expect(staleDataLineCount).toBe(0);
+
+    // inert によりプログラムからの focus() も無視される
+    await previewCheckbox.evaluate((el) => (el as HTMLElement).focus());
+    const focusedIsPreviewCheckbox = await page.evaluate(() =>
+      document.activeElement === document.querySelector(".raw-editor-preview input[type=checkbox]"),
+    );
+    expect(focusedIsPreviewCheckbox).toBe(false);
+
+    await ctx.close();
+  });
+
+  test("プレビューは後続行と重ならない（実測高さを clone の img に固定する）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(
+      page,
+      { content: `![](${LOADED_IMG_SRC})\nline1\nline2` },
+      { data_dir: null },
+    );
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 生表示に入る前（読み込み済み）の実測高さ
+    const renderedImg = page.locator('[data-line="0"] img');
+    const beforeBox = await renderedImg.boundingBox();
+    if (!beforeBox) throw new Error("rendered image has no bounding box");
+    expect(beforeBox.height).toBeGreaterThan(0);
+
+    await placeCaret(page, 0, 0);
+
+    const previewImg = page.locator(".raw-editor-preview img");
+    // clone 側の img に実測高さがインライン style として固定されている
+    // （画像の読み込み完了タイミングに再レイアウトを委ねない）
+    const styleHeight = await previewImg.evaluate((el) => (el as HTMLElement).style.height);
+    expect(styleHeight).toBe(`${beforeBox.height}px`);
+
+    // プレビュー画像の下端が後続行の上端を超えない（重ならない）
+    const previewImgBox = await previewImg.boundingBox();
+    const line1Box = await page.locator('[data-line="1"]').boundingBox();
+    if (!previewImgBox || !line1Box) throw new Error("preview image or line1 has no bounding box");
+    expect(previewImgBox.y + previewImgBox.height).toBeLessThanOrEqual(line1Box.y);
+
+    // ラッパー自体も画像の高さをちゃんと内包している
+    const previewBox = await page.locator(".raw-editor-preview").boundingBox();
+    if (!previewBox) throw new Error("preview has no bounding box");
+    expect(previewBox.height).toBeGreaterThanOrEqual(previewImgBox.height);
+
+    await ctx.close();
+  });
+
+  test("ズーム時もプレビュー画像の見かけの高さが変わらない（実測値の書き戻しでズーム分を二重に掛けない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(
+      page,
+      { content: `![](${LOADED_IMG_SRC})\nline1\nline2`, zoom: 50 },
+      { data_dir: null },
+    );
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // getBoundingClientRect はズーム後（画面表示）のサイズを返す
+    const beforeBox = await page.locator('[data-line="0"] img').boundingBox();
+    if (!beforeBox) throw new Error("rendered image has no bounding box");
+    expect(beforeBox.height).toBeGreaterThan(0);
+
+    await placeCaret(page, 0, 0);
+
+    const previewImgBox = await page.locator(".raw-editor-preview img").boundingBox();
+    if (!previewImgBox) throw new Error("preview image has no bounding box");
+    // 生表示に入る前後で画面上の見かけの高さは変わらないはず。
+    // ズーム前（ローカル座標）の実測値をそのまま style.height に書き込むと、祖先の
+    // ズームがもう一度掛かって半分の高さになってしまう（このテストが検出したい退行）
+    expect(previewImgBox.height).toBeCloseTo(beforeBox.height, 0);
+
+    await ctx.close();
+  });
+});

--- a/tests/visual/paste-e2e.spec.ts
+++ b/tests/visual/paste-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, enterEdit, getContent, injectNoteMock } from "./fixtures";
+import { test, expect, enterEdit, getContent, injectNoteMock, placeCaret } from "./fixtures";
 
 test.describe("ペースト処理", () => {
   test("空の選択状態でURLペースト → リンク変換されずプレーンURL挿入", async ({ openNote }) => {
@@ -186,8 +186,89 @@ test.describe("ペースト処理", () => {
       { timeout: 3000 },
     ).toBe(1);
 
+    // 画像記法の直後で行が割れ、キャレットは次の（空の）行にある
     const content = await getContent(page);
-    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)");
+    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)\n");
+
+    const activeLine = await page.evaluate(() => document.getElementById("editor")!.textContent);
+    expect(activeLine).toBe("");
+
+    await ctx.close();
+  });
+
+  test("行中へのクリップボード画像ペースト → 画像記法の直後で行が割れる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "hello world" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // "hello" の直後（col=5）にキャレットを置く
+    await placeCaret(page, 0, 5);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "pasted.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("hello![](images/00000000-0000-4000-8000-000000000001.png)\n world");
+
+    const activeLine = await page.evaluate(() => document.getElementById("editor")!.textContent);
+    expect(activeLine).toBe(" world");
+
+    await ctx.close();
+  });
+
+  test("行頭（col=0）へのクリップボード画像ペースト → 元の行全体が次の行へ押し出される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "hello" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+
+    await page.evaluate(() => {
+      const editor = document.getElementById("editor")!;
+      const file = new File([new Uint8Array([137, 80, 78, 71])], "pasted.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(pasteEvent);
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "save_pasted_image").length,
+      ),
+      { timeout: 3000 },
+    ).toBe(1);
+
+    const content = await getContent(page);
+    expect(content).toBe("![](images/00000000-0000-4000-8000-000000000001.png)\nhello");
+
+    const activeLine = await page.evaluate(() => document.getElementById("editor")!.textContent);
+    expect(activeLine).toBe("hello");
 
     await ctx.close();
   });


### PR DESCRIPTION
## 背景

画像をペーストした直後はキャレットが画像行にあるため、画像ではなく生の `![](images/...)` 文字列が見えてしまう。また画像行にキャレットを移すと、背の高い画像ブロックが 1 行のテキストに差し替わって全体の表示が大きくずれ、編集位置を見失う。

## 仕様

- 画像を挿入すると記法の直後で行が割れ、キャレットは次の行に移る。画像はすぐ描画された状態で見える
- 画像を含む行を生表示にすると、折り返さない 1 行の生エディタ（横スクロール・スクロールバー非表示）と、その下に編集不可の画像プレビューが、ひとかたまりのカードとして表示される。表示のずれは 1 行分に収まる
- プレビューはクリックしても反応しない（画像行の編集が続く）

## やったこと

- 挿入経路: 画像記法の直後に改行を含めて挿入し、既存の行分割の仕組みでキャレットを次の行へ送る。複数ファイルの連続挿入では生エディタが作り直されるため参照を取り直す
- 生表示: 描画済みのブロックを流用してプレビューを作る。画像の実測サイズをズーム補正つきで固定して、WebView の再描画タイミングに依存した後続行との重なりを断つ。プレビューは編集・フォーカスの対象から完全に外す（mouseup 時に再ヒットテストするエンジンで別の行へ編集が飛ぶのを防ぐため、mousedown 段階で止める）
- テスト: ペースト後のキャレット位置・行割れ、プレビューの表示・非重なり・ズーム・クリック無反応の E2E を追加

## 確認したこと

- eslint、node UT 147 件 + Playwright 261 件（VRT ベースライン差分なし）。WebKit エンジン（実機の WKWebView と同系）でも画像系 E2E 44 件が通ることを確認
- 実機でペースト直後の描画・カード表示・重なり解消・プレビュークリックの無反応を確認

## 関連リンク

- issue: #63
- 先行 PR: #72

- 後続 PR: #75
