### PR TITLE
🐛 Ctrl+A/E をキャレットの行頭・行末移動にする

### DIFF
--- a/src/note.js
+++ b/src/note.js
@@ -210,6 +210,41 @@ function caretOffset(el) {
   return pre.toString().length;
 }
 
+/**
+ * キャレット位置を可視領域までスクロールする。ArrowLeft/Right 等のネイティブなキャレット
+ * 移動は自動でスクロール追従するが、placeCaret による自前のジャンプ（Ctrl+A/E 等）は
+ * 追従しない。atomic な行（折り返さず横スクロール、.raw-editor.atomic）で長い行の行末へ
+ * 飛ぶと、この呼び出しがないとキャレットが画面外へ出る。
+ *
+ * キャレット位置に一時的な span を挿し、それを scrollIntoView した上で除去する。
+ * span に大きさ（inline-block の 1px 幅）を持たせるのは WebKit 対応で、大きさの無い
+ * インライン要素は行頭・行末でレイアウトボックスを持たず scrollIntoView が効かない。
+ * span は textContent を持たないため editorText(el) の結果には影響せず、除去後に
+ * 同じ数値オフセットで placeCaret し直せば、DOM 上のテキストノード分割の有無に関わらず
+ * 元と同じ位置へキャレットを戻せる。
+ */
+function scrollCaretIntoView(el) {
+  const offset = caretOffset(el);
+  const at = nodeAt(el, offset);
+  const marker = document.createElement('span');
+  marker.style.cssText = 'display:inline-block;width:1px;height:1em;';
+  if (at) {
+    const range = document.createRange();
+    range.setStart(at.node, at.offset);
+    range.collapse(true);
+    range.insertNode(marker);
+  } else {
+    el.appendChild(marker);
+  }
+  marker.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  marker.remove();
+  // insertNode が分割したテキストノードを繋ぎ直す（放置すると呼ぶたびに断片が増え、
+  // IME の変換開始位置がノード境界に当たりやすくなる）。normalize で既存の Range は
+  // 無効になるが、直後に数値オフセットでキャレットを置き直すので影響しない
+  el.normalize();
+  placeCaret(el, offset);
+}
+
 /** 生エディタ内のキャレット位置を、文書全体での (行番号, 列) に変換する。 */
 function caretLineCol(ed) {
   const before = editorText(ed).slice(0, caretOffset(ed)).split('\n');
@@ -1301,14 +1336,31 @@ function bindEditor(ed) {
       scheduleSave();
       return;
     }
-    // 選択が生エディタの外へ広がらないように自前で全選択する
-    if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
+    // 選択が生エディタの外へ広がらないように自前で全選択する。
+    // 修飾キーは ⌘ 単独のときだけ効かせる（Ctrl+⌘+A 等の未定義の組み合わせで
+    // 何もしない macOS 標準に合わせる）。toLowerCase は CapsLock 対応
+    if (e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'a') {
       e.preventDefault();
       const range = document.createRange();
       range.selectNodeContents(ed);
       const sel = window.getSelection();
       sel.removeAllRanges();
       sel.addRange(range);
+      return;
+    }
+    // 実機の WKWebView は contenteditable 上で Ctrl+A/E を標準キーバインド（行頭・行末移動）
+    // として処理しないため自前実装する。Shift 付き（選択拡張）はこの分岐に入れず、
+    // ネイティブの選択拡張に任せる
+    const caretKey = e.key.toLowerCase();
+    if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && (caretKey === 'a' || caretKey === 'e')) {
+      e.preventDefault();
+      const text = editorText(ed);
+      const offset = caretOffset(ed);
+      const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+      const nlAfter = text.indexOf('\n', offset);
+      const lineEnd = nlAfter === -1 ? text.length : nlAfter;
+      placeCaret(ed, caretKey === 'a' ? lineStart : lineEnd);
+      scrollCaretIntoView(ed);
       return;
     }
     if (e.key === 'ArrowUp' && activeStart > 0) {

--- a/tests/visual/raw-line-editor-e2e.spec.ts
+++ b/tests/visual/raw-line-editor-e2e.spec.ts
@@ -107,6 +107,115 @@ test.describe("行の生表示と行編集", () => {
   }
 });
 
