### PR TITLE
🐛 行頭の ← / 行末の → でキャレットが隣の行へ移動するようにする

### DIFF
--- a/src/note.js
+++ b/src/note.js
@@ -350,6 +350,9 @@ function applySelectionHighlight() {
   if (!img) { selectedImage = null; return; }
   img.classList.add('img-selected');
   selectImageRange(img);
+  // キー操作（←/→/↑/↓）で画面外の画像行へ着地したとき、選択枠が唯一の状態表示なので
+  // 見える位置までスクロールする
+  img.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 }
 
 /** 行テキスト中で最初に出てくる画像記法の src を取り出す。無ければ null。 */
@@ -421,6 +424,9 @@ function enterLine(lineIdx, col) {
   const blockLines = lines.slice(activeStart, activeEnd + 1);
   const line = lines[i] ?? '';
   placeCaret(ed, blockOffset(blockLines, i - activeStart, col == null ? line.length : Math.min(col, line.length)));
+  // atomic な行（折り返さず横スクロール）へ行末等でキャレットが着地すると、placeCaret だけでは
+  // 横スクロール位置が追従せずキャレットが画面外に出ることがあるため、可視位置まで追従させる
+  scrollCaretIntoView(ed);
 }
 
 /** 生エディタの内容を rawContent へ書き戻す。DOM は触らない（入力中に呼ばれる）。 */
@@ -1379,8 +1385,46 @@ function bindEditor(ed) {
       }
       return;
     }
+    // Shift（選択拡張）・⌥（単語移動）・⌘/Ctrl（行頭/行末移動）付きはこの分岐に入れず、
+    // ネイティブの生エディタ内移動に任せる（Ctrl+A/E・⌘A 分岐と同じ 4 修飾キーの並び）。
+    // 非 collapsed（選択あり）のときも、caretLineCol が返すのは選択開始位置（左端）なので
+    // ここで拾うと「選択を畳む」が「行またぎジャンプ」に化ける。Backspace/Delete 分岐と
+    // 同じく isCollapsed で弾き、選択畳みはネイティブに譲る
+    if (
+      e.key === 'ArrowLeft' && !e.shiftKey && !e.altKey && !e.metaKey && !e.ctrlKey
+      && window.getSelection().isCollapsed && activeStart > 0
+    ) {
+      const { line, col } = caretLineCol(ed);
+      // 行頭のときだけ発動。複数行ブロック（フェンス）の途中の行頭は
+      // contenteditable のネイティブ移動（同一エディタ内で前行末尾へ）に任せる
+      if (line === activeStart && col === 0) {
+        e.preventDefault();
+        // 移動先が画像のみの行なら enterLine が選択状態にする（selectImage が
+        // selectedImage を立てる）。stopPropagation しないと、この 1 回の keydown が
+        // document まで伝播し、画像選択用のキー処理（この直後に登録）が
+        // 立ったばかりの selectedImage を見て同じキーで二重に隣へ進めてしまう
+        e.stopPropagation();
+        enterLine(activeStart - 1, null);
+      }
+      return;
+    }
+    if (
+      e.key === 'ArrowRight' && !e.shiftKey && !e.altKey && !e.metaKey && !e.ctrlKey
+      && window.getSelection().isCollapsed && activeEnd < getLines().length - 1
+    ) {
+      const { line, col } = caretLineCol(ed);
+      if (line === activeEnd && col === getLines()[line].length) {
+        e.preventDefault();
+        // 移動先が画像のみの行なら enterLine が選択状態にする。stopPropagation しないと
+        // 同じ keydown が document の画像選択用キー処理に届き、二重に隣へ進めてしまう
+        e.stopPropagation();
+        enterLine(activeEnd + 1, 0);
+      }
+      return;
+    }
     if ((e.key === 'Backspace' || e.key === 'Delete') && window.getSelection().isCollapsed) {
-      // 結合結果の行が画像のみの行になり enterLine が選択状態にすることがある。同じ理由で止める
+      // 結合結果の行が画像のみの行になり enterLine が選択状態にすることがある。
+      // stopPropagation しないと同じ keydown が document の画像選択用キー処理に届いてしまう
       if (mergeLine(ed, e.key === 'Backspace')) { e.preventDefault(); e.stopPropagation(); }
     }
   });
