### PR TITLE
✨ 画像を貼れるようにする｜7｜付箋上の画像を選択して操作できるようにする

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ const noteLines = {
   getAutoPrefix: "readonly",
   isEmptyListItem: "readonly",
   CHECKBOX_RE: "readonly",
+  isImageOnlyLine: "readonly",
 };
 
 export default [

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,8 +12,8 @@ use crate::model::{
     LanguageSetting, Note, RecoverMutex, Settings, TRASH_MAX,
 };
 use crate::persistence::{
-    self, enforce_trash_limit, extract_image_paths, gc_images, save_notes, save_settings,
-    save_trash,
+    self, enforce_trash_limit, extract_image_paths, gc_images,
+    remove_image_occurrence_from_content, save_notes, save_settings, save_trash,
 };
 use crate::window::{
     create_note_with_window, open_note_window, open_settings_window, open_trash_window,
@@ -131,6 +131,31 @@ pub(crate) fn confirm_delete_if_needed(app: &AppHandle, state: &AppState, id: &s
     }
     app.dialog()
         .message(i18n::text(lang, Msg::DeleteConfirmMessage))
+        .title(i18n::app_name(lang))
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            i18n::text(lang, Msg::DeleteConfirmOk).into(),
+            i18n::text(lang, Msg::DeleteConfirmCancel).into(),
+        ))
+        .blocking_show()
+}
+
+/// 画像削除の確認。`confirm_before_delete` が有効な場合のみダイアログを出す
+/// （無効なら従来どおり即実行）。基盤は `confirm_delete_if_needed` と共通だが、対象が
+/// 付箋そのものではなく画像 1 個なので専用の文言（`Msg::DeleteImageConfirmMessage`）を使う。
+/// 付箋削除と違って「空なら確認しない」特例は無い（画像の有無と付箋の空判定は無関係）。
+pub(crate) fn confirm_delete_image_if_needed(app: &AppHandle, state: &AppState) -> bool {
+    let (confirm, lang) = {
+        let settings = state.settings.recover();
+        (
+            settings.confirm_before_delete,
+            i18n::resolve(settings.language),
+        )
+    };
+    if !confirm {
+        return true;
+    }
+    app.dialog()
+        .message(i18n::text(lang, Msg::DeleteImageConfirmMessage))
         .title(i18n::app_name(lang))
         .buttons(MessageDialogButtons::OkCancelCustom(
             i18n::text(lang, Msg::DeleteConfirmOk).into(),
@@ -505,6 +530,59 @@ pub(crate) fn show_context_menu(
     }
 }
 
+/// 画像削除の実処理。note の content の `line_idx` 行目にある `rel_path` の
+/// `occurrence` 番目の画像記法だけを取り除いて保存し、参照が無くなった画像ファイルを GC する。
+/// note が見つからない・対象の 1 箇所が content の現在値と噛み合わない（呼び出し元の
+/// 状態が古い等）場合は `Ok(None)`。戻り値は保存後の content で、呼び出し元（`delete_image`
+/// コマンド）がフロントエンドの `rawContent` をそのまま置き換えるのに使う。
+///
+/// `delete_note_data` と同じく「ディスク確定 → メモリ反映」の順序を守る。先にメモリを
+/// 書き換えてから保存すると、保存失敗時にメモリだけディスクより先に進んでしまう。
+pub(crate) fn delete_image_data(
+    state: &AppState,
+    note_id: &str,
+    rel_path: &str,
+    line_idx: usize,
+    occurrence: usize,
+) -> Result<Option<String>, String> {
+    let (new_content, notes_snapshot) = {
+        let notes = state.notes.recover();
+        let Some(note) = notes.iter().find(|n| n.id == note_id) else {
+            log::warn!("delete_image: note not found: {}", note_id);
+            return Ok(None);
+        };
+        let Some(new_content) =
+            remove_image_occurrence_from_content(&note.content, rel_path, line_idx, occurrence)
+        else {
+            log::warn!(
+                "delete_image: target does not match current content (note={}, line={}, occurrence={})",
+                note_id,
+                line_idx,
+                occurrence
+            );
+            return Ok(None);
+        };
+        let mut snapshot = notes.clone();
+        drop(notes);
+        let pos = snapshot
+            .iter()
+            .position(|n| n.id == note_id)
+            .expect("note found above still present in snapshot");
+        snapshot[pos].content = new_content.clone();
+        (new_content, snapshot)
+    };
+    save_notes(state, &notes_snapshot)?;
+    *state.notes.recover() = notes_snapshot.clone();
+    let trash_snapshot = state.trash.recover().clone();
+    gc_images(
+        &state.data_dir,
+        std::slice::from_ref(&rel_path.to_string()),
+        &notes_snapshot,
+        &trash_snapshot,
+    );
+    Ok(Some(new_content))
+}
+
 /// 画像を OS の既定アプリで開く。
 #[tauri::command]
 pub(crate) fn open_image(
@@ -513,6 +591,29 @@ pub(crate) fn open_image(
     state: State<AppState>,
 ) -> Result<(), String> {
     image_actions::open_image(&app, &state.data_dir, &image_path)
+}
+
+/// 選択中の画像を Backspace / Delete で削除する（右クリックメニューには削除項目を
+/// 置かず、選択状態からのキー操作だけが入口）。`confirm_before_delete` が有効なら
+/// 付箋削除と同じ確認ダイアログ基盤で確認し、キャンセルされたら `Ok(None)`。
+/// 削除処理そのものは `delete_image_data` を使う。フロント側の data 属性は DOM 改変で
+/// 偽装され得るため、`image_path` の形状はここでも検証する。
+#[tauri::command]
+pub(crate) fn delete_image(
+    id: String,
+    image_path: String,
+    image_line: usize,
+    image_occurrence: usize,
+    app: AppHandle,
+    state: State<AppState>,
+) -> Result<Option<String>, String> {
+    if !persistence::is_valid_image_rel_path(&image_path) {
+        return Ok(None);
+    }
+    if !confirm_delete_image_if_needed(&app, &state) {
+        return Ok(None);
+    }
+    delete_image_data(&state, &id, &image_path, image_line, image_occurrence)
 }
 
 #[cfg(test)]
@@ -967,6 +1068,153 @@ mod tests {
         empty_trash_data(&state).unwrap();
 
         assert!(image_exists(&dir, &image_path));
+    }
+
+    // ── delete_image_data ─────────────────────────────────────
+
+    #[test]
+    fn delete_image_data_removes_image_only_line_and_persists() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(1);
+        write_dummy_image(&dir, &image_path);
+        let content = format!("見出し\n![]({})\n本文", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &image_path, 1, 0).unwrap();
+
+        assert_eq!(result, Some("見出し\n本文".to_string()));
+        assert_eq!(state.notes.recover()[0].content, "見出し\n本文");
+        assert_eq!(read_notes_json(&dir)[0].content, "見出し\n本文");
+    }
+
+    #[test]
+    fn delete_image_data_gc_removes_now_unreferenced_image() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(2);
+        write_dummy_image(&dir, &image_path);
+        let content = format!("![]({})", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        delete_image_data(&state, "a", &image_path, 0, 0).unwrap();
+
+        assert!(!image_exists(&dir, &image_path));
+    }
+
+    /// 他の付箋がまだ同じ画像を参照していれば、そちらは触らずファイルも消さない。
+    #[test]
+    fn delete_image_data_keeps_image_still_referenced_by_another_note() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(3);
+        write_dummy_image(&dir, &image_path);
+        let content_a = format!("![]({})", image_path);
+        let content_b = format!("別の付箋 ![]({})", image_path);
+        let state = make_state(
+            &dir,
+            vec![make_note("a", &content_a), make_note("b", &content_b)],
+            vec![],
+        );
+
+        let result = delete_image_data(&state, "a", &image_path, 0, 0).unwrap();
+
+        assert_eq!(result, Some(String::new()));
+        let notes = state.notes.recover();
+        assert_eq!(
+            notes.iter().find(|n| n.id == "b").unwrap().content,
+            content_b
+        );
+        assert!(image_exists(&dir, &image_path));
+    }
+
+    #[test]
+    fn delete_image_data_strips_syntax_only_from_mixed_line() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(4);
+        write_dummy_image(&dir, &image_path);
+        let content = format!("テキスト ![]({}) 続き", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &image_path, 0, 0).unwrap();
+
+        assert_eq!(result, Some("テキスト  続き".to_string()));
+    }
+
+    /// クリックされた 1 箇所だけを取り除く。同じ画像を参照する他の行は無傷のまま残り、
+    /// その参照が残っている限り画像ファイルも GC されない。
+    #[test]
+    fn delete_image_data_only_removes_targeted_occurrence_and_keeps_other_lines() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(8);
+        write_dummy_image(&dir, &image_path);
+        let content = format!(
+            "![]({})\nテキスト ![別alt]({}) 続き",
+            image_path, image_path
+        );
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &image_path, 0, 0).unwrap();
+
+        let expected = format!("テキスト ![別alt]({}) 続き", image_path);
+        assert_eq!(result, Some(expected.clone()));
+        assert_eq!(state.notes.recover()[0].content, expected);
+        // 2 行目にまだ参照が残っているので画像ファイルは消えない
+        assert!(image_exists(&dir, &image_path));
+    }
+
+    #[test]
+    fn delete_image_data_unknown_note_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(5);
+        let state = make_state(&dir, vec![], vec![]);
+
+        let result = delete_image_data(&state, "missing", &image_path, 0, 0).unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn delete_image_data_no_matching_reference_returns_none_and_writes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let (present, absent) = (uuid_image_path(6), uuid_image_path(7));
+        let content = format!("![]({})", present);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &absent, 0, 0).unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(state.notes.recover()[0].content, content);
+        assert!(!dir.path().join("notes.json").exists());
+    }
+
+    /// occurrence が実在しない（フロントの状態が content の現在値とずれていた等）場合も
+    /// 何も変えずに None を返す。
+    #[test]
+    fn delete_image_data_stale_occurrence_returns_none_and_writes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(9);
+        let content = format!("![]({})", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &image_path, 0, 1).unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(state.notes.recover()[0].content, content);
+        assert!(!dir.path().join("notes.json").exists());
+    }
+
+    /// 保存が失敗したときはメモリを書き換えない（`delete_note_data` と同じ
+    /// 「ディスク確定 → メモリ反映」の順序であることの確認）。
+    #[test]
+    fn delete_image_data_save_failure_leaves_memory_untouched() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("notes.json")).unwrap();
+        let image_path = uuid_image_path(10);
+        let content = format!("![]({})", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = delete_image_data(&state, "a", &image_path, 0, 0);
+
+        assert!(result.is_err());
+        assert_eq!(state.notes.recover()[0].content, content);
     }
 
     // ── delete → restore round-trip ───────────────────────────

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tauri::ipc::{InvokeBody, Request};
@@ -616,6 +617,99 @@ pub(crate) fn delete_image(
     delete_image_data(&state, &id, &image_path, image_line, image_occurrence)
 }
 