+// ── Ctrl+A/E の行頭・行末移動 ─────────────────────────────
+// 実機の WKWebView は contenteditable 上で Ctrl+A/E を標準キーバインドとして処理しない
+// ため、note.js が自前実装している（#69）。テストで使う Chromium は逆にネイティブで
+// 行頭・行末移動を処理するが、自前実装が preventDefault で上書きするため、ここでの
+// 検証は自前実装側の回帰を検出する。
+
+test.describe("Ctrl+A/E の行頭・行末移動", () => {
+  /** 生エディタ内のキャレット位置（選択の折り畳み状態つき）。 */
+  function caretState(page: import("@playwright/test").Page) {
+    return page.evaluate(() => {
+      const ed = document.getElementById("editor")!;
+      const sel = window.getSelection()!;
+      const range = sel.getRangeAt(0);
+      const pre = range.cloneRange();
+      pre.selectNodeContents(ed);
+      pre.setEnd(range.startContainer, range.startOffset);
+      return { offset: pre.toString().length, collapsed: sel.isCollapsed };
+    });
+  }
+
+  /** 生エディタ内の選択の anchor/focus 位置（折り畳み状態つき）。 */
+  function selectionState(page: import("@playwright/test").Page) {
+    return page.evaluate(() => {
+      const ed = document.getElementById("editor")!;
+      const sel = window.getSelection()!;
+      const offsetOf = (node: Node, offset: number) => {
+        const r = document.createRange();
+        r.selectNodeContents(ed);
+        r.setEnd(node, offset);
+        return r.toString().length;
+      };
+      return {
+        collapsed: sel.isCollapsed,
+        anchorOffset: offsetOf(sel.anchorNode!, sel.anchorOffset),
+        focusOffset: offsetOf(sel.focusNode!, sel.focusOffset),
+      };
+    });
+  }
+
+  test("Ctrl+A でキャレットが行頭へ移動する（選択されない）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Control+a");
+
+    expect(await caretState(page)).toEqual({ offset: 0, collapsed: true });
+  });
+
+  test("Ctrl+E でキャレットが行末へ移動する（選択されない）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Control+e");
+
+    expect(await caretState(page)).toEqual({ offset: 2, collapsed: true });
+  });
+
+  test("⌘A はブロック内全選択のまま（回帰）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Meta+a");
+
+    const state = await caretState(page);
+    expect(state.collapsed).toBe(false);
+    expect(await page.evaluate(() => window.getSelection()!.toString())).toBe("本文");
+  });
+
+  test("Ctrl+⌘+A は何もしない（未定義の修飾キー組み合わせは macOS 標準に合わせて無視する）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Control+Meta+a");
+
+    expect(await caretState(page)).toEqual({ offset: 1, collapsed: true });
+  });
+
+  test("Shift+Ctrl+A は行頭まで選択を拡張する（キャレット移動に化けない）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Control+Shift+A");
+
+    expect(await selectionState(page)).toEqual({ collapsed: false, anchorOffset: 1, focusOffset: 0 });
+    expect(await page.evaluate(() => window.getSelection()!.toString())).toBe("本");
+  });
+
+  test("Shift+Ctrl+E は行末まで選択を拡張する（キャレット移動に化けない）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.keyboard.press("Control+Shift+E");
+
+    expect(await selectionState(page)).toEqual({ collapsed: false, anchorOffset: 1, focusOffset: 2 });
+    expect(await page.evaluate(() => window.getSelection()!.toString())).toBe("文");
+  });
+
+  test("atomic な行で Ctrl+E の後、キャレットが横スクロールで可視範囲に入る", async ({ openNote }) => {
+    const longLine = "x".repeat(200);
+    const page = await openNote({ content: `\`\`\`\n${longLine}\n\`\`\`` });
+
+    await placeCaret(page, 1, 0);
+    await page.keyboard.press("Control+e");
+
+    const scrollLeft = await page.locator("#editor").evaluate((el) => el.scrollLeft);
+    expect(scrollLeft).toBeGreaterThan(0);
+  });
+});
+
 // ── クリック位置 → 生 Markdown の列 ──────────────────────
 // 描画テキストには行頭マーカーが出ないため、その分を足し戻して列を決める。
 


### PR DESCRIPTION
## 背景

生エディタで Ctrl+A を押すと、macOS 標準のキャレット行頭移動ではなくブロック内全選択になる。⌘A（ブロック内全選択）の keydown 分岐が Ctrl+A を同一視して拾い、標準キーバインドへ渡していないため。

## 仕様

- Ctrl+A / Ctrl+E でキャレットが論理行の行頭・行末へ移動する（選択はされない）。折り返さない長い行では移動先までの横スクロールが追従する
- Shift+Ctrl+A / Shift+Ctrl+E（行頭・行末までの選択拡張）はネイティブ処理のまま
- ⌘A のブロック内全選択は ⌘ 単独のときだけ効く。Ctrl+⌘+A のような未定義の修飾キーの組み合わせでは何もしない（macOS 標準に合わせる）
- CapsLock オン時も Ctrl+A/E・⌘A が効く

## やったこと

- ⌘A 分岐の修飾キー判定を厳密一致にし、Ctrl+A/E の行頭・行末移動を自前実装。実機の WKWebView は contenteditable 上でこの標準キーバインドを処理しない（テストで使う chromium は処理する）
- キャレット位置まで横スクロールを追従させるユーティリティを新設
- E2E 7 件追加（行頭・行末移動、Shift 拡張、⌘A、Ctrl+⌘+A、スクロール追従）

## 確認したこと

- eslint、node UT 179 件、Playwright 314 件
- 実機で Ctrl+A/E の移動とスクロール追従、Shift 拡張、⌘A 全選択、Ctrl+⌘+A/E が何もしないこと

## 関連リンク

- Closes #69