@@ -1552,6 +1596,18 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'ArrowDown') {
     e.preventDefault();
     if (selectedImage.line < getLines().length - 1) enterLine(selectedImage.line + 1, null);
+    return;
+  }
+  if (e.key === 'ArrowLeft') {
+    e.preventDefault();
+    // 選択を解除して前の行の末尾へ（隣も画像のみの行なら enterLine が連続して選択状態にする）。
+    // 端で行が無ければ選択を維持する（何もしない）
+    if (selectedImage.line > 0) enterLine(selectedImage.line - 1, null);
+    return;
+  }
+  if (e.key === 'ArrowRight') {
+    e.preventDefault();
+    if (selectedImage.line < getLines().length - 1) enterLine(selectedImage.line + 1, 0);
     return;
   }
   if (e.key === 'Backspace' || e.key === 'Delete') {

--- a/tests/visual/image-selection-e2e.spec.ts
+++ b/tests/visual/image-selection-e2e.spec.ts
@@ -176,6 +176,68 @@ test.describe("画像の選択状態", () => {
     await ctx.close();
   });
 
+  test("行末で → の先が画像のみの行なら選択状態になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, null);
+    await page.locator("#editor").press("ArrowRight");
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("行頭で ← の先が画像のみの行なら選択状態になる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 2, 0);
+    await page.locator("#editor").press("ArrowLeft");
+
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("画像選択状態から ← / → で隣の行へ抜けられる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: `text0\n${IMAGE_LINE}\ntext2` });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await placeCaret(page, 0, null);
+    await page.locator("#editor").press("ArrowRight"); // text0 → 画像行（選択状態）
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("ArrowRight"); // 画像行 → text2（↑/↓ ではなく → で抜ける）
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text2");
+
+    await page.keyboard.press("ArrowLeft"); // text2 → 画像行（選択状態）
+    await expect(page.locator(".img-selected")).toHaveCount(1);
+    await expect(page.locator("#editor")).toHaveCount(0);
+
+    await page.keyboard.press("ArrowLeft"); // 画像行 → text0（← で抜ける）
+
+    await expect(page.locator(".img-selected")).toHaveCount(0);
+    await expect(page.locator("#editor")).toBeVisible();
+    expect(await page.locator("#editor").textContent()).toBe("text0");
+
+    await ctx.close();
+  });
+
   test("選択中に Enter → 画像の直下に空行を挿入し、そこへキャレット（選択は解除）", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();

--- a/tests/visual/raw-line-editor-e2e.spec.ts
+++ b/tests/visual/raw-line-editor-e2e.spec.ts
@@ -45,6 +45,107 @@ test.describe("行の生表示と行編集", () => {
     expect(await page.locator("#editor").textContent()).toBe("本文");
   });
 
+  /** 生エディタ内のキャレット位置（#editor 内での文字オフセット）。 */
+  function caretOffsetInEditor(page: import("@playwright/test").Page) {
+    return page.evaluate(() => {
+      const ed = document.getElementById("editor")!;
+      const range = window.getSelection()!.getRangeAt(0);
+      const pre = range.cloneRange();
+      pre.selectNodeContents(ed);
+      pre.setEnd(range.startContainer, range.startOffset);
+      return pre.toString().length;
+    });
+  }
+
+  test("行頭で ← を押すと前の行の末尾へ移る", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 0);
+    await page.locator("#editor").press("ArrowLeft");
+
+    expect(await page.locator("#editor").textContent()).toBe("# 見出し");
+    expect(await caretOffsetInEditor(page)).toBe("# 見出し".length);
+  });
+
+  test("行末で → を押すと次の行の先頭へ移る", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, null);
+    await page.locator("#editor").press("ArrowRight");
+
+    expect(await page.locator("#editor").textContent()).toBe("- 項目");
+    expect(await caretOffsetInEditor(page)).toBe(0);
+  });
+
+  test("行頭以外の ← / 行末以外の → はエディタ内移動のまま", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 1);
+    await page.locator("#editor").press("ArrowLeft");
+    expect(await page.locator("#editor").textContent()).toBe("本文");
+    expect(await caretOffsetInEditor(page)).toBe(0);
+
+    await placeCaret(page, 1, 1);
+    await page.locator("#editor").press("ArrowRight");
+    expect(await page.locator("#editor").textContent()).toBe("本文");
+    expect(await caretOffsetInEditor(page)).toBe(2);
+  });
+
+  test("先頭行の行頭で ← / 最終行の行末で → は何もしない（境界）", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 0, 0);
+    await page.locator("#editor").press("ArrowLeft");
+    expect(await page.locator("#editor").textContent()).toBe("# 見出し");
+    expect(await caretOffsetInEditor(page)).toBe(0);
+
+    await placeCaret(page, 2, null);
+    await page.locator("#editor").press("ArrowRight");
+    expect(await page.locator("#editor").textContent()).toBe("- 項目");
+    expect(await caretOffsetInEditor(page)).toBe("- 項目".length);
+  });
+
+  test("Shift+←・Shift+→ は選択拡張のままで行をまたがない", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 0);
+    await page.locator("#editor").press("Shift+ArrowLeft");
+    expect(await page.locator("#editor").textContent()).toBe("本文");
+
+    await placeCaret(page, 1, null);
+    await page.locator("#editor").press("Shift+ArrowRight");
+    expect(await page.locator("#editor").textContent()).toBe("本文");
+  });
+
+  test("選択中に修飾なし ← を押すと選択が畳まれるだけで行をまたがない", async ({ openNote }) => {
+    const page = await openNote({ content: DOC });
+
+    await placeCaret(page, 1, 0);
+    // 行頭から1文字選択する。選択の開始位置（Range の左端）は行頭 col0 のままなので、
+    // caretLineCol だけで判定すると「行頭にいる」と誤認しかねない
+    await page.locator("#editor").press("Shift+ArrowRight");
+    await page.locator("#editor").press("ArrowLeft");
+
+    expect(await page.locator("#editor").textContent()).toBe("本文");
+    expect(await caretOffsetInEditor(page)).toBe(0);
+  });
+
+  test("フェンス複数行ブロックの途中の行頭 ← / 行末 → はエディタ内のネイティブ移動のまま", async ({ openNote }) => {
+    const page = await openNote({ content: "```\ncode1\ncode2\n```\nafter" });
+    await page.locator(".md-codeblock").click();
+    await page.waitForSelector("#editor", { state: "visible" });
+
+    await placeCaret(page, 2, 0); // "code2" 行の行頭（ブロックの先頭行ではない）
+    await page.locator("#editor").press("ArrowLeft");
+    expect(await page.locator("#editor").textContent()).toBe("```\ncode1\ncode2\n```");
+    expect(await caretOffsetInEditor(page)).toBe("```\ncode1".length);
+
+    await placeCaret(page, 1, null); // "code1" 行の行末（ブロックの最終行ではない）
+    await page.locator("#editor").press("ArrowRight");
+    expect(await page.locator("#editor").textContent()).toBe("```\ncode1\ncode2\n```");
+    expect(await caretOffsetInEditor(page)).toBe("```\ncode1\n".length);
+  });
+
   test("Enter で行が分割される", async ({ openNote }) => {
     const page = await openNote({ content: DOC });
 


### PR DESCRIPTION
## 背景

生表示が行単位のため、↑/↓ はキャレットが隣の行へ移動できるのに対し、←/→ は生エディタの端で止まる。

## 仕様

- 行頭の ← で前の行の末尾へ、行末の → で次の行の先頭へキャレットが移動する
- テキスト選択中の ←/→ は選択を畳むだけで行をまたがない（標準のテキストエディタと同じ）
- 修飾キー付き（Shift の選択拡張・⌥ の単語移動・⌘ の行頭行末移動）はネイティブ処理のまま
- 移動先が画像のみの行なら画像が選択状態になり、さらに ←/→ でその先の行へ抜けられる
- コードフェンスなど複数行ブロックの途中の行頭・行末では、ブロック内のネイティブ移動のまま
- キャレットや画像選択枠が画面外の位置へ着地したときは、見える位置までスクロールが追従する

## やったこと

- 生エディタの keydown に ArrowLeft / ArrowRight 分岐を追加（↑/↓ の既存分岐と同型）。非 collapsed 選択と修飾キーはガードしてネイティブに任せる
- 画像選択中のキー処理（document 側）に ←/→ を追加し、選択状態から隣の行へ抜けられるようにする
- enterLine の着地点と画像選択枠に scrollCaretIntoView / scrollIntoView によるスクロール追従を追加
- E2E 10 件追加（行またぎ・境界・選択の畳み・フェンス内移動・画像行の出入り）

## 確認したこと

- eslint、node UT 179 件、Playwright 324 件
- 実機で ←/→ の行またぎ、境界の停止、選択の畳み、画像行の出入り、フェンス内移動

## 関連リンク

- Closes #68
