### PR TITLE
🐛 キー押しっぱなしで同じ文字が連続入力されるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `src/menu.rs` — アプリメニュー
 - `src/tray.rs` — システムトレイ
 - `src/i18n.rs` — ネイティブ側 UI 文言の言語ごとの表記（`Msg` の表）と表示言語の解決。`Msg` を増やすと訳の付け忘れがコンパイルエラーになる
+- `src/macos_prefs.rs` — 起動時にこのアプリだけ press-and-hold（キー長押しでのアクセント文字ポップアップ）を無効化し、キーリピートを有効にする
 - `tauri.conf.json` — Tauri 設定。`frontendDist` は `../src` を指す。`withGlobalTauri: true` で `window.__TAURI__` を使用
 - `capabilities/default.json` — Tauri v2 のパーミッション定義
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1714,6 +1714,8 @@ dependencies = [
  "dirs 6.0.0",
  "image",
  "log",
+ "objc2",
+ "objc2-foundation",
  "rand 0.10.2",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,10 @@ sys-locale = "0.3"
 arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = "0.3"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod context_menu;
 mod i18n;
 mod image_actions;
+mod macos_prefs;
 mod menu;
 pub mod model;
 mod persistence;
@@ -24,6 +25,8 @@ use window::{bring_all_to_front, open_note_window};
 // ── App Entry ───────────────────────────────────────────────
 
 pub fn run() {
+    macos_prefs::disable_press_and_hold();
+
     let data_dir = persistence::data_dir();
     let (notes, notes_loaded, notes_load_error) = match load_notes(&data_dir) {
         Loaded::Missing => (Vec::new(), true, None),

--- a/src-tauri/src/macos_prefs.rs
+++ b/src-tauri/src/macos_prefs.rs
@@ -1,0 +1,28 @@
+// ── macOS User Defaults ─────────────────────────────────────
+
+/// アプリ起動時に一度だけ呼ぶ。キーの長押しをこのアプリに限って「押しっぱなしでリピート」
+/// にする（macOS 既定の press-and-hold アクセントポップアップを止める）。
+///
+/// `setBool:forKey:` ではなく `registerDefaults:` を使う。`registerDefaults:` は検索リストの
+/// 最下位（NSRegistrationDomain）に値を積むだけで plist に書き込まれないため、他アプリや
+/// システム全体の設定には影響せず、次回起動時は自動的にこの登録からやり直しになる
+/// （つまり永続化されない）。
+#[cfg(target_os = "macos")]
+pub fn disable_press_and_hold() {
+    use objc2::runtime::AnyObject;
+    use objc2_foundation::{NSDictionary, NSNumber, NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let key = NSString::from_str("ApplePressAndHoldEnabled");
+    let value = NSNumber::new_bool(false);
+    let dict: objc2::rc::Retained<NSDictionary<NSString, AnyObject>> =
+        NSDictionary::from_slices(&[&*key], &[value.as_ref()]);
+    // SAFETY: `registerDefaults:` は AnyObject に property list 型を要求する。
+    // 渡す値は NSNumber(bool) なのでこれを満たす
+    unsafe {
+        defaults.registerDefaults(&dict);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn disable_press_and_hold() {}


### PR DESCRIPTION
## 背景

付箋の編集中、英数キーを押しっぱなしにしても同じ文字が連続入力されない。macOS の press-and-hold（長押しでアクセント文字を選ぶ）が発動し、中身の無い候補ポップアップが出る。

## 仕様

- キーを押しっぱなしにすると同じ文字が連続入力される（キーリピート）
- 無効化はこのアプリだけ。システム全体・他アプリの press-and-hold は変わらない
- ユーザーが `defaults write` で明示設定している場合はそちらが勝つ

## やったこと

- 起動時に `NSUserDefaults` の `registerDefaults:` で `ApplePressAndHoldEnabled=false` を登録する（`macos_prefs.rs` 新規）。検索リスト最下位への非永続登録なので plist に書き込まれず、明示設定があればそちらが優先される

## 確認したこと

- cargo fmt / clippy / test 165 件
- 実機で付箋上の英字キー長押しがキーリピートになること

## 関連リンク

- Closes #73