+/// `run_on_main_thread` からの結果待ちが万一戻ってこなくても UI を無限にフリーズさせない
+/// ための上限。
+const COPY_IMAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// arboard 呼び出しをメインスレッドで実行し、結果を待ち合わせて返す。arboard は macOS で
+/// NSPasteboard をメインスレッド外から操作するとクラッシュしうる
+/// （`image_actions::copy_image_to_clipboard` の doc 参照）。この関数を呼ぶ `copy_image` /
+/// `cut_image` は非 async コマンドで、Tauri の IPC はメッセージを受け取ったスレッド上で
+/// そのままインライン実行する（別スレッドへディスパッチしない）。macOS ではその IPC 受信
+/// 自体がメインスレッド（WKWebView のコールバック）で起きるため、コマンド本体はすでに
+/// メインスレッド上で動いている。`run_on_main_thread` はメインスレッドから呼べば即時実行
+/// されるため、ここでの委譲は安全に完結する。同メソッドはクロージャの戻り値を返さないため、
+/// 結果は `std::sync::mpsc` で待ち合わせる（コマンドを async 化するとこのインライン実行の
+/// 前提が崩れ、待ち合わせがイベントループの周回待ちになる点に注意）。
+fn copy_image_on_main_thread(
+    app: &AppHandle,
+    data_dir: &Path,
+    rel_path: &str,
+) -> Result<(), String> {
+    let data_dir = data_dir.to_path_buf();
+    let rel_path = rel_path.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.run_on_main_thread(move || {
+        let result = image_actions::copy_image_to_clipboard(&data_dir, &rel_path);
+        let _ = tx.send(result);
+    })
+    .map_err(|e| e.to_string())?;
+    rx.recv_timeout(COPY_IMAGE_TIMEOUT)
+        .map_err(|e| e.to_string())?
+}
+
+/// 選択中の画像をクリップボードにコピーする。`image_path` の形状・実在検証は
+/// `copy_image_to_clipboard` が行う。
+#[tauri::command]
+pub(crate) fn copy_image(
+    image_path: String,
+    app: AppHandle,
+    state: State<AppState>,
+) -> Result<(), String> {
+    copy_image_on_main_thread(&app, &state.data_dir, &image_path)
+}
+
+/// `cut_image` の早期 return 条件（不正な画像パスなら実行せず `Ok(None)` として扱う）。
+/// フロント側の data 属性は DOM 改変で偽装され得るため、コマンド側でも検証する。
+/// `AppHandle` を要らない形に切り出しているのは、この判定単体をユニットテストするため。
+fn cut_image_should_skip(image_path: &str) -> bool {
+    !persistence::is_valid_image_rel_path(image_path)
+}
+
+/// カット（コピー → 削除）の削除側のロジック。`copy_result` は先に行ったコピーの成否
+/// （`cut_image` では `copy_image_on_main_thread` の戻り値を渡す）。コピーに失敗していれば
+/// 削除せずそのエラーを返す（消えて戻せない方が最悪なため、コピー成功が前提）。
+/// `AppHandle` を要らない形に分けているのは、コピーの成否をここへ注入することでコピー→削除の
+/// 順序をユニットテストできるようにするため（`copy_image_on_main_thread` 自体は
+/// メインスレッド委譲が要るため単体テストできない）。
+fn cut_image_after_copy(
+    state: &AppState,
+    note_id: &str,
+    rel_path: &str,
+    line_idx: usize,
+    occurrence: usize,
+    copy_result: Result<(), String>,
+) -> Result<Option<String>, String> {
+    copy_result?;
+    delete_image_data(state, note_id, rel_path, line_idx, occurrence)
+}
+
+/// 選択中の画像を ⌘X でカットする（コピー → 削除）。macOS のカットの慣習に合わせて
+/// 確認ダイアログは出さない（`delete_image` の `confirm_before_delete` 確認は経由しない。
+/// クリップボードに載るためペーストで復元できる）。
+#[tauri::command]
+pub(crate) fn cut_image(
+    id: String,
+    image_path: String,
+    image_line: usize,
+    image_occurrence: usize,
+    app: AppHandle,
+    state: State<AppState>,
+) -> Result<Option<String>, String> {
+    if cut_image_should_skip(&image_path) {
+        return Ok(None);
+    }
+    let copy_result = copy_image_on_main_thread(&app, &state.data_dir, &image_path);
+    cut_image_after_copy(
+        &state,
+        &id,
+        &image_path,
+        image_line,
+        image_occurrence,
+        copy_result,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1215,6 +1309,61 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(state.notes.recover()[0].content, content);
+    }
+
+    // ── cut_image_after_copy ───────────────────────────────────
+    // コピー処理はメインスレッド委譲が要るため単体テストできない。その戻り値を模した
+    // Result<(), String> を直接注入して「コピー成功→削除」「コピー失敗→削除しない」の
+    // 順序だけを検証する。
+
+    #[test]
+    fn cut_image_after_copy_deletes_when_copy_succeeds() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(11);
+        write_dummy_image(&dir, &image_path);
+        let content = format!("見出し\n![]({})\n本文", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = cut_image_after_copy(&state, "a", &image_path, 1, 0, Ok(()));
+
+        assert_eq!(result, Ok(Some("見出し\n本文".to_string())));
+        assert_eq!(state.notes.recover()[0].content, "見出し\n本文");
+    }
+
+    /// コピーに失敗した場合は削除処理そのものを呼ばない（消えて戻せない方が最悪なため）。
+    #[test]
+    fn cut_image_after_copy_does_not_delete_when_copy_fails() {
+        let dir = TempDir::new().unwrap();
+        let image_path = uuid_image_path(12);
+        write_dummy_image(&dir, &image_path);
+        let content = format!("![]({})", image_path);
+        let state = make_state(&dir, vec![make_note("a", &content)], vec![]);
+
+        let result = cut_image_after_copy(
+            &state,
+            "a",
+            &image_path,
+            0,
+            0,
+            Err("clipboard error".to_string()),
+        );
+
+        assert_eq!(result, Err("clipboard error".to_string()));
+        assert_eq!(state.notes.recover()[0].content, content);
+        assert!(image_exists(&dir, &image_path));
+    }
+
+    // ── cut_image_should_skip ────────────────────────────────
+
+    #[test]
+    fn cut_image_should_skip_rejects_invalid_path() {
+        assert!(cut_image_should_skip("images/../notes.json"));
+        assert!(cut_image_should_skip("not-an-image-path"));
+    }
+
+    #[test]
+    fn cut_image_should_skip_accepts_valid_path() {
+        assert!(!cut_image_should_skip(&uuid_image_path(3)));
     }
 
     // ── delete → restore round-trip ───────────────────────────

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -44,6 +44,7 @@ pub(crate) enum Msg {
     DeleteConfirmMessage,
     DeleteConfirmOk,
     DeleteConfirmCancel,
+    DeleteImageConfirmMessage,
 
     /// 読み込めなかったファイル名を差し込む `{files}` を含む
     DataLoadFailed,
@@ -92,6 +93,7 @@ pub(crate) fn text(lang: Lang, msg: Msg) -> &'static str {
         Msg::DeleteConfirmMessage => ("この付箋を削除しますか？", "Delete this note?"),
         Msg::DeleteConfirmOk => ("削除", "Delete"),
         Msg::DeleteConfirmCancel => ("キャンセル", "Cancel"),
+        Msg::DeleteImageConfirmMessage => ("この画像を削除しますか？", "Delete this image?"),
 
         Msg::DataLoadFailed => (
             "{files} を読み込めませんでした。\n\n中身が壊れているか、ファイルを開けない状態です。ファイルは削除していません。\n\n該当のファイルを削除するか、JSON として読める状態に直してから、貼っとっとを起動し直してください。",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,8 @@ pub fn run() {
             commands::save_pasted_image,
             commands::open_image,
             commands::delete_image,
+            commands::copy_image,
+            commands::cut_image,
         ])
         .setup(|app| {
             // Set up app menu and system tray

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() {
             commands::show_context_menu,
             commands::save_pasted_image,
             commands::open_image,
+            commands::delete_image,
         ])
         .setup(|app| {
             // Set up app menu and system tray

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -318,6 +318,136 @@ pub(crate) fn extract_image_paths(content: &str) -> Vec<String> {
     paths
 }
 
+/// `line`（前後の空白を除く）が、`rel_path` を指す画像記法 1 個だけで構成されているか。
+/// フロントエンドの `isImageOnlyLine`（`src/note-lines.js`）と対になる判定。
+fn is_image_only_line(line: &str, rel_path: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(rest) = trimmed.strip_prefix("![") else {
+        return false;
+    };
+    let Some(alt_end) = rest.find(']') else {
+        return false;
+    };
+    let after_alt = &rest[alt_end + 1..];
+    let Some(src_part) = after_alt.strip_prefix('(') else {
+        return false;
+    };
+    let Some(src_end) = src_part.find(')') else {
+        return false;
+    };
+    let (src, tail) = (&src_part[..src_end], &src_part[src_end + 1..]);
+    tail.is_empty() && src == rel_path
+}
+
+/// `line` 内でバッククォート 1 組（`` `...` ``）に囲まれた区間（開始・終了のバッククォート自身を
+/// 含む、バイトオフセットの半開区間）を列挙する。`src/markdown.js` の `inlineMarkdown` が
+/// code を先にプレースホルダへ保護してから画像記法を解釈するのと同じ解釈で、この区間内の
+/// `![alt](src)` は実際には `<img>` として描画されない（コードスパンの地の文字列のまま）。
+/// occurrence の数え方（`strip_image_ref_occurrence` / フロントの `rewriteImageWidth`）を
+/// この「実際に描画されるか」に揃えるための下ごしらえ。
+fn code_span_ranges(line: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'`' {
+            if let Some(rel_end) = line[i + 1..].find('`') {
+                // `[^`]+` 相当（中身が空のペアは対象外）。バッククォート自身を含めて 1 区間とする
+                if rel_end > 0 {
+                    let end = i + 1 + rel_end + 1;
+                    ranges.push((i, end));
+                    i = end;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    ranges
+}
+
+fn is_in_code_span(ranges: &[(usize, usize)], pos: usize) -> bool {
+    ranges.iter().any(|&(start, end)| pos >= start && pos < end)
+}
+
+/// `line` 内で `rel_path` を参照する `![alt](rel_path)` のうち、`occurrence` 番目（0 始まり、
+/// 行内での出現順。コードスパン内の記法は数えない）だけを取り除いた文字列を返す。同じパスの
+/// 他の出現・他の画像には触れない。`occurrence` 番目が実在しなければ `None`（unchanged）。
+/// `extract_image_paths` と同じ手書きスキャンで、対象区間だけを飛ばして出力を組み立てる。
+fn strip_image_ref_occurrence(line: &str, rel_path: &str, occurrence: usize) -> Option<String> {
+    let code_spans = code_span_ranges(line);
+    let mut out = String::with_capacity(line.len());
+    let mut seen = 0usize;
+    let mut removed = false;
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < line.len() {
+        // `!` と `[` は ASCII なので、一致した位置は常に UTF-8 の文字境界にある
+        if !is_in_code_span(&code_spans, i)
+            && i + 1 < bytes.len()
+            && bytes[i] == b'!'
+            && bytes[i + 1] == b'['
+        {
+            let after_alt_start = i + 2;
+            if let Some(alt_end) = line[after_alt_start..].find(']') {
+                let paren_pos = after_alt_start + alt_end + 1;
+                if line.as_bytes().get(paren_pos) == Some(&b'(') {
+                    let src_start = paren_pos + 1;
+                    if let Some(src_len) = line[src_start..].find(')') {
+                        let src = &line[src_start..src_start + src_len];
+                        if src == rel_path {
+                            if seen == occurrence {
+                                removed = true;
+                                seen += 1;
+                                i = src_start + src_len + 1;
+                                continue;
+                            }
+                            seen += 1;
+                        }
+                    }
+                }
+            }
+        }
+        let ch = line[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    removed.then_some(out)
+}
+
+/// content の `line_idx` 行目（0 始まり）にある、`rel_path` を参照する `occurrence` 番目
+/// （0 始まり、行内での出現順）の画像記法だけを取り除く。行全体が画像のみ（前後空白のみ）
+/// なら行ごと取り除く（画像のみの行は記法が 1 個しかないので `occurrence` は必ず 0）。
+///
+/// クリックされた 1 箇所だけを対象にする（フロント側の `imageOccurrenceInLine` /
+/// `rewriteImageWidth` と同じ考え方）。同じ画像を指す他の行・他の occurrence には触れない
+/// ため、コードフェンス内に同じ記法がテキストとして出現していても巻き込まれない。1 箇所だけ
+/// 残しても、その参照が残っている限り `gc_images` は正しくファイルを保持する（孤児化しない）。
+///
+/// `line_idx` が範囲外、または `occurrence` 番目が実在しない（呼び出し元の状態が content の
+/// 現在値とずれている等）場合は `None`。
+pub(crate) fn remove_image_occurrence_from_content(
+    content: &str,
+    rel_path: &str,
+    line_idx: usize,
+    occurrence: usize,
+) -> Option<String> {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let line = *lines.get(line_idx)?;
+    if is_image_only_line(line, rel_path) {
+        if occurrence != 0 {
+            return None;
+        }
+        let mut out = lines;
+        out.remove(line_idx);
+        return Some(out.join("\n"));
+    }
+    let stripped = strip_image_ref_occurrence(line, rel_path, occurrence)?;
+    let mut out: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    out[line_idx] = stripped;
+    Some(out.join("\n"))
+}
+
 /// notes / trash の全 content が参照している画像相対パスの集合。
 fn referenced_image_paths(notes: &[Note], trash: &[Note]) -> HashSet<String> {
     notes
@@ -570,6 +700,203 @@ mod tests {
     fn extract_image_paths_rejects_backslash_traversal_payload() {
         let content = "![](images/..\\notes.json)";
         assert!(extract_image_paths(content).is_empty());
+    }
+
+    // ── remove_image_occurrence_from_content ──
+
+    #[test]
+    fn remove_image_occurrence_drops_image_only_line_entirely() {
+        let path = uuid_image_path(1);
+        let content = format!("見出し\n![]({})\n本文", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 1, 0),
+            Some("見出し\n本文".to_string())
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_drops_image_only_line_with_width_and_alt() {
+        let path = uuid_image_path(1);
+        let content = format!("前\n  ![説明|300]({})  \n後", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 1, 0),
+            Some("前\n後".to_string())
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_strips_syntax_only_from_mixed_line() {
+        let path = uuid_image_path(1);
+        let content = format!("テキスト ![]({}) の続き", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some("テキスト  の続き".to_string())
+        );
+    }
+
+    /// クリックされた 1 箇所だけを取り除く。同じパスを参照する他の行はそのまま残る
+    /// 同じパスを参照する他の行・他の出現はそのまま残る。
+    #[test]
+    fn remove_image_occurrence_touches_only_the_targeted_line() {
+        let path = uuid_image_path(1);
+        let content = format!("![]({})\nテキスト ![別alt]({}) 続き", path, path);
+
+        // 1 行目（image-only）を対象にすると、1 行目だけが丸ごと消え 2 行目は無傷
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some(format!("テキスト ![別alt]({}) 続き", path))
+        );
+        // 2 行目を対象にすると、2 行目の記法だけが消え 1 行目は無傷
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 1, 0),
+            Some(format!("![]({})\nテキスト  続き", path))
+        );
+    }
+
+    /// 同じ行に同じパスの画像が複数あっても、occurrence で指定した 1 個だけを取り除く。
+    #[test]
+    fn remove_image_occurrence_targets_only_the_specified_occurrence_in_a_line() {
+        let path = uuid_image_path(1);
+        let content = format!("![]({}) 通常 ![別alt]({})", path, path);
+
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some(format!(" 通常 ![別alt]({})", path))
+        );
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 1),
+            Some(format!("![]({}) 通常 ", path))
+        );
+    }
+
+    /// コードフェンス内に同じ画像記法がテキストとして出現していても巻き込まれない
+    /// （行・occurrence 単位で 1 箇所だけを対象にするため）。
+    #[test]
+    fn remove_image_occurrence_does_not_touch_identical_syntax_inside_code_fence() {
+        let path = uuid_image_path(1);
+        let content = format!("```\n![]({})\n```\ntext ![]({}) here", path, path);
+
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 3, 0),
+            Some(format!("```\n![]({})\n```\ntext  here", path))
+        );
+    }
+
+    /// 同じ行にコードスパン（`` `...` ``）内の画像記法もどきと実画像が同居していても、
+    /// コードスパン内は occurrence に数えない（実際に <img> として描画されるものだけを数える、
+    /// フロントの imageOccurrenceInLine と同じ定義に揃える）。
+    #[test]
+    fn remove_image_occurrence_skips_code_span_when_counting_occurrence() {
+        let path = uuid_image_path(1);
+        let content = format!("`![]({})` と ![]({})", path, path);
+
+        // occurrence 0 は「実際に描画される」方（コードスパンの外）を指す
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some(format!("`![]({})` と ", path))
+        );
+        // コードスパン内は数えないので occurrence 1 は存在しない
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_keeps_other_images_untouched() {
+        let (p1, p2) = (uuid_image_path(1), uuid_image_path(2));
+        let content = format!("![]({})\n![]({})", p1, p2);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &p1, 0, 0),
+            Some(format!("![]({})", p2))
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_no_match_in_line_returns_none() {
+        let path = uuid_image_path(1);
+        let content = "plain text without images".to_string();
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            None
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_out_of_range_line_returns_none() {
+        let path = uuid_image_path(1);
+        let content = format!("![]({})", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 5, 0),
+            None
+        );
+    }
+
+    /// occurrence が実在しない（呼び出し元が古い content を基に指定した等）場合は
+    /// 何も取り除かず None を返す。
+    #[test]
+    fn remove_image_occurrence_nonexistent_occurrence_returns_none() {
+        let path = uuid_image_path(1);
+        let content = format!("text ![]({})", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 1),
+            None
+        );
+    }
+
+    /// 行が画像記法だけで構成されていても、occurrence が 0 以外なら（呼び出し元の状態が
+    /// ずれている）取り除かない。
+    #[test]
+    fn remove_image_occurrence_image_only_line_with_nonzero_occurrence_returns_none() {
+        let path = uuid_image_path(1);
+        let content = format!("![]({})", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 1),
+            None
+        );
+    }
+
+    /// 行が画像記法だけで構成されていても、対象と別のパスなら行ごと消さない。
+    #[test]
+    fn remove_image_occurrence_image_only_line_of_different_path_untouched() {
+        let (p1, p2) = (uuid_image_path(1), uuid_image_path(2));
+        let content = format!("![]({})", p1);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &p2, 0, 0),
+            None
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_sole_image_only_line_becomes_empty_string() {
+        let path = uuid_image_path(1);
+        let content = format!("![]({})", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some(String::new())
+        );
+    }
+
+    /// 行全体が前後空白＋画像記法だけなら image-only 行として丸ごと消える
+    /// （strip_image_ref_occurrence 側の「混在行の空白だけ残る」経路は通らない）。
+    #[test]
+    fn remove_image_occurrence_whitespace_padded_image_only_line_is_dropped() {
+        let path = uuid_image_path(1);
+        let content = format!("  ![]({})  ", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some(String::new())
+        );
+    }
+
+    #[test]
+    fn remove_image_occurrence_does_not_panic_on_multibyte_content() {
+        let path = uuid_image_path(1);
+        let content = format!("日本語のテキスト ![説明]({}) さらに続く文章", path);
+        assert_eq!(
+            remove_image_occurrence_from_content(&content, &path, 0, 0),
+            Some("日本語のテキスト  さらに続く文章".to_string())
+        );
     }
 
     // ── gc_images ──

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -112,6 +112,7 @@ const I18N_TABLE = {
   toastDeleteFailed: { ja: '付箋の削除に失敗しました', en: 'Failed to delete note' },
   toastImageDropUnsupported: { ja: '画像として扱えないファイルです', en: 'This file cannot be added as an image' },
   toastOpenImageFailed: { ja: '画像を開けませんでした', en: 'Failed to open the image' },
+  toastDeleteImageFailed: { ja: '画像の削除に失敗しました', en: 'Failed to delete the image' },
   imageOpenHint: { ja: 'ダブルクリックで開く', en: 'Double-click to open' },
 };
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -113,6 +113,8 @@ const I18N_TABLE = {
   toastImageDropUnsupported: { ja: '画像として扱えないファイルです', en: 'This file cannot be added as an image' },
   toastOpenImageFailed: { ja: '画像を開けませんでした', en: 'Failed to open the image' },
   toastDeleteImageFailed: { ja: '画像の削除に失敗しました', en: 'Failed to delete the image' },
+  toastCopyImageFailed: { ja: '画像のコピーに失敗しました', en: 'Failed to copy the image' },
+  toastCutImageFailed: { ja: '画像のカットに失敗しました', en: 'Failed to cut the image' },
   imageOpenHint: { ja: 'ダブルクリックで開く', en: 'Double-click to open' },
 };
 

--- a/src/note-lines.js
+++ b/src/note-lines.js
@@ -63,7 +63,23 @@ function isEmptyListItem(lineText) {
 /** 打ち終えたチェックボックス記法。`- [ ] ` へ補完する対象を拾う。 */
 const CHECKBOX_RE = /^([-*])\s?\[([xX]?)\]$/;
 
+// `save_pasted_image`（Rust 側）が生成するパスの形状（`images/<uuid v4>.<ext>`）と対応させる。
+// note.js の IMAGE_REL_PATH_RE と同じ形状だが、ここでは行全体が画像記法 1 個だけ
+// （前後は空白のみ）であることまで見る必要があるため、行頭・行末アンカー込みで別に持つ。
+const IMAGE_ONLY_LINE_RE = /^\s*!\[[^\]]*\]\(images\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpe?g|gif|webp)\)\s*$/i;
+
+/**
+ * 行の内容が画像記法 1 個（`![alt|width](images/...)` 形式、前後は空白のみ）だけで
+ * 構成されているか。true の行は生表示に入れず、選択状態で操作する。
+ * テキストと画像が混在する行・複数画像を含む行・リモート URL の画像は対象外（false）。
+ */
+function isImageOnlyLine(lineText) {
+  return IMAGE_ONLY_LINE_RE.test(lineText);
+}
+
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
-  module.exports = { blockOffset, markerLength, getAutoPrefix, isEmptyListItem, CHECKBOX_RE };
+  module.exports = {
+    blockOffset, markerLength, getAutoPrefix, isEmptyListItem, CHECKBOX_RE, isImageOnlyLine,
+  };
 }

--- a/src/note.html
+++ b/src/note.html
@@ -252,6 +252,12 @@
     outline-offset: 1px;
     box-shadow: 0 0 0 1px rgba(10, 132, 255, 0.35);
   }
+  /* 選択状態は DOM 選択（Range）を画像に張って作る（⌘C/⌘X をネイティブ Edit メニュー経由で
+     機能させるための仕掛け）。ブラウザ既定の選択ハイライト（青みがかった網掛け）が
+     .img-selected の枠と二重に見えないよう透明化する */
+  #markdown-view img.img-selected::selection {
+    background: transparent;
+  }
   /* 画像ホバー時に右下へ出すリサイズハンドル。共有 1 要素を画像ごとに位置だけ動かして使い回す。
      mdView.innerHTML の再描画（renderAll）で消されないよう、mdView の外（body 直下）に置く。
      position: fixed でビューポート座標に直接置くので、mdView のスクロール位置の影響を受けない */

--- a/src/note.html
+++ b/src/note.html
@@ -245,6 +245,13 @@
     cursor: pointer;
     filter: brightness(0.94);
   }
+  /* クリック選択（画像を選んで Backspace/Delete で削除できる状態）。ホバー枠より太く、
+     ノートの配色（--bar）に依存しない固定色にして、どの付箋の色でも視認できるようにする */
+  #markdown-view img.img-selected {
+    outline: 3px solid #0a84ff;
+    outline-offset: 1px;
+    box-shadow: 0 0 0 1px rgba(10, 132, 255, 0.35);
+  }
   /* 画像ホバー時に右下へ出すリサイズハンドル。共有 1 要素を画像ごとに位置だけ動かして使い回す。
      mdView.innerHTML の再描画（renderAll）で消されないよう、mdView の外（body 直下）に置く。
      position: fixed でビューポート座標に直接置くので、mdView のスクロール位置の影響を受けない */

--- a/src/note.js
+++ b/src/note.js
@@ -270,17 +270,35 @@ function buildImagePreview(block) {
 // imageOccurrenceInLine と同じ考え方）。
 let selectedImage = null;
 
-/** 選択を解除し、ハイライト用クラスも剥がす。 */
+/** 選択を解除し、ハイライト用クラスと DOM 選択（Range）も剥がす。 */
 function clearImageSelection() {
   if (!selectedImage) return;
   selectedImage = null;
   // querySelectorAll で念のため複数剥がす（1 画像のみの不変条件を守る側の防御）
   mdView.querySelectorAll('.img-selected').forEach(el => el.classList.remove('img-selected'));
+  // 画像に張った DOM 選択も一緒に外す（張ったままだと次に別行を生表示するときに
+  // 「範囲選択中は生表示に入らない」ガードへ誤って引っかかる）
+  const sel = window.getSelection();
+  if (sel.rangeCount) sel.removeAllRanges();
 }
 
 /**
- * selectedImage が指す img 要素に選択枠（.img-selected）を付け直す。renderAll() の直後
- * （mdView.innerHTML を丸ごと差し替えた直後）に呼び、選択状態を新しい DOM へ引き継ぐ。
+ * img 要素を DOM 選択（Range）で覆う。ネイティブの Edit メニュー（PredefinedMenuItem::copy/cut）
+ * は「テキスト選択が無いと項目自体が無効」になり keydown も届かないため、⌘C/⌘X をメニュー経由で
+ * 機能させるには DOM 選択を張って項目を有効化しておく必要がある。実際のコピー/カット処理は
+ * document の copy/cut イベント（copySelectedImage 等）で拾う。
+ */
+function selectImageRange(img) {
+  const range = document.createRange();
+  range.selectNode(img);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+/**
+ * selectedImage が指す img 要素に選択枠（.img-selected）と DOM 選択を付け直す。renderAll() の
+ * 直後（mdView.innerHTML を丸ごと差し替えた直後）に呼び、選択状態を新しい DOM へ引き継ぐ。
  * 対象がもう存在しない（行が消えた・画像が無くなった等）場合は選択そのものを解除する。
  */
 function applySelectionHighlight() {
@@ -292,6 +310,7 @@ function applySelectionHighlight() {
   const img = imgs[selectedImage.occurrence];
   if (!img) { selectedImage = null; return; }
   img.classList.add('img-selected');
+  selectImageRange(img);
 }
 
 /** 行テキスト中で最初に出てくる画像記法の src を取り出す。無ければ null。 */
@@ -1322,7 +1341,14 @@ for (const type of ['cut', 'paste', 'drop']) {
 // 削除処理中の多重発火ガード（キーリピートでの確認ダイアログ多重表示・二重削除を防ぐ）
 let deletingImage = false;
 
-async function deleteSelectedImage(key) {
+/**
+ * 選択中の画像を取り除く共通処理。`cmd` は 'delete_image'（Backspace/Delete、
+ * confirm_before_delete に従う）または 'cut_image'（⌘X、コピー成功後に確認なしで削除）。
+ * どちらも Rust 側が新しい content（`Option<String>`）を返し、成功時はここで
+ * rawContent に反映してキャレットを置く。`preferredLineAfter` は削除後のキャレット候補行
+ * （行番号が無効なら末尾へフォールバックする）。
+ */
+async function removeSelectedImage(cmd, preferredLineAfter, failMessageKey) {
   if (!selectedImage || deletingImage) return;
   deletingImage = true;
   try {
@@ -1335,15 +1361,15 @@ async function deleteSelectedImage(key) {
     const { line, occurrence, relSrc } = selectedImage;
     let newContent;
     try {
-      newContent = await invoke('delete_image', {
+      newContent = await invoke(cmd, {
         id: noteId,
         imagePath: relSrc,
         imageLine: line,
         imageOccurrence: occurrence,
       });
     } catch (err) {
-      console.error('delete_image failed:', err);
-      showToast(I18N.t('toastDeleteImageFailed'));
+      console.error(`${cmd} failed:`, err);
+      showToast(I18N.t(failMessageKey));
       return;
     }
     // キャンセル（confirm_before_delete で拒否）・対象が既に無い場合は選択を保ったまま何もしない
@@ -1352,16 +1378,40 @@ async function deleteSelectedImage(key) {
     rawContent = newContent;
     renderAll();
     const lines = getLines();
-    // 削除後のキャレット位置: 来た方向（押されたキー）の逆側優先。Backspace は前の行
-    // （mergeLine の「前の行へ戻る」と同じ向き）。先頭行を消した場合は前が無いので
-    // 先頭（0）に留まる（末尾へは飛ばさない）。Delete はそのまま同じ index
-    // （消えた行の次が繰り上がってくる）。それも無ければ末尾へ
-    const preferred = key === 'Backspace' ? Math.max(0, line - 1) : line;
+    const preferred = preferredLineAfter(line);
     const target = (preferred >= 0 && preferred < lines.length) ? preferred : lines.length - 1;
     enterLine(target, null);
   } finally {
     deletingImage = false;
   }
+}
+
+function deleteSelectedImage(key) {
+  // 削除後のキャレット位置: 来た方向（押されたキー）の逆側優先。Backspace は前の行
+  // （mergeLine の「前の行へ戻る」と同じ向き）。先頭行を消した場合は前が無いので
+  // 先頭（0）に留まる（末尾へは飛ばさない）。Delete はそのまま同じ index
+  // （消えた行の次が繰り上がってくる）。それも無ければ末尾へ
+  const preferredLineAfter = (line) => key === 'Backspace' ? Math.max(0, line - 1) : line;
+  return removeSelectedImage('delete_image', preferredLineAfter, 'toastDeleteImageFailed');
+}
+
+/** ⌘C。選択中の画像をクリップボードへコピーする。選択は維持する。 */
+async function copySelectedImage() {
+  if (!selectedImage) return;
+  try {
+    await invoke('copy_image', { imagePath: selectedImage.relSrc });
+  } catch (err) {
+    console.error('copy_image failed:', err);
+    showToast(I18N.t('toastCopyImageFailed'));
+  }
+}
+
+/**
+ * ⌘X。選択中の画像をカット（コピー→削除）する。
+ * キャレット配置は Backspace と同じ（前の行優先、先頭行なら先頭に留まる）。
+ */
+function cutSelectedImage() {
+  return removeSelectedImage('cut_image', (line) => Math.max(0, line - 1), 'toastCutImageFailed');
 }
 
 document.addEventListener('keydown', (e) => {
@@ -1385,9 +1435,14 @@ document.addEventListener('keydown', (e) => {
   }
   if (e.key === 'Backspace' || e.key === 'Delete') {
     e.preventDefault();
+    if (e.repeat) return; // 押しっぱなしでの多重削除・確認ダイアログ多重表示を防ぐ
     deleteSelectedImage(e.key);
     return;
   }
+  // ⌘C/⌘X はここでは拾わない。実アプリではネイティブ Edit メニューの
+  // PredefinedMenuItem::copy/cut がショートカットを先取りし、DOM の keydown まで
+  // 届かないため（メニュー項目は DOM 選択が無いと無効化もされる）。DOM 選択を張った上で
+  // document の copy/cut イベント（下記）を拾う経路に一本化する
   if (e.key === 'Enter') {
     e.preventDefault();
     // Enter は画像の行の直下、Shift+Enter は直上に空行を挿入し、そこへキャレットを置く
@@ -1410,6 +1465,22 @@ document.addEventListener('mousedown', (e) => {
   if (!selectedImage) return;
   if (e.target.closest('.img-selected') || e.target.closest('.img-resize-handle')) return;
   clearImageSelection();
+});
+
+// 画像選択中の ⌘C/⌘X はネイティブ Edit メニューのショートカットとして処理される
+// （keydown まで届かない）。selectImage が張った DOM 選択のおかげでメニュー項目が有効になり、
+// メニュー経由の Copy/Cut が WebKit の copy/cut イベントとして DOM に届く。selectedImage が
+// 無いとき（通常のテキスト選択）は preventDefault せず、ブラウザ既定のコピー/カットに任せる
+document.addEventListener('copy', (e) => {
+  if (!selectedImage) return;
+  e.preventDefault();
+  copySelectedImage();
+});
+
+document.addEventListener('cut', (e) => {
+  if (!selectedImage) return;
+  e.preventDefault();
+  cutSelectedImage();
 });
 
 // ── Drag Window ───────────────────────────────────

--- a/src/note.js
+++ b/src/note.js
@@ -159,6 +159,7 @@ function renderAll() {
   // （放置すると detached な img へ書き込む・別画像の上にハンドルが残る事故になる）
   hideHandle();
   mdView.innerHTML = renderMarkdown(rawContent);
+  applySelectionHighlight();
 }
 
 /** 行 lineIdx を含む描画済みブロックを返す。フェンスは複数行を 1 ブロックとして持つ。 */
@@ -261,6 +262,61 @@ function buildImagePreview(block) {
   return preview;
 }
 
+// ── Image Selection ───────────────────────────────
+// 画像のみの行（前後空白のみの `![alt|width](images/...)`）は生表示に入らず、代わりに
+// 「選択状態」を持つ（enterLine が唯一の入口）。選択は 1 画像のみ（複数選択なし）で、
+// { line, occurrence, relSrc } を保持する。line/occurrence は Rust 側の画像削除
+// （`delete_image` コマンド）が対象を 1 箇所だけに絞るのと同じ単位（rewriteImageWidth /
+// imageOccurrenceInLine と同じ考え方）。
+let selectedImage = null;
+
+/** 選択を解除し、ハイライト用クラスも剥がす。 */
+function clearImageSelection() {
+  if (!selectedImage) return;
+  selectedImage = null;
+  // querySelectorAll で念のため複数剥がす（1 画像のみの不変条件を守る側の防御）
+  mdView.querySelectorAll('.img-selected').forEach(el => el.classList.remove('img-selected'));
+}
+
+/**
+ * selectedImage が指す img 要素に選択枠（.img-selected）を付け直す。renderAll() の直後
+ * （mdView.innerHTML を丸ごと差し替えた直後）に呼び、選択状態を新しい DOM へ引き継ぐ。
+ * 対象がもう存在しない（行が消えた・画像が無くなった等）場合は選択そのものを解除する。
+ */
+function applySelectionHighlight() {
+  if (!selectedImage) return;
+  const lineEl = mdView.querySelector(`[data-line="${selectedImage.line}"]`);
+  if (!lineEl) { selectedImage = null; return; }
+  const imgs = Array.from(lineEl.querySelectorAll('img[data-rel-src]'))
+    .filter(el => el.dataset.relSrc === selectedImage.relSrc);
+  const img = imgs[selectedImage.occurrence];
+  if (!img) { selectedImage = null; return; }
+  img.classList.add('img-selected');
+}
+
+/** 行テキスト中で最初に出てくる画像記法の src を取り出す。無ければ null。 */
+function firstImageRelSrc(lineText) {
+  const m = lineText.match(/!\[[^\]]*\]\(([^)\s]+)\)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * 行 line の occurrence 番目（relSrc と一致する画像のうち何番目か。imageOccurrenceInLine と
+ * 同じ定義）の画像を選択状態にする。relSrc は呼び出し元が特定して渡す（行テキストを
+ * 記法の出現順に数え直すと、混在する別画像の occurrence 定義とずれるため、ここでは数え直さない）。
+ * 生表示中なら書き戻して閉じる。
+ */
+function selectImage(line, occurrence, relSrc) {
+  commitActive();
+  // 選択は 1 画像のみ。次の選択を立てる前に必ず前の選択を解除する
+  // （↑↓ で画像のみの行から画像のみの行へ直接移る経路は enterLine の
+  // 「非画像なら clearImageSelection」を通らないため、ここで解除しないと 2 つ同時に残る）
+  clearImageSelection();
+  if (!relSrc || !isValidImageRelPath(relSrc)) return;
+  selectedImage = { line, occurrence, relSrc };
+  applySelectionHighlight();
+}
+
 /** 行 lineIdx を生 Markdown に差し替え、col 列にキャレットを置く（col が null なら行末）。 */
 function enterLine(lineIdx, col) {
   commitActive();
@@ -270,6 +326,15 @@ function enterLine(lineIdx, col) {
   const lines = getLines();
   const i = Math.max(0, Math.min(lineIdx, lines.length - 1));
   const block = findBlock(i);
+  // 画像のみの行は生表示に入らず、選択状態になる（enterLine の入口での唯一の関所）。
+  // ただし未終端フェンスの中では行の見た目が画像のみでも実際には画像として描画されない
+  // （<pre> の中の生テキスト）ため、単独ブロック（フェンスでない）のときだけ対象にする
+  const isStandalone = !block || block.start === block.end;
+  if (isStandalone && isImageOnlyLine(lines[i] ?? '')) {
+    selectImage(i, 0, firstImageRelSrc(lines[i]));
+    return;
+  }
+  clearImageSelection();
   activeStart = block ? block.start : i;
   activeEnd = block ? block.end : i;
 
@@ -362,19 +427,34 @@ mdView.addEventListener('mouseup', (e) => {
   // 無視しないと「余白クリック」扱いになり、キャレットが最終行へ飛んでしまう
   if (e.target.closest('.raw-editor-preview')) return;
   if (e.target.closest('.raw-editor')) return;
-  if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]') || e.target.closest('img')) return;
+  // リンクの中（画像を包むリンクも含む）はリンク側のクリック処理に一本化する
+  if (e.target.closest('a[data-url]') || e.target.closest('input[type="checkbox"]')) return;
   // 範囲選択したときは生表示に入らない（コピーの邪魔をしない）
   if (!window.getSelection().isCollapsed) return;
+
+  // 画像本体のクリックは選択状態にする（ダブルクリックで開く・右クリックメニュー・
+  // リサイズハンドルとは独立に共存する）
+  const img = e.target.closest('img[data-rel-src]');
+  if (img) {
+    const relSrc = img.dataset.relSrc;
+    const lineEl = img.closest('[data-line]');
+    if (isValidImageRelPath(relSrc) && lineEl) {
+      selectImage(Number(lineEl.dataset.line), imageOccurrenceInLine(lineEl, img, relSrc), relSrc);
+    }
+    return;
+  }
 
   const el = e.target.closest('[data-line]');
   const lines = getLines();
   if (!el) {
-    enterLine(lines.length - 1, null); // 余白クリックは最終行の行末へ
+    // 余白クリックは最終行の行末へ。最終行が画像のみの行なら enterLine が選択状態にする
+    enterLine(lines.length - 1, null);
     return;
   }
   // フェンスは行単位のマッピングを持たないので末尾に置く
   if (el.dataset.lineEnd != null) { enterLine(Number(el.dataset.lineEnd), null); return; }
   const lineIdx = Number(el.dataset.line);
+  // 画像のみの行の余白クリックも enterLine が選択状態にする
   enterLine(lineIdx, rawColFromPoint(el, lines[lineIdx] ?? '', e));
 });
 
@@ -493,10 +573,32 @@ resizeHandle.addEventListener('mouseleave', (e) => {
 // スクロールすると画像とハンドルの対応がずれるので、位置合わせをやり直す前提で一旦隠す
 mdView.addEventListener('scroll', () => hideHandle());
 
+/**
+ * line 中でバッククォート 1 組（`...`）に囲まれた区間（開始・終了のバッククォートを含む）を
+ * 列挙する。markdown.js の inlineMarkdown が code を先に保護してから画像記法を解釈するのと
+ * 同じ解釈で、区間内の `![alt](src)` は画像記法として数えない（occurrence の定義を DOM 側
+ * ＝実際に <img> として描画されるものと一致させる）。
+ */
+function codeSpanRanges(line) {
+  const ranges = [];
+  const re = /`[^`]+`/g;
+  let m;
+  while ((m = re.exec(line))) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+function isInCodeSpan(ranges, pos) {
+  return ranges.some(([start, end]) => pos >= start && pos < end);
+}
+
 /** 行 lineIdx の Markdown 記法のうち、relSrc と一致する occurrence 番目（0始まり）の画像記法だけ `|width` を追加・置換する。 */
 function rewriteImageWidth(line, relSrc, width, occurrence) {
+  const codeSpans = codeSpanRanges(line);
   let seen = -1;
-  return line.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (whole, alt, src) => {
+  return line.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (whole, alt, src, offset) => {
+    if (isInCodeSpan(codeSpans, offset)) return whole;
     if (src !== relSrc) return whole;
     seen++;
     if (seen !== occurrence) return whole;
@@ -1102,6 +1204,10 @@ function bindEditor(ed) {
     if (composing || e.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter') {
       e.preventDefault();
+      // 分割結果の新しい行が画像のみの行になり enterLine が選択状態にすることがある
+      // （selectImage が selectedImage を立てる）。この 1 回の keydown が document まで
+      // 伝播すると、画像選択用のキー処理が同じキーで二重発火してしまうため止める
+      e.stopPropagation();
       splitLine(ed);
       return;
     }
@@ -1124,19 +1230,23 @@ function bindEditor(ed) {
     }
     if (e.key === 'ArrowUp' && activeStart > 0) {
       const { line, col } = caretLineCol(ed);
-      if (line === activeStart) { e.preventDefault(); enterLine(activeStart - 1, col); }
+      // 移動先が画像のみの行なら enterLine が選択状態に切り替える（スキップはしない）。
+      // selectedImage を立てる呼び出しなので、後段の画像選択用キー処理へ二重に届かせない
+      if (line === activeStart) { e.preventDefault(); e.stopPropagation(); enterLine(activeStart - 1, col); }
       return;
     }
     if (e.key === 'ArrowDown') {
       const { line, col } = caretLineCol(ed);
       if (line === activeEnd && activeEnd < getLines().length - 1) {
         e.preventDefault();
+        e.stopPropagation();
         enterLine(activeEnd + 1, col);
       }
       return;
     }
     if ((e.key === 'Backspace' || e.key === 'Delete') && window.getSelection().isCollapsed) {
-      if (mergeLine(ed, e.key === 'Backspace')) e.preventDefault();
+      // 結合結果の行が画像のみの行になり enterLine が選択状態にすることがある。同じ理由で止める
+      if (mergeLine(ed, e.key === 'Backspace')) { e.preventDefault(); e.stopPropagation(); }
     }
   });
 
@@ -1204,6 +1314,103 @@ for (const type of ['cut', 'paste', 'drop']) {
     e.stopPropagation();
   }, true);
 }
+
+// ── Image Selection: keyboard ──────────────────────
+// 画像選択中は生エディタが無い（フォーカス先の contenteditable が存在しない）ため、
+// document レベルの keydown で拾う。selectedImage が無いときは即 return するので、
+// 色ドットの矢印キーナビゲーションや ⌘W 等、他のキー処理とは衝突しない。
+// 削除処理中の多重発火ガード（キーリピートでの確認ダイアログ多重表示・二重削除を防ぐ）
+let deletingImage = false;
+
+async function deleteSelectedImage(key) {
+  if (!selectedImage || deletingImage) return;
+  deletingImage = true;
+  try {
+    // 別行の未保存入力（デバウンス窓の中）が残っていると、Rust 側は古い content を基に
+    // 削除後の内容を計算してしまい、その戻り値で rawContent を丸ごと置き換えるときに
+    // 未保存分が黙って消える。削除対象を Rust に渡す前に必ず確定させる
+    await flushContent();
+    // flush の await 中に選択が変わった／消えた可能性を考慮し、ここで再確認する
+    if (!selectedImage) return;
+    const { line, occurrence, relSrc } = selectedImage;
+    let newContent;
+    try {
+      newContent = await invoke('delete_image', {
+        id: noteId,
+        imagePath: relSrc,
+        imageLine: line,
+        imageOccurrence: occurrence,
+      });
+    } catch (err) {
+      console.error('delete_image failed:', err);
+      showToast(I18N.t('toastDeleteImageFailed'));
+      return;
+    }
+    // キャンセル（confirm_before_delete で拒否）・対象が既に無い場合は選択を保ったまま何もしない
+    if (newContent == null) return;
+    clearImageSelection();
+    rawContent = newContent;
+    renderAll();
+    const lines = getLines();
+    // 削除後のキャレット位置: 来た方向（押されたキー）の逆側優先。Backspace は前の行
+    // （mergeLine の「前の行へ戻る」と同じ向き）。先頭行を消した場合は前が無いので
+    // 先頭（0）に留まる（末尾へは飛ばさない）。Delete はそのまま同じ index
+    // （消えた行の次が繰り上がってくる）。それも無ければ末尾へ
+    const preferred = key === 'Backspace' ? Math.max(0, line - 1) : line;
+    const target = (preferred >= 0 && preferred < lines.length) ? preferred : lines.length - 1;
+    enterLine(target, null);
+  } finally {
+    deletingImage = false;
+  }
+}
+
+document.addEventListener('keydown', (e) => {
+  if (!selectedImage) return;
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    clearImageSelection();
+    return;
+  }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    // 選択を解除して隣の行へ（隣も画像のみの行なら enterLine が連続して選択状態にする）。
+    // 端で行が無ければ選択を維持する（何もしない）
+    if (selectedImage.line > 0) enterLine(selectedImage.line - 1, null);
+    return;
+  }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (selectedImage.line < getLines().length - 1) enterLine(selectedImage.line + 1, null);
+    return;
+  }
+  if (e.key === 'Backspace' || e.key === 'Delete') {
+    e.preventDefault();
+    deleteSelectedImage(e.key);
+    return;
+  }
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    // Enter は画像の行の直下、Shift+Enter は直上に空行を挿入し、そこへキャレットを置く
+    // （画像が先頭行でも Shift+Enter で上に行を作れるよう、挿入位置は画像の行インデックス自体）。
+    // applyLines が rawContent 更新 → renderAll → enterLine → scheduleSave の順で
+    // 行挿入の作法（splitLine 等）に揃えて処理する
+    const lines = getLines();
+    const insertAt = e.shiftKey ? selectedImage.line : selectedImage.line + 1;
+    lines.splice(insertAt, 0, '');
+    clearImageSelection();
+    applyLines(lines, insertAt, 0);
+  }
+  // その他の印字キーは何もしない
+});
+
+// 別の場所をクリックすると選択解除（選択中の画像自身・リサイズハンドルへのクリックは除く。
+// mousedown で先に消しておくことで、別画像をクリックした場合も mouseup 側の選択処理と
+// 素直に入れ替わる）
+document.addEventListener('mousedown', (e) => {
+  if (!selectedImage) return;
+  if (e.target.closest('.img-selected') || e.target.closest('.img-resize-handle')) return;
+  clearImageSelection();
+});
 
 // ── Drag Window ───────────────────────────────────
 titlebar.addEventListener('mousedown', (e) => {

--- a/tests/unit/note-lines.test.js
+++ b/tests/unit/note-lines.test.js
@@ -7,6 +7,7 @@ const {
   getAutoPrefix,
   isEmptyListItem,
   CHECKBOX_RE,
+  isImageOnlyLine,
 } = require("../../src/note-lines.js");
 
 describe("getAutoPrefix", () => {
@@ -261,5 +262,74 @@ describe("blockOffset", () => {
 
   test("空行も改行 1 文字として数える", () => {
     assert.equal(blockOffset(["", "x"], 1, 1), 2);
+  });
+});
+
+describe("isImageOnlyLine", () => {
+  const PATH = "images/00000000-0000-4000-8000-000000000001.png";
+
+  test("画像記法だけの行 → true", () => {
+    assert.equal(isImageOnlyLine(`![](${PATH})`), true);
+  });
+
+  test("alt 付き → true", () => {
+    assert.equal(isImageOnlyLine(`![説明](${PATH})`), true);
+  });
+
+  test("幅指定付き → true", () => {
+    assert.equal(isImageOnlyLine(`![|300](${PATH})`), true);
+  });
+
+  test("alt + 幅指定付き → true", () => {
+    assert.equal(isImageOnlyLine(`![説明|300](${PATH})`), true);
+  });
+
+  test("前後に空白のみ → true", () => {
+    assert.equal(isImageOnlyLine(`  ![](${PATH})  `), true);
+  });
+
+  test("拡張子違い（jpg/jpeg/gif/webp）も true", () => {
+    for (const ext of ["jpg", "jpeg", "gif", "webp"]) {
+      const path = `images/00000000-0000-4000-8000-000000000001.${ext}`;
+      assert.equal(isImageOnlyLine(`![](${path})`), true, ext);
+    }
+  });
+
+  test("テキストと混在 → false", () => {
+    assert.equal(isImageOnlyLine(`text ![](${PATH})`), false);
+    assert.equal(isImageOnlyLine(`![](${PATH}) text`), false);
+  });
+
+  test("複数画像 → false", () => {
+    assert.equal(isImageOnlyLine(`![](${PATH})![](${PATH})`), false);
+  });
+
+  test("リモート URL の画像 → false（images/ 相対パスのみ対象）", () => {
+    assert.equal(isImageOnlyLine("![](https://example.com/pic.png)"), false);
+  });
+
+  test("プレーンテキスト → false", () => {
+    assert.equal(isImageOnlyLine("plain text"), false);
+  });
+
+  test("空行 → false", () => {
+    assert.equal(isImageOnlyLine(""), false);
+  });
+
+  test("alt が「リンク」を含む文字列でも、リンクではなく画像記法単体なら true", () => {
+    // alt はただの文字列。「リンク先」という語が入っていても記法自体は ![alt](images/...) のまま
+    assert.equal(isImageOnlyLine(`![リンク先](${PATH})`), true);
+  });
+
+  test("リンクで包まれた画像（[![](p)](url)）は画像記法単体ではないので false", () => {
+    assert.equal(isImageOnlyLine(`[![](${PATH})](https://example.com)`), false);
+  });
+
+  test("不正な uuid 形状のパス → false", () => {
+    assert.equal(isImageOnlyLine("![](images/not-a-uuid.png)"), false);
+  });
+
+  test("パストラバーサル細工 → false", () => {
+    assert.equal(isImageOnlyLine("![](images/../notes.json)"), false);
   });
 });

--- a/tests/unit/tauri-commands.test.js
+++ b/tests/unit/tauri-commands.test.js
@@ -27,14 +27,25 @@ function mockCommands() {
     .filter((c) => !c.startsWith("plugin:"));
 }
 
-/** src/*.js が invoke / fireInvoke に渡すコマンド名リテラル。plugin 呼び出しは対象外。 */
+/**
+ * src/*.js が invoke / fireInvoke / removeSelectedImage に渡すコマンド名リテラル。
+ * plugin 呼び出しは対象外。removeSelectedImage(cmd, ...) は画像の削除/カットで
+ * 'delete_image' / 'cut_image' を渡す呼び出し元（note.js）で、invoke を直接は呼ばず
+ * removeSelectedImage 内部で invoke するため、invoke/fireInvoke だけを見る抽出だと漏れる。
+ */
 function invokedCommands() {
   const names = new Set();
+  const patterns = [
+    /(?:invoke|fireInvoke)\(\s*['"]([^'"]+)['"]/g,
+    /removeSelectedImage\(\s*['"]([^'"]+)['"]/g,
+  ];
   for (const f of fs.readdirSync(path.join(root, "src"))) {
     if (!f.endsWith(".js")) continue;
     const src = read(path.join("src", f));
-    for (const m of src.matchAll(/(?:invoke|fireInvoke)\(\s*['"]([^'"]+)['"]/g)) {
-      if (!m[1].startsWith("plugin:")) names.add(m[1]);
+    for (const re of patterns) {
+      for (const m of src.matchAll(re)) {
+        if (!m[1].startsWith("plugin:")) names.add(m[1]);
+      }
     }
   }
   return [...names];
@@ -46,6 +57,13 @@ describe("Tauri コマンド名の照合", () => {
   test("抽出の空振り検知: 登録一覧が取れている", () => {
     assert.ok(handlers.includes("get_note"));
     assert.ok(handlers.length >= 10, `抽出できたのは ${handlers.length} 件だけ`);
+  });
+
+  test("抽出の空振り検知: removeSelectedImage 経由の delete_image が抽出できている", () => {
+    assert.ok(
+      invokedCommands().includes("delete_image"),
+      "removeSelectedImage('delete_image', ...) 形の呼び出しが抽出されていない",
+    );
   });
 
   test("モックの分岐は実在するコマンドだけを持つ", () => {

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -52,6 +52,7 @@ export async function injectNoteMock(
         case "save_pasted_image":     return "images/00000000-0000-4000-8000-000000000001.png";
         case "show_context_menu":     return null;
         case "open_image":            return null;
+        case "delete_image":          return null;
         default:                      return null;
       }
     };

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -53,6 +53,8 @@ export async function injectNoteMock(
         case "show_context_menu":     return null;
         case "open_image":            return null;
         case "delete_image":          return null;
+        case "copy_image":            return null;
+        case "cut_image":             return null;
         default:                      return null;
       }
     };

--- a/tests/visual/image-copy-cut-e2e.spec.ts
+++ b/tests/visual/image-copy-cut-e2e.spec.ts
@@ -1,0 +1,252 @@
+import { test, expect, injectNoteMock, enterEdit, getContent } from "./fixtures";
+
+// 選択中の画像は ⌘C でコピー（選択は維持）、⌘X でコピーしたうえで確認ダイアログ無しに
+// 削除できる。⌘C/⌘X はネイティブ Edit メニューがショートカットを先取りするため keydown
+// では拾えず、メニュー項目も「テキスト選択が無いと無効」になる。そのため selectImage() が
+// 画像に DOM 選択（Range）を張って項目を有効化し、メニュー経由の Copy/Cut を document の
+// copy/cut イベントとして拾う。Playwright にはネイティブ Edit メニューが無いため、ここで
+// 検証できるのは copy/cut イベントが届いた後の分岐だけ。
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+const IMAGE_LINE = `![](${IMAGE_PATH})`;
+
+function selectImageAtLine(page: import("@playwright/test").Page, line: number) {
+  return page.evaluate(
+    (l) => (window as unknown as { enterLine(l: number, c: number | null): void }).enterLine(l, null),
+    line,
+  );
+}
+
+/** document へ copy/cut の ClipboardEvent を dispatch する。戻り値は dispatchEvent の返り値
+ * （cancelable なイベントで preventDefault() が呼ばれていれば false）。 */
+function dispatchClipboardEvent(page: import("@playwright/test").Page, type: "copy" | "cut") {
+  return page.evaluate((t) => {
+    const ev = new ClipboardEvent(t, { bubbles: true, cancelable: true });
+    return document.dispatchEvent(ev);
+  }, type);
+}
+
+/** `cut_image` の戻り値を固定する。それ以外のコマンドは通常どおり処理する。 */
+function mockCutImage(page: import("@playwright/test").Page, result: string | null) {
+  return page.addInitScript((r) => {
+    const prevInvoke = (window as any).__TAURI__.core.invoke;
+    (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+      if (cmd === "cut_image") {
+        (window as any).__captured_invokes?.push({ cmd, args });
+        return r;
+      }
+      return prevInvoke(cmd, args);
+    };
+  }, result);
+}
+
+function capturedCalls(page: import("@playwright/test").Page, cmd: string) {
+  return page.evaluate(
+    (c) => (window as any).__captured_invokes.filter((call: any) => call.cmd === c),
+    cmd,
+  );
+}
+
+/** 現在の DOM 選択が非collapsed で、選択中の画像（.img-selected）を覆っているか。 */
+function domSelectionCoversSelectedImage(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const sel = window.getSelection();
+    const img = document.querySelector("img.img-selected");
+    if (!sel || !img || sel.rangeCount === 0 || sel.isCollapsed) return false;
+    return sel.getRangeAt(0).intersectsNode(img);
+  });
+}
+
+test.describe("選択中の画像を ⌘C / ⌘X でコピー・カットする（DOM copy/cut イベント経由）", () => {
+  test("選択状態になると画像に DOM 選択（Range）が張られる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+
+    expect(await domSelectionCoversSelectedImage(page)).toBe(true);
+
+    await ctx.close();
+  });
+
+  test("Esc で選択解除すると DOM 選択も消える", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    expect(await domSelectionCoversSelectedImage(page)).toBe(true);
+
+    await page.keyboard.press("Escape");
+
+    const rangeCount = await page.evaluate(() => window.getSelection()?.rangeCount ?? 0);
+    expect(rangeCount).toBe(0);
+
+    await ctx.close();
+  });
+
+  test("copy イベント → copy_image が正しい引数で invoke され preventDefault される（選択は維持）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    const notCanceled = await dispatchClipboardEvent(page, "copy");
+    expect(notCanceled).toBe(false); // preventDefault() された
+
+    await expect.poll(async () => (await capturedCalls(page, "copy_image")).length).toBe(1);
+    const calls = await capturedCalls(page, "copy_image");
+    expect(calls[0].args).toEqual({ imagePath: IMAGE_PATH });
+
+    // コピーは選択を解除しない
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("copy_image が失敗（reject）するとトーストが出て選択は維持される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === "copy_image") throw new Error("copy_image failed");
+        return prevInvoke(cmd, args);
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await dispatchClipboardEvent(page, "copy");
+
+    await expect(page.locator(".toast")).toBeVisible();
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await ctx.close();
+  });
+
+  test("cut イベント → cut_image が正しい引数で invoke され preventDefault され、確認なしで消えてキャレットは前の行へ", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` }, {}, { captureInvokes: true });
+    await mockCutImage(page, "text0\ntext2");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+
+    const notCanceled = await dispatchClipboardEvent(page, "cut");
+    expect(notCanceled).toBe(false);
+
+    await expect.poll(async () => (await capturedCalls(page, "cut_image")).length).toBe(1);
+    const calls = await capturedCalls(page, "cut_image");
+    expect(calls[0].args).toMatchObject({ imagePath: IMAGE_PATH, imageLine: 1, imageOccurrence: 0 });
+
+    // 確認ダイアログ相当の待ち合わせ無しに、1 回の invoke で即座に消える
+    await expect.poll(() => getContent(page)).toBe("text0\ntext2");
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    // Backspace と同じキャレット配置（前の行）
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
+  test("cut イベントで先頭行の画像をカット → 前の行が無いので先頭に留まる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${IMAGE_LINE}\ntext1\ntext2` }, {}, { captureInvokes: true });
+    await mockCutImage(page, "text1\ntext2");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 0);
+    await dispatchClipboardEvent(page, "cut");
+
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text1");
+
+    await ctx.close();
+  });
+
+  test("cut_image が失敗（reject）するとトーストが出て選択は維持される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = `text0\n${IMAGE_LINE}`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === "cut_image") throw new Error("cut_image failed (e.g. copy failed)");
+        return prevInvoke(cmd, args);
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await dispatchClipboardEvent(page, "cut");
+
+    await expect(page.locator(".toast")).toBeVisible();
+    expect(await getContent(page)).toBe(content);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await ctx.close();
+  });
+
+  test("生エディタ内の copy では copy_image が割り込まず、内容も変わらない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 画像は選択せず、通常のテキスト行を生表示にする
+    await enterEdit(page, 0);
+    await page.locator("#editor").click();
+    await page.keyboard.press("ControlOrMeta+a"); // 全選択してからコピー
+
+    // 実際のキー操作（selectedImage が無いのでブラウザ既定のコピーに任される経路）
+    await page.keyboard.press("ControlOrMeta+c");
+
+    const copyCalls = await capturedCalls(page, "copy_image");
+    expect(copyCalls.length).toBe(0);
+    // コピーはテキストを変えない
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
+  test("生エディタ内の cut では cut_image が割り込まず、ネイティブのカットでテキストが切り取られる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page, 0);
+    await page.locator("#editor").click();
+    await page.keyboard.press("ControlOrMeta+a"); // 全選択してからカット
+
+    await page.keyboard.press("ControlOrMeta+x");
+
+    const cutCalls = await capturedCalls(page, "cut_image");
+    expect(cutCalls.length).toBe(0);
+    // 割り込まれていなければブラウザ既定のカットが働き、選択していたテキストが切り取られる
+    expect(await page.locator("#editor").textContent()).toBe("");
+
+    await ctx.close();
+  });
+});

--- a/tests/visual/image-delete-e2e.spec.ts
+++ b/tests/visual/image-delete-e2e.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect, injectNoteMock, getContent } from "./fixtures";
+
+// 選択中の画像は Backspace / Delete で削除する。ここではフロントエンドが選択状態からの
+// キー操作をどう `delete_image` invoke に翻訳し、戻り値をどう反映するかを検証する。
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+const IMAGE_LINE = `![](${IMAGE_PATH})`;
+
+/** 生表示を経由せず、選択状態にするための直接呼び出し（画像のみの行なら enterLine が選択する）。 */
+function selectImageAtLine(page: import("@playwright/test").Page, line: number) {
+  return page.evaluate(
+    (l) => (window as unknown as { enterLine(l: number, c: number | null): void }).enterLine(l, null),
+    line,
+  );
+}
+
+/**
+ * `delete_image` の戻り値（または例外）を固定する。それ以外のコマンドは通常どおり処理する。
+ * delayMs を指定すると解決を遅らせる（in-flight 中の多重発火ガードを検証するため）。
+ */
+function mockDeleteImage(
+  page: import("@playwright/test").Page,
+  result: string | null,
+  shouldThrow = false,
+  delayMs = 0,
+) {
+  return page.addInitScript(([r, throwIt, delay]) => {
+    const prevInvoke = (window as any).__TAURI__.core.invoke;
+    (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+      if (cmd === "delete_image") {
+        // captureInvokes の記録はここで肩代わりする（下の分岐は通らないため素通りしない）
+        (window as any).__captured_invokes?.push({ cmd, args });
+        if (delay) await new Promise((res) => setTimeout(res, delay as number));
+        if (throwIt) throw new Error("delete_image failed");
+        return r;
+      }
+      return prevInvoke(cmd, args);
+    };
+  }, [result, shouldThrow, delayMs] as const);
+}
+
+async function lastDeleteImageCall(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const calls = (window as any).__captured_invokes.filter((c: any) => c.cmd === "delete_image");
+    return calls[calls.length - 1]?.args;
+  });
+}
+
+// テスト用の webServer（serve の clean-urls）が `/note.html?id=...` を `/note` へ 301 する際に
+// クエリ文字列を落とすため、この環境では note.js 側の noteId が常に null になる
+// （id を見ないモックの get_note 等では表面化しないが、id をそのまま invoke に渡す
+// delete_image では顕在化する）。id 以外のフィールドで検証する
+function expectDeleteImageArgs(
+  args: unknown,
+  expected: { imagePath: string; imageLine: number; imageOccurrence: number },
+) {
+  expect(args).toMatchObject(expected);
+}
+
+test.describe("選択中の画像を Backspace / Delete で削除する", () => {
+  test("Backspace → delete_image が正しい引数で invoke され、キャレットは前の行へ", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "text0\ntext2");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Backspace");
+
+    await expect.poll(() => lastDeleteImageCall(page)).toBeTruthy();
+    const args = await lastDeleteImageCall(page);
+    expectDeleteImageArgs(args, { imagePath: IMAGE_PATH, imageLine: 1, imageOccurrence: 0 });
+
+    await expect.poll(() => getContent(page)).toBe("text0\ntext2");
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
+  test("Delete → キャレットは（繰り上がった）同じ index の行へ", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "text0\ntext2");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await page.keyboard.press("Delete");
+
+    const args = await lastDeleteImageCall(page);
+    expectDeleteImageArgs(args, { imagePath: IMAGE_PATH, imageLine: 1, imageOccurrence: 0 });
+
+    // 削除後、旧 line2（"text2"）が index 1 に繰り上がる。Delete はその index を優先する
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text2");
+
+    await ctx.close();
+  });
+
+  test("Backspace で先頭行を削除 → 前の行が無いので先頭に留まる（末尾へは飛ばない）", async ({ browser }) => {
+    // 3 行以上のフィクスチャでないと「先頭に留まる」と「末尾へ飛ぶ」の区別がつかない
+    // （2 行だと削除後は 1 行しか残らず、どちらの解釈でも同じ行に着地してしまう）
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${IMAGE_LINE}\ntext1\ntext2` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "text1\ntext2");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 0);
+    await page.keyboard.press("Backspace");
+
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text1");
+
+    await ctx.close();
+  });
+
+  test("delete_image が null（キャンセル）を返すと選択を維持したまま何も変わらない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = `text0\n${IMAGE_LINE}`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, null);
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await page.keyboard.press("Delete");
+
+    await expect.poll(() => lastDeleteImageCall(page)).toBeTruthy();
+    // content は変わらず、選択も解除されない（生表示にも入らない）
+    expect(await getContent(page)).toBe(content);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("delete_image が失敗（reject）するとトーストが出て選択は維持される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = `text0\n${IMAGE_LINE}`;
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, null, true);
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await page.keyboard.press("Backspace");
+
+    await expect(page.locator(".toast")).toBeVisible();
+    expect(await getContent(page)).toBe(content);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await ctx.close();
+  });
+
+  test("混在行の画像も選択して削除できる（occurrence 指定はそのまま）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text ${IMAGE_LINE} 続き` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "text  続き");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 混在行は画像本体クリックで選択する（生表示中の行ではない）
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Delete");
+
+    const args = await lastDeleteImageCall(page);
+    expectDeleteImageArgs(args, { imagePath: IMAGE_PATH, imageLine: 0, imageOccurrence: 0 });
+    await expect.poll(() => getContent(page)).toBe("text  続き");
+
+    await ctx.close();
+  });
+
+  // code-reviewer 指摘の回帰: imageOccurrenceInLine（DOM・relSrc 単位）で選んだ画像を、
+  // 行テキストの通し番号で src を引き直す旧実装だと別の画像を対象にしてしまっていた
+  const IMAGE_PATH_2 = "images/00000000-0000-4000-8000-000000000002.png";
+  test("同じ行に別々の画像2枚 → 2枚目を選択・削除すると正しい方（2枚目）が対象になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(
+      page,
+      { content: `![](${IMAGE_PATH}) ![](${IMAGE_PATH_2})` },
+      {},
+      { captureInvokes: true },
+    );
+    await mockDeleteImage(page, `![](${IMAGE_PATH}) `);
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      document.querySelectorAll("img")[1].dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+    });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    const selectedIsSecond = await page.evaluate(
+      () => document.querySelectorAll("img")[1].classList.contains("img-selected"),
+    );
+    expect(selectedIsSecond).toBe(true);
+
+    await page.keyboard.press("Delete");
+
+    const args = await lastDeleteImageCall(page);
+    expectDeleteImageArgs(args, { imagePath: IMAGE_PATH_2, imageLine: 0, imageOccurrence: 0 });
+    await expect.poll(() => getContent(page)).toBe(`![](${IMAGE_PATH}) `);
+
+    await ctx.close();
+  });
+
+  test("Backspace 連打（in-flight 中）でも delete_image は 1 回しか呼ばれない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "text0", false, 200);
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectImageAtLine(page, 1);
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Backspace"); // in-flight 中の連打（キーリピート相当）
+    await page.keyboard.press("Backspace");
+
+    await page.waitForTimeout(400); // 200ms の遅延 + マージン
+
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "delete_image"),
+    );
+    expect(calls.length).toBe(1);
+
+    await ctx.close();
+  });
+
+  test("削除前に別行の未保存入力を flush する（デバウンス窓での消失防止）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `line0\n${IMAGE_LINE}` }, {}, { captureInvokes: true });
+    await mockDeleteImage(page, "line0X");
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator('[data-line="0"]').click();
+    await page.waitForSelector("#editor", { state: "visible" });
+    await page.locator("#editor").click();
+    await page.keyboard.type("X"); // scheduleSave() の 300ms デバウンスが保留中になる
+
+    // 画像行を選択状態にする（生表示は commit されるが、保存はまだ飛んでいない）
+    await selectImageAtLine(page, 1);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Backspace");
+
+    await expect.poll(() => lastDeleteImageCall(page)).toBeTruthy();
+
+    const calls = await page.evaluate(() => (window as any).__captured_invokes);
+    const updateIdx = calls.findIndex(
+      (c: any) => c.cmd === "update_note_content" && c.args.content === `line0X\n${IMAGE_LINE}`,
+    );
+    const deleteIdx = calls.findIndex((c: any) => c.cmd === "delete_image");
+    expect(updateIdx).toBeGreaterThanOrEqual(0);
+    expect(updateIdx).toBeLessThan(deleteIdx);
+
+    await ctx.close();
+  });
+});

--- a/tests/visual/image-raw-preview-e2e.spec.ts
+++ b/tests/visual/image-raw-preview-e2e.spec.ts
@@ -9,10 +9,13 @@ const LOADED_IMG_SRC =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNDAiIGhlaWdodD0iNjAiPjxyZWN0IHdpZHRoPSIyNDAiIGhlaWdodD0iNjAiIGZpbGw9InJlZCIvPjwvc3ZnPg==";
 
 test.describe("画像行の生表示中プレビュー", () => {
+  // 画像のみの行（前後空白のみ）は生表示に入れない「オブジェクト」として扱う（issue #63 後続）。
+  // このプレビュー自体は「テキストと画像が混在する行」向けの挙動なので、以下のフィクスチャは
+  // すべてテキストと画像を混在させ、対象行が生表示に入れることを前提にしている。
   test("画像行を生表示にすると #editor の直後にプレビューが出る（幅指定も反映）", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
-    await injectNoteMock(page, { content: `![|150](${IMAGE_PATH})` });
+    await injectNoteMock(page, { content: `text ![|150](${IMAGE_PATH})` });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
@@ -48,7 +51,7 @@ test.describe("画像行の生表示中プレビュー", () => {
   test("別の行へ移るとプレビューが消える", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
-    await injectNoteMock(page, { content: `![](${IMAGE_PATH})\ntext` });
+    await injectNoteMock(page, { content: `text0 ![](${IMAGE_PATH})\ntext1` });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
@@ -64,7 +67,7 @@ test.describe("画像行の生表示中プレビュー", () => {
   test("生表示を抜ける（commit）とプレビューが消える", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
-    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` });
+    await injectNoteMock(page, { content: `text ![](${IMAGE_PATH})` });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
@@ -83,7 +86,7 @@ test.describe("画像行の生表示中プレビュー", () => {
   test("プレビューは pointer-events: none で操作対象にならない", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
-    await injectNoteMock(page, { content: `![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await injectNoteMock(page, { content: `text ![](${IMAGE_PATH})` }, {}, { captureInvokes: true });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
@@ -118,7 +121,7 @@ test.describe("画像行の生表示中プレビュー", () => {
   test("プレビュー中央のクリックでは余白クリック扱いにならず最終行へ飛ばない", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
-    await injectNoteMock(page, { content: `![](${IMAGE_PATH})\nline1\nline2` });
+    await injectNoteMock(page, { content: `text ![](${IMAGE_PATH})\nline1\nline2` });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
@@ -135,7 +138,7 @@ test.describe("画像行の生表示中プレビュー", () => {
     await expect(page.locator("#editor")).toContainText("![](images/");
 
     const content = await getContent(page);
-    expect(content).toBe(`![](${IMAGE_PATH})\nline1\nline2`);
+    expect(content).toBe(`text ![](${IMAGE_PATH})\nline1\nline2`);
 
     await ctx.close();
   });

--- a/tests/visual/image-selection-e2e.spec.ts
+++ b/tests/visual/image-selection-e2e.spec.ts
@@ -1,0 +1,400 @@
+import { test, expect, injectNoteMock, enterEdit, placeCaret, getContent } from "./fixtures";
+
+// 画像のみの行（前後空白のみの `![alt|width](images/...)`）は、クリック・↑↓ の
+// どちらからも生表示に入らず、代わりに「選択状態」になる。削除は選択中の
+// Backspace / Delete で行う（image-delete-e2e.spec.ts）。
+
+const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+const IMAGE_LINE = `![](${IMAGE_PATH})`;
+
+test.describe("画像の選択状態", () => {
+  test("画像本体のクリックで選択状態になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("画像のみの行の余白クリック（img 以外の同じ行）でも選択状態になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${IMAGE_LINE}\ntext1` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // asset:// URL はテスト環境で解決できず <img> はレイアウトサイズ 0 になるため、
+    // ブロック div（[data-line="0"]）をクリックしても img には当たらない
+    await page.locator('[data-line="0"]').click({ force: true });
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("画像のみの行が最終行 → 余白クリック（付箋の空白部分）でも選択状態になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 余白クリック（画像のみの行が最終行）は選択状態になり #editor は開かないので、
+    // #editor の出現を待つ enterEdit は使わず直接クリックする
+    await page.click("#markdown-view");
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("付箋全体が画像のみの行 1 本 → 選択して削除すれば通常どおり入力できる（行き詰まりの回帰防止）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: IMAGE_LINE }, {}, { captureInvokes: true });
+    await page.addInitScript(() => {
+      const prevInvoke = (window as any).__TAURI__.core.invoke;
+      (window as any).__TAURI__.core.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === "delete_image") return "";
+        return prevInvoke(cmd, args);
+      };
+    });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.click("#markdown-view"); // 画像のみの行 1 本 → 選択状態（#editor は開かない）
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Delete");
+    await expect.poll(() => getContent(page)).toBe("");
+
+    // 画像が消えた後は通常どおりクリックで入力できる
+    await enterEdit(page);
+    await expect(page.locator("#editor")).toBeVisible();
+    await page.locator("#editor").pressSequentially("hello");
+    expect(await getContent(page)).toBe("hello");
+
+    await ctx.close();
+  });
+
+  test("↓ でテキスト行 → 画像のみの行（選択）→ テキスト行と遷移する", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    await page.locator("#editor").press("ArrowDown");
+
+    await expect(page.locator("#editor")).toHaveCount(0);
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("ArrowDown");
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text2");
+
+    await ctx.close();
+  });
+
+  test("↑ で連続する画像のみの行を経ても、1 行ずつ選択状態が続く（飛び越えない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\n${IMAGE_LINE}\ntext3` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 3, 0);
+    await page.locator("#editor").press("ArrowUp"); // text3 → line2（画像のみ、選択）
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await page.keyboard.press("ArrowUp"); // line2 → line1（画像のみ、選択のまま）
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await page.keyboard.press("ArrowUp"); // line1 → line0（text0、生表示）
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
+  test("↓ の先が無ければ選択を維持する（端）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, 0);
+    await page.locator("#editor").press("ArrowDown");
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("ArrowDown");
+
+    await expect(page.locator(".img-selected")).toHaveCount(1); // 変わらない
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("↑ の先が無ければ選択を維持する（端）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${IMAGE_LINE}\ntext1` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 1, 0);
+    await page.locator("#editor").press("ArrowUp");
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("ArrowUp");
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("選択中に Enter → 画像の直下に空行を挿入し、そこへキャレット（選択は解除）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator('[data-line="1"]').click({ force: true });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Enter");
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("");
+    expect(await getContent(page)).toBe(`text0\n${IMAGE_LINE}\n\ntext2`);
+
+    await ctx.close();
+  });
+
+  test("選択中に Shift+Enter → 画像の直上に空行を挿入し、そこへキャレット（画像が先頭行でも）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `${IMAGE_LINE}\ntext1` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator('[data-line="0"]').click({ force: true });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Shift+Enter");
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("");
+    expect(await getContent(page)).toBe(`\n${IMAGE_LINE}\ntext1`);
+
+    await ctx.close();
+  });
+
+  test("Esc で選択解除", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.click("#markdown-view");
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Escape");
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("別の行をクリックすると選択解除される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.click("#markdown-view");
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.locator('[data-line="0"]').click();
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
+  test("ダブルクリックは選択と共存する（open_image が呼ばれる）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: IMAGE_LINE }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image").length,
+      ),
+    ).toBe(1);
+
+    await ctx.close();
+  });
+
+  test("右クリックメニューは選択と共存する（show_context_menu に imagePath が渡る）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: IMAGE_LINE }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+      img.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+
+    await expect.poll(() =>
+      page.evaluate(() =>
+        (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu").length,
+      ),
+    ).toBe(1);
+    const calls = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "show_context_menu"),
+    );
+    expect(calls[0].args.imagePath).toBe(IMAGE_PATH);
+    // line/occurrence は渡さない
+    expect(calls[0].args.imageLine).toBeUndefined();
+    expect(calls[0].args.imageOccurrence).toBeUndefined();
+
+    await ctx.close();
+  });
+
+  test("リサイズハンドルへの mousedown は選択を消さない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `![|100](${IMAGE_PATH})` }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, cancelable: true }));
+      img.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.evaluate(() => {
+      const handle = document.querySelector(".img-resize-handle")!;
+      handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await ctx.close();
+  });
+
+  test("リサイズのドラッグ確定（renderAll 経由）後も選択が正しく復元される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 600, height: 400 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: IMAGE_LINE }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const img = document.querySelector("img")!;
+      img.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    // ドラッグでリサイズ確定 → applyImageWidth が renderAll() を呼び、mdView.innerHTML が
+    // 丸ごと差し替わる（.img-selected が付いていた古い img 要素ごと消える）
+    await page.evaluate(([startX, endX]) => {
+      const img = document.querySelector("img")!;
+      const handle = document.querySelector(".img-resize-handle")!;
+      img.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, clientX: startX, clientY: 0 }));
+      handle.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, clientX: startX, clientY: 0, buttons: 1 }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { bubbles: true, clientX: endX, clientY: 0, buttons: 1 }),
+      );
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: endX, clientY: 0 }));
+    }, [0, 50]);
+
+    expect(await getContent(page)).toBe(`![|250](${IMAGE_PATH})`);
+    // renderAll 後も選択枠は同じ画像に付き直っている
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    const stillSelected = await page.evaluate(() => document.querySelector("img.img-selected") != null);
+    expect(stillSelected).toBe(true);
+
+    await ctx.close();
+  });
+
+  test("未終端フェンスの最終行が画像のみの行に見えても選択にならず、生表示に入る（退行防止）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    // 閉じフェンスが無いため、フェンス開始行〜最終行がまとめて 1 つの <pre> ブロックになる
+    const content = "```\ntext\n" + IMAGE_LINE;
+    await injectNoteMock(page, { content });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page); // 余白クリック → 最終行（フェンス内、見た目は画像のみ）
+
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe(content);
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("テキストと画像が混在する行は従来どおり生表示に入る（選択にならない・退行防止）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text ${IMAGE_LINE}` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page);
+
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe(`text ${IMAGE_LINE}`);
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## 背景

画像を含む行も他の行と同じく生表示（生 Markdown の編集）に入るが、`![](images/<uuid>.png)` という記法は人間が読み書きする価値がほぼ無く、画像を貼るたびに意味のない文字列と向き合うことになる。キーボードでの行移動でも画像が生文字列として現れる。

## 仕様

画像だけの行は生の記法を見せず、「選択」で操作するオブジェクトとして扱う。

- クリック、またはキャレットの ↑↓ 移動で画像が選択状態（青枠）になる。↑↓ でそのまま隣の行へ抜けられる
- 選択中の操作: Backspace / Delete で削除（削除確認の設定に従う。どこからも参照されなくなった画像ファイルは回収）、⌘C でクリップボードへコピー、⌘X でカット（コピー成功を確認してから確認ダイアログ無しで削除）、Enter / Shift+Enter で画像の下・上に空行を挿入、Esc・別の場所のクリックで解除
- ダブルクリックで開く・右クリックメニュー（開く / Finder で表示 / コピー）・リサイズハンドルは選択と共存する
- テキストと画像が混在する行は従来どおり生表示（プレビュー付き）に入る
- 付箋の中身が画像だけになっても、余白クリックで末尾に空行が足されて文字を入力できる

## やったこと

- FE: 生表示への入り口（enterLine）に関所を置き、画像のみの行は選択状態へ振り分ける。選択中のキー操作は document レベルで受ける（IME・既存ショートカットとは干渉しない）。⌘C / ⌘X はネイティブ Edit メニューがショートカットを先取りするため、選択時に画像へ DOM 選択を張ってメニュー項目を有効化し、document の copy / cut イベントで処理する
- BE(コピー / カット): クリップボード書き込みはメインスレッドへ委譲して待ち合わせる。カットは「コピー成功 → 削除」の順序を保証する
- BE: 削除コマンドを追加。行番号と行内の出現順で対象 1 箇所だけを取り除く（インラインコード内の記法は出現数に数えない）。保存はディスク確定後にメモリへ反映し、未参照になった画像ファイルを回収
- テスト: 選択の遷移・削除・空行挿入・混在行の退行・同一行に別画像 2 枚・多重発火ガードなどの E2E と Rust ユニットテストを追加

## 確認したこと

- cargo test 165 件 / clippy / fmt、eslint、node UT + Playwright 297 件（VRT ベースライン差分なし）。WebKit エンジンでも画像系 E2E 76 件が通ることを確認
- 実機で選択・削除・⌘C のペースト先での貼り付け・⌘X・空行挿入・解除、ダブルクリック / リサイズ / 右クリックとの共存、通常編集の退行が無いことを確認

## 関連リンク

- issue: #63
- 先行 PR: #74

