### PR TITLE
✨ 付箋の選択範囲をコピーできるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ HTML はマークアップと `<style>` だけを持ち、スクリプトは同�
 - 設定: `get_settings`, `update_settings`, `open_settings`
 - ゴミ箱: `get_trash`, `get_trash_max`, `restore_note`, `empty_trash`, `open_trash`
 - メニュー: `show_context_menu`
+- 選択範囲: `copy_markdown`（右クリックメニューの「Markdown をコピー」）
 
 ### アプリメニュー
 - File: New Note (⌘N), Trash... (⌘⇧T) — ネイティブアイコン付き

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,12 @@ import globals from "globals";
 // ずれていると no-undef が実行時の ReferenceError を見逃す。
 const utils = { escapeHtml: "readonly", showToast: "readonly" };
 const i18n = { I18N: "readonly" };
-const markdown = { inlineMarkdown: "readonly", renderMarkdown: "readonly" };
+const markdown = {
+  inlineMarkdown: "readonly",
+  renderMarkdown: "readonly",
+  inlineSegments: "readonly",
+  parseImageAlt: "readonly",
+};
 const noteLines = {
   blockOffset: "readonly",
   markerLength: "readonly",
@@ -17,6 +22,7 @@ const noteLines = {
   isEmptyListItem: "readonly",
   CHECKBOX_RE: "readonly",
   isImageOnlyLine: "readonly",
+  visibleOffsetToRawOffset: "readonly",
 };
 const history = {
   createHistory: "readonly",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -503,6 +503,7 @@ pub(crate) fn show_context_menu(
     is_pinned: bool,
     current_color: String,
     image_path: Option<String>,
+    has_selection: bool,
     app: AppHandle,
     state: State<AppState>,
 ) {
@@ -525,6 +526,7 @@ pub(crate) fn show_context_menu(
         is_pinned,
         &current_color,
         validated_image_path.as_deref(),
+        has_selection,
         lang,
     ) {
         log::error!("context menu error: {}", e);
@@ -616,8 +618,8 @@ pub(crate) fn delete_image(
 }
 
 /// `run_on_main_thread` からの結果待ちが万一戻ってこなくても UI を無限にフリーズさせない
-/// ための上限。
-const COPY_IMAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// ための上限。画像コピーと Markdown コピー（テキスト）の両方で共有する。
+const MAIN_THREAD_CLIPBOARD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// arboard 呼び出しをメインスレッドで実行し、結果を待ち合わせて返す。arboard は macOS で
 /// NSPasteboard をメインスレッド外から操作するとクラッシュしうる
@@ -642,7 +644,7 @@ fn copy_image_on_main_thread(
         let _ = tx.send(result);
     })
     .map_err(|e| e.to_string())?;
-    rx.recv_timeout(COPY_IMAGE_TIMEOUT)
+    rx.recv_timeout(MAIN_THREAD_CLIPBOARD_TIMEOUT)
         .map_err(|e| e.to_string())?
 }
 
@@ -655,6 +657,29 @@ pub(crate) fn copy_image(
     state: State<AppState>,
 ) -> Result<(), String> {
     copy_image_on_main_thread(&app, &state.data_dir, &image_path)
+}
+
+/// arboard 呼び出しをメインスレッドで実行する（理由は `copy_image_on_main_thread` のコメント参照）。
+fn copy_markdown_on_main_thread(app: &AppHandle, text: &str) -> Result<(), String> {
+    let text = text.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.run_on_main_thread(move || {
+        let result = arboard::Clipboard::new()
+            .and_then(|mut cb| cb.set_text(text))
+            .map_err(|e| e.to_string());
+        let _ = tx.send(result);
+    })
+    .map_err(|e| e.to_string())?;
+    rx.recv_timeout(MAIN_THREAD_CLIPBOARD_TIMEOUT)
+        .map_err(|e| e.to_string())?
+}
+
+/// 選択範囲の生 Markdown をテキストとしてクリップボードにコピーする（右クリックメニューの
+/// 「Markdown をコピー」）。text/html + text/plain を同時に載せる通常コピー（⌘C）とは別経路で、
+/// こちらはプレーンテキスト 1 形式のみを載せる。
+#[tauri::command]
+pub(crate) fn copy_markdown(text: String, app: AppHandle) -> Result<(), String> {
+    copy_markdown_on_main_thread(&app, &text)
 }
 
 /// `cut_image` の早期 return 条件（不正な画像パスなら実行せず `Ok(None)` として扱う）。

--- a/src-tauri/src/context_menu.rs
+++ b/src-tauri/src/context_menu.rs
@@ -37,6 +37,7 @@ pub(crate) fn build_context_menu(
     is_pinned: bool,
     current_color: &str,
     image_path: Option<&str>,
+    has_selection: bool,
     lang: Lang,
 ) -> tauri::Result<()> {
     let color_items: Vec<IconMenuItem<tauri::Wry>> = COLOR_DEFS
@@ -60,6 +61,18 @@ pub(crate) fn build_context_menu(
 
     let copy = PredefinedMenuItem::copy(app, None)?;
     let paste = PredefinedMenuItem::paste(app, None)?;
+    // 選択範囲があるときだけ「Markdown をコピー」を足す（通常の Copy の直後）
+    let copy_markdown = has_selection
+        .then(|| {
+            MenuItem::with_id(
+                app,
+                "ctx_copy_markdown",
+                i18n::text(lang, Msg::CtxCopyMarkdown),
+                true,
+                None::<&str>,
+            )
+        })
+        .transpose()?;
     // 画像上で開いたときだけ「画像を開く」「Finder で表示」「画像をコピー」を足す
     let image_items = image_path
         .map(|_| {
@@ -159,7 +172,11 @@ pub(crate) fn build_context_menu(
     )?;
     let sep3 = PredefinedMenuItem::separator(app)?;
 
-    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&copy, &paste];
+    let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&copy];
+    if let Some(copy_markdown) = &copy_markdown {
+        items.push(copy_markdown);
+    }
+    items.push(&paste);
     if let Some((sep_img, open_image, reveal_image, copy_image)) = &image_items {
         items.push(sep_img);
         items.push(open_image);
@@ -258,6 +275,11 @@ pub(crate) fn handle_context_menu_event(app: &AppHandle, event_id: &str) {
                 if let Err(e) = image_actions::copy_image_to_clipboard(&state.data_dir, &path) {
                     log::error!("copy image error: {}", e);
                 }
+            }
+        }
+        "ctx_copy_markdown" => {
+            if let Some(w) = &win {
+                let _ = w.emit_to(w.label(), "ctx-copy-markdown", ());
             }
         }
         _ if event_id.starts_with("ctx_color_") => {

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -62,6 +62,7 @@ pub(crate) enum Msg {
     CtxOpenImage,
     CtxRevealImage,
     CtxCopyImage,
+    CtxCopyMarkdown,
 
     ColorYellow,
     ColorBlue,
@@ -115,6 +116,7 @@ pub(crate) fn text(lang: Lang, msg: Msg) -> &'static str {
         Msg::CtxOpenImage => ("画像を開く", "Open Image"),
         Msg::CtxRevealImage => ("Finder で表示", "Show in Finder"),
         Msg::CtxCopyImage => ("画像をコピー", "Copy Image"),
+        Msg::CtxCopyMarkdown => ("Markdown をコピー", "Copy Markdown"),
 
         Msg::ColorYellow => ("イエロー", "Yellow"),
         Msg::ColorBlue => ("ブルー", "Blue"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,7 @@ pub fn run() {
             commands::delete_image,
             commands::copy_image,
             commands::cut_image,
+            commands::copy_markdown,
         ])
         .setup(move |app| {
             // Set up app menu and system tray

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -116,6 +116,8 @@ const I18N_TABLE = {
   toastCopyImageFailed: { ja: '画像のコピーに失敗しました', en: 'Failed to copy the image' },
   toastCutImageFailed: { ja: '画像のカットに失敗しました', en: 'Failed to cut the image' },
   imageOpenHint: { ja: 'ダブルクリックで開く', en: 'Double-click to open' },
+  imageAltFallback: { ja: '(画像)', en: '(image)' },
+  imageAltFallbackWithExt: { ja: '(画像.{ext})', en: '(image.{ext})' },
 };
 
 // 訳の付け忘れ検出（キーを増やしたときに片方の言語が抜けていたら気づけるように）

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -32,46 +32,324 @@ function parseImageAlt(altRaw) {
   return { alt: m[1], width };
 }
 
+// ── インライン記法の置換チェーン（inlineMarkdown と inlineSegments で共有） ──────
+// 正規表現と、コールバックが複雑なもの（画像・リンク・裸URL）のビルダー関数を共有し、
+// 2 つの経路で記法の解釈がずれないようにする。
+const CODE_RE = /`([^`]+)`/g;
+const BOLD_RE = /\*\*(.+?)\*\*/g;
+const ITALIC_RE = /\*([^*]+)\*/g;
+const DEL_RE = /~~([^~]+)~~/g;
+const IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+const LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+const BAREURL_RE = /((?:^|[^"=]))((https?:\/\/)[^\s<]+)/g;
+// eslint-disable-next-line no-control-regex -- \x00 is the placeholder marker
+const CODE_RESTORE_RE = /\x00CODE(\d+)\x00/g;
+
+// ![alt](src) → <img>（link の正規表現より先。`!` プレフィックスで区別する）
+// data-rel-src は resolve 前の相対パス。ダブルクリック・右クリックのハンドラは
+// asset URL 化された src ではなくこちらから元の相対パスを取り出す
+function buildImageHtml(altRaw, src) {
+  const resolved = (typeof window !== 'undefined' && typeof window.resolveImageSrc === 'function')
+    ? window.resolveImageSrc(src)
+    : src;
+  // title はダブルクリックで開けることを伝えるアフォーダンス（クリックしても反応が無いため）
+  const hint = (typeof window !== 'undefined' && window.I18N) ? window.I18N.t('imageOpenHint') : 'ダブルクリックで開く';
+  const { alt, width } = parseImageAlt(altRaw);
+  const widthAttr = width != null ? ` width="${width}"` : '';
+  return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}" data-rel-src="${escapeAttr(src)}" title="${escapeAttr(hint)}"${widthAttr}>`;
+}
+function buildLinkHtml(text, url) {
+  return `<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${text}</a>`;
+}
+function buildBareUrlHtml(pre, url) {
+  return `${pre}<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${url}</a>`;
+}
+function buildStrongHtml(inner) {
+  return `<strong>${inner}</strong>`;
+}
+function buildEmHtml(inner) {
+  return `<em>${inner}</em>`;
+}
+function buildDelHtml(inner) {
+  return `<del>${inner}</del>`;
+}
+
+/**
+ * escapeHtml 済みの文字列からインライン装飾を解決する。note.js の描画パス本体で、
+ * 呼び出し頻度が高いためオフセット追跡は一切行わない素の逐次置換チェーン。
+ */
 function inlineMarkdown(escaped) {
   // `code` → placeholder (protect from bold/italic/strikethrough)
   const codeBlocks = [];
-  escaped = escaped.replace(/`([^`]+)`/g, (_, c) => {
+  escaped = escaped.replace(CODE_RE, (_, c) => {
     codeBlocks.push(c);
     return '\x00CODE' + (codeBlocks.length - 1) + '\x00';
   });
   // **bold** → <strong>
-  escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  escaped = escaped.replace(BOLD_RE, (_, inner) => buildStrongHtml(inner));
   // *italic* → <em> (after bold to avoid conflict)
-  escaped = escaped.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  escaped = escaped.replace(ITALIC_RE, (_, inner) => buildEmHtml(inner));
   // ~~strikethrough~~ → <del>
-  escaped = escaped.replace(/~~([^~]+)~~/g, '<del>$1</del>');
-  // ![alt](src) → <img> (before the link regex; `!` prefix distinguishes it from a link)
-  // data-rel-src は resolve 前の相対パス。ダブルクリック・右クリックのハンドラは
-  // asset URL 化された src ではなくこちらから元の相対パスを取り出す
-  escaped = escaped.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, altRaw, src) => {
-    const resolved = (typeof window !== 'undefined' && typeof window.resolveImageSrc === 'function')
-      ? window.resolveImageSrc(src)
-      : src;
-    // title はダブルクリックで開けることを伝えるアフォーダンス（クリックしても反応が無いため）
-    const hint = (typeof window !== 'undefined' && window.I18N) ? window.I18N.t('imageOpenHint') : 'ダブルクリックで開く';
-    const { alt, width } = parseImageAlt(altRaw);
-    const widthAttr = width != null ? ` width="${width}"` : '';
-    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(resolved)}" data-rel-src="${escapeAttr(src)}" title="${escapeAttr(hint)}"${widthAttr}>`;
-  });
+  escaped = escaped.replace(DEL_RE, (_, inner) => buildDelHtml(inner));
+  escaped = escaped.replace(IMAGE_RE, (_, altRaw, src) => buildImageHtml(altRaw, src));
   // [text](url) → <a>
-  escaped = escaped.replace(
-    /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g,
-    (_, text, url) => `<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${text}</a>`
-  );
+  escaped = escaped.replace(LINK_RE, (_, text, url) => buildLinkHtml(text, url));
   // Bare URLs → <a> (skip URLs already inside an <a> tag)
-  escaped = escaped.replace(
-    /((?:^|[^"=]))((https?:\/\/)[^\s<]+)/g,
-    (_, pre, url) => `${pre}<a href="${escapeAttr(url)}" data-url="${escapeAttr(url)}">${url}</a>`
-  );
+  escaped = escaped.replace(BAREURL_RE, (_, pre, url) => buildBareUrlHtml(pre, url));
   // Restore code blocks
-  // eslint-disable-next-line no-control-regex -- \x00 is the placeholder marker
-  escaped = escaped.replace(/\x00CODE(\d+)\x00/g, (_, i) => '<code>' + codeBlocks[i] + '</code>');
+  escaped = escaped.replace(CODE_RESTORE_RE, (_, i) => '<code>' + codeBlocks[i] + '</code>');
   return escaped;
+}
+
+// ── inlineSegments の内部実装 ─────────────────────────────────
+// inlineMarkdown と同じ置換チェーンを、raw（escapeHtml 前）テキストの各文字が
+// 出力のどこに由来するかを追跡しながら適用し、セグメント列を組み立てる。
+// 由来の追跡は文字単位の２つの配列で行う:
+//   - grp[i]: 文字 i が属する group の id。まだ何の記法にも巻き込まれていない
+//     素のテキストなら -1（「plain」）
+//   - srcIdx[i]: grp[i] === -1 のときだけ有効。文字 i が由来する raw 上の位置
+// grp !== -1 の文字（装飾・画像・リンク等で生成された文字）の src 範囲は
+// group id をキーにした groupSpans に持つ（同じ id の文字は全員同じ範囲を指す）。
+//
+// 不変条件: 1 つの group の文字が 2 つ以上のセグメントに分かれることは絶対にない
+// （崩れると閉じタグが割れて本文が二重出力される。例: `**https://u**https://u` で
+// 裸URLステップが bold group の途中に部分的に触れるケース）。
+// これを守るため、1 回のステップ内の処理は 2 フェーズに分ける:
+//   フェーズ A: そのステップの全マッチと、マッチが触れる既存 group ブロックを
+//     安定するまで合併し、出力の区間分割を先に確定する
+//   フェーズ B: 確定した区間分割を左から右へ 1 回だけ走査して出力する
+// マッチ単位で出力しながら進めると、後続マッチの合併が出力済みの範囲に食い込むため、
+// 分割の確定と出力の書き出しを分離している。合併区間には常に新しい group id を
+// 割り当てる（既存 id の使い回しは、その group をさらに別の合併が巻き込むケースで
+// 区間分割の再計算を招くため）
+
+function applyInlineStep(state, regex, buildHtml) {
+  const { text, grp, srcIdx, groupSpans } = state;
+  // ゼロ幅マッチは除去する。残すと [start, start) の空区間を持つ comp ができ、
+  // フェーズ A/B の区間分割（区間は必ず非空という前提）が壊れる
+  const matches = [...text.matchAll(regex)].filter((m) => m[0].length > 0);
+
+  // 「不可分な最小単位」の境界を求める。装飾等で作られた group（grp !== -1）はもちろん、
+  // plain（grp === -1）でも escapeAndTrackOffsets が生んだエンティティ展開
+  // （例: raw の '>' 1 文字 → escaped の "&gt;" 4 文字、全員 srcIdx が同じ）は
+  // 同じ raw 文字に由来する不可分な単位なので、マッチ境界がその途中に落ちても割ってはいけない
+  // （割ると同じ raw 位置が 2 つのセグメントに属してしまう）
+  function blockStart(pos) {
+    const g = grp[pos];
+    if (g === -1) {
+      const sidx = srcIdx[pos];
+      let s = pos;
+      while (s > 0 && grp[s - 1] === -1 && srcIdx[s - 1] === sidx) s--;
+      return s;
+    }
+    let s = pos;
+    while (s > 0 && grp[s - 1] === g) s--;
+    return s;
+  }
+  function blockEnd(lastPos) {
+    const g = grp[lastPos];
+    if (g === -1) {
+      const sidx = srcIdx[lastPos];
+      let e = lastPos + 1;
+      while (e < grp.length && grp[e] === -1 && srcIdx[e] === sidx) e++;
+      return e;
+    }
+    let e = lastPos + 1;
+    while (e < grp.length && grp[e] === g) e++;
+    return e;
+  }
+
+  // フェーズ A: 区間分割を確定する
+  let comps = matches.map((m, idx) => ({ start: m.index, end: m.index + m[0].length, pieces: [idx] }));
+  let changed = comps.length > 0;
+  while (changed) {
+    changed = false;
+    for (const c of comps) {
+      const bs = blockStart(c.start);
+      if (bs < c.start) {
+        c.start = bs;
+        changed = true;
+      }
+      const be = blockEnd(c.end - 1);
+      if (be > c.end) {
+        c.end = be;
+        changed = true;
+      }
+    }
+    if (changed) {
+      comps.sort((a, b) => a.start - b.start);
+      const merged = [];
+      for (const c of comps) {
+        const last = merged[merged.length - 1];
+        if (last && c.start < last.end) {
+          last.end = Math.max(last.end, c.end);
+          last.pieces.push(...c.pieces);
+        } else {
+          merged.push(c);
+        }
+      }
+      comps = merged;
+    }
+  }
+
+  // フェーズ B: 確定した区間分割を左から右へ 1 回だけ走査して出力する
+  const newText = [];
+  const newGrp = [];
+  const newSrcIdx = [];
+  function copyVerbatim(a, b, gid) {
+    // a > b はフェーズ A の区間分割が壊れていない限り起こり得ない前提。
+    // 黙って握りつぶすと閉じタグの消失のような不変条件違反を検出できなくなるため throw する
+    if (a > b) throw new Error(`applyInlineStep: invalid range [${a}, ${b})`);
+    if (a === b) return;
+    newText.push(text.slice(a, b));
+    for (let i = a; i < b; i++) {
+      newGrp.push(gid === null ? grp[i] : gid);
+      newSrcIdx.push(gid === null ? srcIdx[i] : -1);
+    }
+  }
+
+  let cursor = 0;
+  for (const comp of comps) {
+    copyVerbatim(cursor, comp.start, null);
+
+    let srcStart = Infinity;
+    let srcEnd = -Infinity;
+    for (let i = comp.start; i < comp.end; i++) {
+      const g = grp[i];
+      const span = g === -1 ? { srcStart: srcIdx[i], srcEnd: srcIdx[i] + 1 } : groupSpans[g];
+      if (span.srcStart < srcStart) srcStart = span.srcStart;
+      if (span.srcEnd > srcEnd) srcEnd = span.srcEnd;
+    }
+    const gid = state.nextGroupId++;
+    groupSpans[gid] = { srcStart, srcEnd };
+
+    const pieces = comp.pieces.slice().sort((a, b) => matches[a].index - matches[b].index);
+    let pos = comp.start;
+    for (const idx of pieces) {
+      const m = matches[idx];
+      const pStart = m.index;
+      const pEnd = pStart + m[0].length;
+      copyVerbatim(pos, pStart, gid);
+      const replacement = buildHtml(m);
+      newText.push(replacement);
+      for (let i = 0; i < replacement.length; i++) {
+        newGrp.push(gid);
+        newSrcIdx.push(-1);
+      }
+      pos = pEnd;
+    }
+    copyVerbatim(pos, comp.end, gid);
+
+    cursor = comp.end;
+  }
+  copyVerbatim(cursor, text.length, null);
+
+  state.text = newText.join('');
+  state.grp = newGrp;
+  state.srcIdx = newSrcIdx;
+}
+
+// escapeHtml と同じ変換（& → &amp; / < → &lt; / > → &gt;）を、raw 上のオフセットを
+// 追跡しながら行う。エンティティに展開された文字は全員もとの raw 文字と同じ位置を指す
+// （& 1文字 → &amp; の 5 文字全部が同じ raw index、という決定的な対応）
+function escapeAndTrackOffsets(raw) {
+  let text = '';
+  const srcIdx = [];
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    const piece = c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c;
+    text += piece;
+    for (let k = 0; k < piece.length; k++) srcIdx.push(i);
+  }
+  return { text, srcIdx };
+}
+
+// escapeAndTrackOffsets の逆変換。visibleText（DOM textContent 相当）を組み立てるためだけに使う。
+// &amp; を最後にデコードすること: 先にデコードすると、たとえば &amp;lt; のような
+// （このモジュールが生成することはないが）文字列を "&lt;" → さらに "<" と二重にデコードしてしまう
+function decodeEntities(s) {
+  return s.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+}
+
+// html.replace(/<[^>]*>/g, '') は属性値の中身を見ないため、属性値に生の '>' を含む HTML
+// （例: href 属性の中に code 復元で <code> タグが混入するケース）で誤ってタグの終わりと
+// 誤認し、属性値の一部が可視テキストとして漏れ出す。タグの外側にいるか、タグの中でも
+// 引用符（" / '）に入っているかを状態機械で追跡し、引用符内の '>' は無視して正しくタグだけを除去する
+function stripTagsQuoteAware(html) {
+  let out = '';
+  let i = 0;
+  const n = html.length;
+  while (i < n) {
+    const c = html[i];
+    if (c !== '<') {
+      out += c;
+      i++;
+      continue;
+    }
+    // タグの内部（i はタグ開始の '<' の直後から始める）
+    i++;
+    let quote = null;
+    while (i < n) {
+      const ch = html[i];
+      if (quote) {
+        if (ch === quote) quote = null;
+      } else if (ch === '"' || ch === "'") {
+        quote = ch;
+      } else if (ch === '>') {
+        i++;
+        break;
+      }
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * raw（escapeHtml 前）の行テキストからインライン装飾を解決し、セグメント列を返す。
+ * 各セグメントは { srcStart, srcEnd, html, visibleText }。
+ *   - srcStart/srcEnd は raw 文字列上のオフセット（[srcStart, srcEnd) の半開区間）。
+ *     全セグメントの srcStart/srcEnd は [0, raw.length) を隙間なく覆う
+ *   - html は全セグメント連結すると inlineMarkdown(escapeHtml(raw)) と完全一致する
+ *   - visibleText は DOM の textContent 相当（タグを除去しエンティティをデコードした可視文字）
+ * srcStart/srcEnd は「トップレベルの構成要素」単位（ネストした装飾は外側 1 セグメントの html に含まれる）。
+ */
+function inlineSegments(raw) {
+  const { text: initialText, srcIdx: initialSrcIdx } = escapeAndTrackOffsets(raw);
+  const state = {
+    text: initialText,
+    grp: new Array(initialText.length).fill(-1),
+    srcIdx: initialSrcIdx,
+    groupSpans: {},
+    nextGroupId: 0,
+  };
+
+  const codeBlocks = [];
+  applyInlineStep(state, CODE_RE, (m) => {
+    codeBlocks.push(m[1]);
+    return '\x00CODE' + (codeBlocks.length - 1) + '\x00';
+  });
+  applyInlineStep(state, BOLD_RE, (m) => buildStrongHtml(m[1]));
+  applyInlineStep(state, ITALIC_RE, (m) => buildEmHtml(m[1]));
+  applyInlineStep(state, DEL_RE, (m) => buildDelHtml(m[1]));
+  applyInlineStep(state, IMAGE_RE, (m) => buildImageHtml(m[1], m[2]));
+  applyInlineStep(state, LINK_RE, (m) => buildLinkHtml(m[1], m[2]));
+  applyInlineStep(state, BAREURL_RE, (m) => buildBareUrlHtml(m[1], m[2]));
+  applyInlineStep(state, CODE_RESTORE_RE, (m) => '<code>' + codeBlocks[m[1]] + '</code>');
+
+  const segments = [];
+  let i = 0;
+  while (i < state.text.length) {
+    const g = state.grp[i];
+    let j = i + 1;
+    while (j < state.text.length && state.grp[j] === g) j++;
+    const html = state.text.slice(i, j);
+    const { srcStart, srcEnd } =
+      g === -1 ? { srcStart: state.srcIdx[i], srcEnd: state.srcIdx[j - 1] + 1 } : state.groupSpans[g];
+    segments.push({ srcStart, srcEnd, html, visibleText: decodeEntities(stripTagsQuoteAware(html)) });
+    i = j;
+  }
+  return segments;
 }
 
 function renderMarkdown(text) {
@@ -186,5 +464,5 @@ function renderMarkdown(text) {
 
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
-  module.exports = { renderMarkdown };
+  module.exports = { renderMarkdown, inlineMarkdown, inlineSegments };
 }

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -464,5 +464,5 @@ function renderMarkdown(text) {
 
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
-  module.exports = { renderMarkdown, inlineMarkdown, inlineSegments };
+  module.exports = { renderMarkdown, inlineMarkdown, inlineSegments, parseImageAlt };
 }

--- a/src/note-lines.js
+++ b/src/note-lines.js
@@ -77,9 +77,45 @@ function isImageOnlyLine(lineText) {
   return IMAGE_ONLY_LINE_RE.test(lineText);
 }
 
+/**
+ * インライン部（行頭マーカーを除いた raw 行の残り）の可視文字オフセットを raw オフセットへ
+ * 変換する。markdown-view の DOM 選択（可視テキスト基準）から生 Markdown の範囲を求めるのに使う
+ * （note.js の resolveSelectionPoint が、行頭マーカー分を除いた残りをここへ渡す）。
+ *
+ * inlineSegments(inlineRaw) の各セグメントを可視文字数で消費しながら探し、visibleOffset が
+ * 属するセグメント内の位置を raw オフセットへ写す。プレーンセグメント（装飾を伴わない素の
+ * テキスト）は可視文字と raw 文字が 1:1 対応するのでそのまま足す。装飾セグメント（**bold** 等）
+ * の内部（両端どちらでもない位置）に境界が落ちた場合は、記法を欠けさせないようセグメント全体を
+ * 含める側（開始端なら srcStart、終了端なら srcEnd）に丸める。
+ *
+ * @param {string} inlineRaw マーカーを除いた raw 行の残り
+ * @param {number} visibleOffset インライン部の可視文字数オフセット
+ * @param {boolean} isEnd 選択の終了端かどうか（装飾セグメント内部への丸め方向に使う）
+ * @returns {number} inlineRaw 上のオフセット
+ */
+function visibleOffsetToRawOffset(inlineRaw, visibleOffset, isEnd) {
+  const segments = inlineSegments(inlineRaw);
+  let consumed = 0;
+  for (const seg of segments) {
+    const segLen = seg.visibleText.length;
+    if (visibleOffset > consumed + segLen) {
+      consumed += segLen;
+      continue;
+    }
+    const within = visibleOffset - consumed;
+    const isPlain = seg.visibleText === inlineRaw.slice(seg.srcStart, seg.srcEnd);
+    if (isPlain) return seg.srcStart + within;
+    if (within <= 0) return seg.srcStart;
+    if (within >= segLen) return seg.srcEnd;
+    return isEnd ? seg.srcEnd : seg.srcStart;
+  }
+  return inlineRaw.length;
+}
+
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
   module.exports = {
     blockOffset, markerLength, getAutoPrefix, isEmptyListItem, CHECKBOX_RE, isImageOnlyLine,
+    visibleOffsetToRawOffset,
   };
 }

--- a/src/note.js
+++ b/src/note.js
@@ -309,6 +309,12 @@ function buildImagePreview(block) {
 // imageOccurrenceInLine と同じ考え方）。
 let selectedImage = null;
 
+// contextmenu ハンドラで「Markdown をコピー」用に計算し退避しておく生 Markdown 文字列。
+// メニュー表示前に flushContent() が挟まると DOM 選択（Range）が renderAll() で失われるため、
+// 退避はメニューを開く invoke の直前・DOM がまだ壊れていない時点で行う（詳細は contextmenu
+// リスナー側のコメント参照）。選択が無ければ null。
+let pendingMarkdownCopy = null;
+
 /** 選択を解除し、ハイライト用クラスと DOM 選択（Range）も剥がす。 */
 function clearImageSelection() {
   if (!selectedImage) return;
@@ -966,13 +972,32 @@ function htmlToMarkdown(html) {
   return resolveDataImages(dataImgSrcs).then(map => renderNodesToMd(doc.body.childNodes, map));
 }
 
-function nodeToMd(node, imageMap) {
+/**
+ * <pre>(内側に <code> があればその中身、無ければ <pre> 自身)のテキストをフェンス（```）で
+ * 囲んで返す。renderMarkdown のフェンス記法は行内に他の要素が無い前提の単純な正規表現
+ * （note-lines.js 参照）なので、内部の <span> 等の装飾タグは textContent で読み捨てて
+ * プレーンテキストへ潰す（構文ハイライト用にトークンごと <span> で包む貼り付け元でも、
+ * コード内容自体の改行・空白はそのまま残る）。
+ */
+function preToMd(node) {
+  const code = node.querySelector('code');
+  const text = (code || node).textContent.replace(/\n$/, '');
+  return text ? '```\n' + text + '\n```\n' : '';
+}
+
+/**
+ * @param depth リスト入れ子の深さ（1 が最上位）。ul/ol の子（li）へ入るときだけ +1 する。
+ *   li はこの深さから 2 スペース単位のインデントを算出する（markdown.js 側の入れ子判定と対応）。
+ */
+function nodeToMd(node, imageMap, depth = 0) {
   if (node.nodeType === Node.TEXT_NODE) return node.textContent;
   if (node.nodeType !== Node.ELEMENT_NODE) return '';
   const tag = node.tagName.toLowerCase();
   // Strip script/style tags entirely — their text content is never useful
   if (tag === 'script' || tag === 'style') return '';
-  const inner = Array.from(node.childNodes).map(child => nodeToMd(child, imageMap)).join('');
+  if (tag === 'pre') return preToMd(node);
+  const childDepth = (tag === 'ul' || tag === 'ol') ? depth + 1 : depth;
+  const inner = Array.from(node.childNodes).map(child => nodeToMd(child, imageMap, childDepth)).join('');
   switch (tag) {
     case 'a': {
       const href = node.getAttribute('href') || '';
@@ -990,14 +1015,23 @@ function nodeToMd(node, imageMap) {
     case 'blockquote':         return inner ? inner.split('\n').filter(l => l).map(l => `> ${l}`).join('\n') + '\n' : '';
     case 'ul': case 'ol':     return inner;
     case 'li': {
+      // 自身のインライン内容とネストした <ul>/<ol> を分けて処理する。混ぜて inner のまま
+      // 出すと、ネストしたリストが改行・インデント無しで自身の文末に連結され
+      // "- parent- child" のように潰れる
       const parent = node.parentElement?.tagName.toLowerCase();
-      if (parent === 'ol') {
-        const idx = Array.from(node.parentElement.children).indexOf(node) + 1;
-        return `${idx}. ${inner}\n`;
-      }
-      return `- ${inner}\n`;
+      const ownNodes = Array.from(node.childNodes)
+        .filter((c) => !(c.nodeType === Node.ELEMENT_NODE && ['UL', 'OL'].includes(c.tagName)));
+      const nestedLists = Array.from(node.children).filter((c) => ['UL', 'OL'].includes(c.tagName));
+      const ownText = ownNodes.map((c) => nodeToMd(c, imageMap, depth)).join('').trim();
+      const nestedMd = nestedLists.map((c) => nodeToMd(c, imageMap, depth)).join('');
+      const indent = '  '.repeat(Math.max(0, depth - 1));
+      const marker = parent === 'ol'
+        ? `${Array.from(node.parentElement.children).indexOf(node) + 1}. `
+        : '- ';
+      return `${indent}${marker}${ownText}\n${nestedMd}`;
     }
     case 'br':                 return '\n';
+    case 'hr':                 return '---\n';
     case 'p': case 'div':     return inner + '\n';
     // CSP の img-src が https を許可していないため、リモート URL は画像記法にせずリンクにする。
     // data: は resolveDataImages が保存済みの相対パスに解決済み（未解決なら alt のみ残す）。
@@ -1027,7 +1061,7 @@ function nodeToMd(node, imageMap) {
  * 挿入が完全に消えてしまわないよう text にフォールバックする（同期・非同期どちらの経路でも）。
  */
 function toMarkdown(text, html) {
-  if (!html || !/<(?:a|strong|b|em|i|del|s|code|h[1-3]|blockquote|[uo]l|li|img)\b/i.test(html)) {
+  if (!html || !/<(?:a|strong|b|em|i|del|s|code|pre|h[1-3]|blockquote|[uo]l|li|hr|img)\b/i.test(html)) {
     return text;
   }
   const converted = htmlToMarkdown(html);
@@ -1644,14 +1678,579 @@ document.addEventListener('mousedown', (e) => {
   clearImageSelection();
 });
 
+// ── Selection Copy (markdown-view) ─────────────────────────
+// 描画部分（markdown-view）の選択から、対応する生 Markdown の範囲を求める。通常コピー
+// （text/html + text/plain の同時セット）と「Markdown をコピー」（右クリックメニュー）が
+// この写像を共有する。詳細は各関数のコメント参照（可視オフセット → raw オフセットの
+// 純粋な変換自体は note-lines.js の visibleOffsetToRawOffset に持たせている）。
+
+/** .md-ordered 行だけが持つ、自動採番の表示専用プレフィックス（"1. " 等）の文字数。
+ * 他の行はマーカー（"- " 等）が inlineMarkdown に渡らず DOM に一切現れないため 0。 */
+function orderedDisplayPrefixLength(lineEl) {
+  const span = lineEl.querySelector(':scope > .md-order-num');
+  return span ? span.textContent.length + 1 : 0; // + 直後の区切りスペース
+}
+
+/** lineEl の可視テキスト先頭から (node, offset) までの文字数。node は lineEl 自身か
+ * その子孫である前提（呼び出し元が closest('[data-line]') で特定した後に渡す）。 */
+function visibleOffsetInLine(lineEl, node, offset) {
+  const range = document.createRange();
+  range.selectNodeContents(lineEl);
+  range.setEnd(node, offset);
+  return range.toString().length;
+}
+
+/**
+ * 選択の一端（node, offset）が指す位置を、文書全体での (行番号, raw 列オフセット) に変換する。
+ * isEnd は選択の終了端かどうか（装飾記法の内部に境界が落ちたときの丸め方向に使う。
+ * visibleOffsetToRawOffset 参照）。対応する行が見つからなければ null。
+ */
+function resolveSelectionPoint(node, offset, isEnd) {
+  let target = node;
+  let targetOffset = offset;
+  let el = target.nodeType === Node.ELEMENT_NODE ? target : target.parentElement;
+  let block = el ? el.closest('[data-line]') : null;
+  if (!block && target.nodeType === Node.ELEMENT_NODE && target.children.length > 0) {
+    // 選択端点が mdView 自身のようなコンテナを指している場合（offset は子要素インデックス）、
+    // 対応する子要素へ踏み込んで解決し直す。コンテナ末尾を指すオフセットは最後の子の末尾へ、
+    // それ以外はその子の先頭へ丸める
+    const container = target;
+    const atEnd = targetOffset >= container.children.length;
+    const child = container.children[atEnd ? container.children.length - 1 : targetOffset];
+    target = child;
+    targetOffset = atEnd ? child.childNodes.length : 0;
+    el = target;
+    block = el.closest('[data-line]');
+  }
+  if (!block) return null;
+
+  const line = Number(block.dataset.line);
+  const visible = visibleOffsetInLine(block, target, targetOffset);
+
+  if (block.matches('.md-codeblock')) {
+    // コードブロック: 可視テキストはフェンス内側の raw 行そのまま（改行で連結）なので、
+    // 可視オフセットから行・列を直接計算する。renderMarkdown の data-line-end は、閉じた
+    // フェンスでは「閉じフェンス行自身」（内容行はその手前まで）を指すが、未クローズ（EOF まで
+    // フェンスが閉じない）だと「最後の内容行自身」を指す（閉じフェンス行が存在しないため）。
+    // この違いを lines[lineEnd] が閉じフェンス行の形かどうかで判別し、内容行の終端をずらす
+    const lineEnd = Number(block.dataset.lineEnd);
+    const lines = getLines();
+    const closed = lineEnd > line && /^```\s*$/.test(lines[lineEnd] ?? '');
+    const lastContentLine = closed ? lineEnd - 1 : lineEnd;
+    if (lastContentLine < line + 1) {
+      // 内容行が 1 行も無い退化ケース（例: 閉じないまま "```" だけで EOF）。フェンス行自身へ逃がす
+      return { line, col: lines[line].length };
+    }
+    let remaining = visible;
+    for (let l = line + 1; l <= lastContentLine; l++) {
+      const text = lines[l];
+      if (l === lastContentLine || remaining <= text.length) {
+        return { line: l, col: Math.min(remaining, text.length) };
+      }
+      remaining -= text.length + 1; // + 行間の改行
+    }
+  }
+
+  const lineText = getLines()[line];
+  const markerLen = markerLength(lineText);
+  const inlineRaw = lineText.slice(markerLen);
+  const prefixLen = orderedDisplayPrefixLength(block);
+  const contentVisible = Math.max(0, visible - prefixLen);
+  const rawOffset = markerLen + visibleOffsetToRawOffset(inlineRaw, contentVisible, isEnd);
+  return { line, col: rawOffset };
+}
+
+/** コードブロックの行範囲（開始行〜終了行、フェンス行含む）を [start, end] のペア配列で返す。
+ * renderMarkdown が付ける data-line/data-line-end を DOM から読む。 */
+function codeBlockLineRanges() {
+  return Array.from(mdView.querySelectorAll('[data-line-end]'))
+    .map((el) => [Number(el.dataset.line), Number(el.dataset.lineEnd)]);
+}
+
+function isCodeBlockLine(ranges, l) {
+  return ranges.some(([s, e]) => l >= s && l <= e);
+}
+
+/** [openLine, dataLineEnd] から実際のフェンス情報を組み立てる。closed は data-line-end が
+ * 閉じフェンス行自身を指しているか（true）、内容行自身を指しているか（false・未クローズ）。
+ * resolveSelectionPoint のコードブロック分岐と同じ判定式。 */
+function codeBlockFenceInfo(lines, openLine, dataLineEnd) {
+  const closed = dataLineEnd > openLine && /^```\s*$/.test(lines[dataLineEnd] ?? '');
+  return {
+    closed,
+    openLine,
+    closeLine: closed ? dataLineEnd : null,
+    firstContentLine: openLine + 1,
+    lastContentLine: closed ? dataLineEnd - 1 : dataLineEnd,
+  };
+}
+
+/**
+ * コードブロックの可視テキストはフェンス内側の内容行だけなので、選択が内容行の全体（先頭〜末尾）
+ * にちょうど一致していても、開き・閉じフェンス行自体は行範囲に含まれない。これは非対称になりやすい
+ * （選択がブロックより上から始まれば開きフェンスは自然に含まれるが、内容の末尾ちょうどで終わる
+ * 選択では閉じフェンス行が範囲外に落ちる）。ここでは「内容行の先頭から選択が始まっていれば
+ * 開きフェンスも、内容行の末尾で選択が終わっていれば閉じフェンスも含める」よう両端を対称に拡張し、
+ * 「ブロックの可視テキスト全体を選択したらフェンス込みで丸ごと取れる」形に揃える。
+ * 未クローズのブロック（閉じフェンスが無い）、内容行が 1 行も無い空フェンス（別途
+ * expandZeroVisibleLineSelection が処理する退化ケース）は対象外。
+ */
+function expandCodeBlockFences(start, end, lines, codeBlockRanges) {
+  let newStart = start;
+  let newEnd = end;
+  for (const [openLine, dataLineEnd] of codeBlockRanges) {
+    const info = codeBlockFenceInfo(lines, openLine, dataLineEnd);
+    if (!info.closed || info.firstContentLine > info.lastContentLine) continue;
+    // 開始・終了それぞれが「そのブロックを覆っているか」を独立に見るだけでは、内容行の
+    // 一部（例: 複数行あるうちの 1 行だけ）を先頭〜末尾で選択したときに、片方の条件だけが
+    // 偶然成立してフェンスが片側にだけ付いてしまう（例: "```js\nline1" のような未クローズの
+    // 断片ができ、貼り戻すと以降の行までコードブロック化する）。両端が揃ってブロック全体を
+    // 覆っているときだけ拡張する
+    const startCovers = start.line < info.openLine
+      || (start.line === info.firstContentLine && start.col === 0);
+    const endCovers = end.line > info.closeLine
+      || (end.line === info.lastContentLine && end.col === lines[end.line].length);
+    if (!startCovers || !endCovers) continue;
+    if (start.line === info.firstContentLine && start.col === 0) {
+      newStart = { line: info.openLine, col: 0 };
+    }
+    if (end.line === info.lastContentLine && end.col === lines[end.line].length) {
+      newEnd = { line: info.closeLine, col: lines[info.closeLine].length };
+    }
+  }
+  return { start: newStart, end: newEnd };
+}
+
+/**
+ * hr（<hr> は子ノードを持たない）や内容行の無い空フェンス（<code> が空）は、その行に可視の
+ * テキストノードが 1 つも無い。resolveSelectionPoint は選択の開始・終了をテキストノード基準で
+ * 区別するため、その行だけを選択しても start/end が同じ点に潰れてしまう。この行だけを選択した
+ * 結果 start===end になっているときは、行（コードブロックなら開始行〜終了行）をまるごと採ることで
+ * この退化を吸収する。resolveSelectionRange・buildPlainFromSelection の両方が
+ * resolveSelectionBounds を経由するよう、ここで一元化する。
+ */
+function expandZeroVisibleLineSelection(start, end, lines) {
+  if (start.line !== end.line || start.col !== end.col) return { start, end };
+  const row = mdView.querySelector(`[data-line="${start.line}"]`);
+  if (row && row.classList.contains('md-hr')) {
+    return { start: { line: start.line, col: 0 }, end: { line: start.line, col: lines[start.line].length } };
+  }
+  if (row && row.tagName === 'PRE' && row.hasAttribute('data-line-end')) {
+    const code = row.querySelector('code');
+    if (!code || code.textContent.length === 0) {
+      const lineEndIdx = Number(row.dataset.lineEnd);
+      return { start: { line: start.line, col: 0 }, end: { line: lineEndIdx, col: lines[lineEndIdx].length } };
+    }
+  }
+  return { start, end };
+}
+
+/**
+ * DOM Range（markdown-view 内の選択）を生 Markdown 上の (行, 列) の開始・終了点へ解決する。
+ * resolveSelectionRange（Markdown をコピー）と buildPlainFromSelection（通常コピーの
+ * text/plain）が同じ行範囲・境界を共有するための土台。解決できなければ null。
+ */
+function resolveSelectionBounds(range) {
+  const start = resolveSelectionPoint(range.startContainer, range.startOffset, false);
+  const end = resolveSelectionPoint(range.endContainer, range.endOffset, true);
+  if (!start || !end) return null;
+  const lines = getLines();
+  const codeBlockRanges = codeBlockLineRanges();
+
+  // 開始行の可視オフセットが 0（= マーカー直後）なら、行頭（インデント・マーカー含む）から取る。
+  // コードブロック行を対象外にする理由は下の終了端と同じ（適用すると選択していない行頭の
+  // 生テキストまで巻き込む）
+  if (!isCodeBlockLine(codeBlockRanges, start.line) && start.col === markerLength(lines[start.line])) {
+    start.col = 0;
+  }
+  // 終了端が「次の行の可視オフセット 0」（＝その行のマーカー直後、内容は 1 文字も選択されて
+  // いない）に落ちている場合、終了端をその行の行頭（col 0）まで切り詰める。行頭からドラッグして
+  // 次の行の先頭で止める典型操作でここに落ちるが、切り詰めないとその行のマーカー（`> ` や
+  // `- [ ] ` 等）だけが選択に含まれてしまう（内容が 0 文字なのにマーカーだけ拾う不整合）。
+  // ただしコードブロック行には「マーカー相当の接頭辞」という概念が無く、行頭からの生テキストが
+  // そのまま可視テキストなので、この切り詰めを適用すると選択済みの文字を落としてしまう
+  // （例: `  - li` というコード行の可視オフセット 0 は raw の col 0 そのもの）。終了行が
+  // コードブロック行のときは対象外にする
+  if (
+    end.line > start.line
+    && !isCodeBlockLine(codeBlockRanges, end.line)
+    && end.col === markerLength(lines[end.line])
+  ) {
+    end.col = 0;
+  }
+
+  const fenceExpanded = expandCodeBlockFences(start, end, lines, codeBlockRanges);
+  const expanded = expandZeroVisibleLineSelection(fenceExpanded.start, fenceExpanded.end, lines);
+  return expanded;
+}
+
+/**
+ * DOM Range（markdown-view 内の選択）から、対応する生 Markdown 文字列を組み立てる。
+ * 解決できなければ null。
+ */
+function resolveSelectionRange(range) {
+  const bounds = resolveSelectionBounds(range);
+  if (!bounds) return null;
+  const { start, end } = bounds;
+  const lines = getLines();
+  if (start.line === end.line) return lines[start.line].slice(start.col, end.col);
+  const parts = [lines[start.line].slice(start.col)];
+  for (let l = start.line + 1; l < end.line; l++) parts.push(lines[l]);
+  parts.push(lines[end.line].slice(0, end.col));
+  return parts.join('\n');
+}
+
+/** src の拡張子（小文字）を返す。クエリ・フラグメントは無視する。読み取れなければ null。 */
+function imageExt(src) {
+  if (!src) return null;
+  const m = src.split(/[?#]/)[0].match(/\.([a-zA-Z0-9]+)$/);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/**
+ * 通常コピー（text/html・text/plain）で画像の代わりに載せる表示ラベルを alt・src から組み立てる。
+ * 生 Markdown の画像記法（`![alt](path)`）は UUID パス等が外部で意味を持たないため出さず、
+ * 常に「(〜)」の平文にする。alt があってもそのままでは無く拡張子付きにするのは、貼り付け先で
+ * 画像 1 枚ぶんだと分かるようにするため（例: alt「サンプル画像」+ .png → "(サンプル画像.png)"）。
+ *   - alt 非空・拡張子あり: "(alt.ext)"
+ *   - alt 非空・拡張子なし: "(alt)"
+ *   - alt 空・拡張子あり: i18n imageAltFallbackWithExt（例: "(画像.png)"）
+ *   - alt 空・拡張子なし: i18n imageAltFallback（例: "(画像)"）
+ * window.I18N を読み込まない場面・テスト環境でも壊れないよう、無ければ日本語のフォールバックを
+ * 返す（他の画像文言と同じパターン）。「Markdown をコピー」は生記法のままなのでここは使わない。
+ */
+function imageDisplayLabel(alt, src) {
+  const ext = imageExt(src);
+  if (alt) return ext ? `(${alt}.${ext})` : `(${alt})`;
+  const hasI18n = typeof window !== 'undefined' && window.I18N;
+  if (!ext) return hasI18n ? window.I18N.t('imageAltFallback') : '(画像)';
+  const template = hasI18n ? window.I18N.t('imageAltFallbackWithExt') : '(画像.{ext})';
+  return template.replace('{ext}', ext);
+}
+
+// 画像記法（![alt](src)）を raw 文字列中から検索する（非 global・先頭アンカーなし）。
+// リンクや装飾に包まれた画像（`[![alt](p)](url)` / `**![a](p)**` 等）はセグメント合併で
+// 1 つの装飾セグメントにまとまり、raw が画像記法だけでは終わらないため、完全一致ではなく検索で拾う
+const IMAGE_MARKDOWN_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/;
+
+/**
+ * インライン部分の raw 文字列から [localStart, localEnd) の範囲だけを、装飾記法を可視テキストへ
+ * 置換した文字列として取り出す。境界は呼び出し元（resolveSelectionPoint 経由）で常に装飾記法の
+ * 単位に丸められている前提のため、装飾セグメントは重なっていれば全体を含める。
+ * 画像は inlineSegments の visibleText がタグの中身（＝属性である alt）を拾えないため常に空になる。
+ * リンク・装飾に包まれた画像も同様に visibleText が空になる（stripTagsQuoteAware が <img> ごと
+ * 中身の無いタグとして扱うため）ので、raw に完全一致するかではなく「visibleText が空かつ html に
+ * <img を含む」ことで画像セグメントと判定し、raw から画像記法を検索して alt を取り出す。
+ */
+function inlineVisibleSlice(inlineRaw, localStart, localEnd) {
+  if (localStart >= localEnd) return '';
+  const segments = inlineSegments(inlineRaw);
+  let out = '';
+  for (const seg of segments) {
+    const segStart = Math.max(seg.srcStart, localStart);
+    const segEnd = Math.min(seg.srcEnd, localEnd);
+    if (segStart >= segEnd) continue;
+    const raw = inlineRaw.slice(seg.srcStart, seg.srcEnd);
+    if (raw === seg.visibleText) {
+      out += inlineRaw.slice(segStart, segEnd); // 装飾なしの素のテキスト。raw==visible なのでそのまま
+      continue;
+    }
+    if (seg.visibleText === '' && /<img\b/i.test(seg.html)) {
+      const imgMatch = raw.match(IMAGE_MARKDOWN_RE);
+      const { alt } = parseImageAlt(imgMatch ? imgMatch[1] : '');
+      out += imageDisplayLabel(alt, imgMatch ? imgMatch[2] : '');
+    } else {
+      out += seg.visibleText;
+    }
+  }
+  return out;
+}
+
+/**
+ * 通常コピーの text/plain。生 Markdown の行構造（インデント・リスト記号・チェックボックス
+ * 記法・コードフェンス・--- ・> ・# 見出しマーカー）はそのまま残し、インライン装飾（**太字** 等）
+ * だけを可視テキストへ置換する。resolveSelectionBounds を共有するため、「Markdown をコピー」
+ * （resolveSelectionRange）と行範囲・境界の丸めが一致する。
+ * @param bounds resolveSelectionBounds(range) の結果（呼び出し元と共有し二重に解決しない）。
+ *   null なら空文字を返す。
+ */
+function buildPlainFromSelection(range, bounds) {
+  if (!bounds) return '';
+  const { start, end } = bounds;
+  const lines = getLines();
+  // コードブロックの内容（フェンス行含む）は markdown 記法として解釈しない。renderMarkdown が
+  // 付ける data-line/data-line-end の範囲を DOM から読み、その行はインライン装飾の置換を
+  // 一切行わず raw のまま返す
+  const codeBlockRanges = codeBlockLineRanges();
+
+  const renderSlice = (lineIdx, colStart, colEnd) => {
+    const lineText = lines[lineIdx];
+    if (isCodeBlockLine(codeBlockRanges, lineIdx)) return lineText.slice(colStart, colEnd);
+    const markerLen = markerLength(lineText);
+    const markerPart = lineText.slice(Math.min(colStart, markerLen), Math.min(colEnd, markerLen));
+    const inlineRaw = lineText.slice(markerLen);
+    const localStart = Math.max(0, colStart - markerLen);
+    const localEnd = Math.max(0, colEnd - markerLen);
+    return markerPart + inlineVisibleSlice(inlineRaw, localStart, localEnd);
+  };
+
+  if (start.line === end.line) return renderSlice(start.line, start.col, end.col);
+  const parts = [renderSlice(start.line, start.col, lines[start.line].length)];
+  for (let l = start.line + 1; l < end.line; l++) parts.push(renderSlice(l, 0, lines[l].length));
+  parts.push(renderSlice(end.line, 0, end.col));
+  return parts.join('\n');
+}
+
+// ── 通常コピーの text/html セマンティック変換 ──────────────────────
+// 描画 DOM（.md-h1 等の CSS クラス）をそのまま text/html に載せると、貼り付け先
+// （Google Docs / Notion / Slack / Word / 別の付箋）は独自クラスに意味を持たないため
+// 見出し・リスト・コードブロックの構造が失われる。行要素の並びを見出し・リスト・
+// 引用・コードブロックのセマンティック HTML（h1〜h3 / ul・ol / blockquote / pre）へ
+// 変換してから text/html に載せる。htmlToMarkdown（リッチテキストペースト変換）が
+// 読める形に合わせてあり、別の付箋へ貼り戻すと構造が概ね復元される。
+
+/** 行要素のクラスから、変換で使う種別を判定する。markdown.js の renderMarkdown の
+ * 分岐と対応させている。 */
+function lineElementKind(row) {
+  if (row.tagName === 'PRE') return 'codeblock';
+  if (row.classList.contains('md-h1')) return 'h1';
+  if (row.classList.contains('md-h2')) return 'h2';
+  if (row.classList.contains('md-h3')) return 'h3';
+  if (row.classList.contains('md-check')) return 'check';
+  if (row.classList.contains('md-ordered')) return 'ordered';
+  if (row.classList.contains('md-bullet')) return 'bullet';
+  if (row.classList.contains('md-blockquote')) return 'blockquote';
+  if (row.classList.contains('md-hr')) return 'hr';
+  if (row.classList.contains('md-empty')) return 'empty';
+  return 'line'; // .md-line（無印の行）
+}
+
+/** md-indent-N クラスからインデントレベルを読む（無ければ 0）。 */
+function lineElementIndentLevel(row) {
+  const m = Array.from(row.classList).find((c) => /^md-indent-\d$/.test(c));
+  return m ? Number(m.slice('md-indent-'.length)) : 0;
+}
+
+/** class・data-* 属性と <input>（チェックボックスの入力要素。可視テキストを持たない）を
+ * すべて落とす（アプリ内部の状態で、貼り付け先には意味を持たないため）。
+ * <a> は data-url を落とすだけで href はそのまま残す。 */
+function stripInternalAttrs(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  div.querySelectorAll('input').forEach((el) => el.remove());
+  div.querySelectorAll('*').forEach((el) => {
+    el.removeAttribute('class');
+    Array.from(el.attributes).forEach((attr) => {
+      if (attr.name.startsWith('data-')) el.removeAttribute(attr.name);
+    });
+  });
+  return div.innerHTML;
+}
+
+/** リスト系の行種別（bullet/ordered/check）かどうか。連続グループ化・ツリー構築で
+ * 「リスト行かどうか」を種別混在のまま束ねるために使う。 */
+function isListKind(kind) {
+  return kind === 'bullet' || kind === 'ordered' || kind === 'check';
+}
+
+/**
+ * 1 つのリスト項目行（bullet/ordered/check）から <li> の中身を取り出す。
+ * ordered は自動採番の表示専用プレフィックス（.md-order-num）を、check は
+ * <input> を、それぞれ構造から除いて内容だけにする。
+ * ordered の表示番号はクローン（選択範囲によっては .md-order-num が欠けている）ではなく、
+ * mdView 上の元の行要素から読む（fix: 番号スパンより後ろから選択しても正しい番号を拾う）。
+ */
+function extractListItemContent(kind, row) {
+  if (kind === 'check') {
+    const input = row.querySelector('input');
+    const checked = !!(input && input.checked);
+    const span = row.querySelector('span');
+    // to-do ブロックとして解釈するペースト先は無いため平文に落とすが、`[x] `/`[ ] ` の形にして
+    // おくことで、貼り戻し先が別の付箋なら htmlToMarkdown 経由で本物のチェックボックスに戻る
+    const html = (checked ? '[x] ' : '[ ] ') + (span ? stripInternalAttrs(span.innerHTML) : '');
+    return { html };
+  }
+  if (kind === 'ordered') {
+    const original = mdView.querySelector(`[data-line="${row.dataset.line}"]`) || row;
+    const numSpan = original.querySelector('.md-order-num');
+    const num = numSpan ? parseInt(numSpan.textContent, 10) || 1 : 1;
+    const clone = row.cloneNode(true);
+    clone.querySelector('.md-order-num')?.remove();
+    // .md-order-num の直後にある区切りスペース 1 文字ぶんも一緒に落とす
+    const html = stripInternalAttrs(clone.innerHTML.replace(/^ /, ''));
+    return { html, num };
+  }
+  return { html: stripInternalAttrs(row.innerHTML) }; // bullet
+}
+
+/** フラットな { level, kind, html, num } の並びを、level の差にもとづく親子ツリーへ組み立てる。
+ * kind は各ノードが自分の <ul>/<ol> をどちらで開くかの判断に使う（bullet/ordered/check が
+ * 混在した入れ子でも、ノードごとに正しいタグへ振り分けられるようにするため）。 */
+function buildListTree(items) {
+  const base = Math.min(...items.map((it) => it.level));
+  const root = { level: base - 1, children: [] };
+  const stack = [root];
+  for (const item of items) {
+    while (stack.length > 1 && stack[stack.length - 1].level >= item.level) stack.pop();
+    const node = { level: item.level, kind: item.kind, html: item.html, num: item.num, children: [] };
+    stack[stack.length - 1].children.push(node);
+    stack.push(node);
+  }
+  return root.children;
+}
+
+/** ツリーの 1 階層ぶんを直列化する。同じ階層内でも種別（bullet/ordered/check）が変われば
+ * <ul>/<ol> を区切り直す（check は <ul> 扱い）。ordered の各 <li> には元の行要素から読んだ
+ * 表示番号を value として個別に付ける。renderMarkdown は番号行以外（bullet 等）が挟まると
+ * カウンタをリセットするため、入れ子を挟んだ番号リストは画面上「1 / 1 / 2」のように連番が
+ * 途中でリセットされることがあるが、種別混在でも 1 つの <ol> にまとめる都合上ブラウザの
+ * 既定の自動採番（1 / 2 / 3）に任せると食い違う。<li value> で個々の番号を明示することで
+ * 貼り付け先の採番を画面表示・text/plain と一致させる */
+function serializeListTree(nodes) {
+  let out = '';
+  let i = 0;
+  while (i < nodes.length) {
+    const kind = nodes[i].kind;
+    const tag = kind === 'ordered' ? 'ol' : 'ul';
+    const startAttr = kind === 'ordered' ? ` start="${nodes[i].num}"` : '';
+    out += `<${tag}${startAttr}>`;
+    while (i < nodes.length && nodes[i].kind === kind) {
+      const valueAttr = kind === 'ordered' ? ` value="${nodes[i].num}"` : '';
+      out += `<li${valueAttr}>${nodes[i].html}`;
+      if (nodes[i].children.length) out += serializeListTree(nodes[i].children);
+      out += '</li>';
+      i++;
+    }
+    out += `</${tag}>`;
+  }
+  return out;
+}
+
+/** 連続するリスト行（bullet/ordered/check が混在してよい）1 ブロックぶんを <ul>/<ol> の
+ * 入れ子ツリーに組み立てる。種別の変わり目でリストが分断されないよう、レベル差による
+ * 親子関係は種別をまたいで判定する。 */
+function buildListHtml(rows) {
+  const items = rows.map((row) => {
+    const kind = lineElementKind(row);
+    return { level: lineElementIndentLevel(row), kind, ...extractListItemContent(kind, row) };
+  });
+  return serializeListTree(buildListTree(items));
+}
+
+/**
+ * トップレベルが行要素（mdView 直下の [data-line] 要素）の並びであるクローンを、
+ * セマンティック HTML へ変換する。連続する同種の行（リスト・引用）はまとめて 1 ブロックにする。
+ */
+function rowsToSemanticHtml(rows) {
+  const out = [];
+  let i = 0;
+  while (i < rows.length) {
+    const row = rows[i];
+    const kind = lineElementKind(row);
+    if (kind === 'h1' || kind === 'h2' || kind === 'h3') {
+      out.push(`<${kind}>${stripInternalAttrs(row.innerHTML)}</${kind}>`);
+      i++;
+    } else if (kind === 'hr') {
+      out.push('<hr>');
+      i++;
+    } else if (kind === 'empty') {
+      out.push('<p></p>');
+      i++;
+    } else if (kind === 'codeblock') {
+      const code = row.querySelector('code');
+      // Google Docs / Word 等は HTML ペーストでコードブロックの書式を持たないため、
+      // 等幅フォントで見分けられるよう inline style を付ける
+      out.push(`<pre style="font-family: monospace"><code>${code ? code.innerHTML : ''}</code></pre>`);
+      i++;
+    } else if (kind === 'blockquote') {
+      const lines = [];
+      while (i < rows.length && lineElementKind(rows[i]) === 'blockquote') {
+        lines.push(`<p>${stripInternalAttrs(rows[i].innerHTML)}</p>`);
+        i++;
+      }
+      out.push(`<blockquote>${lines.join('')}</blockquote>`);
+    } else if (isListKind(kind)) {
+      const group = [];
+      while (i < rows.length && isListKind(lineElementKind(rows[i]))) {
+        group.push(rows[i]);
+        i++;
+      }
+      out.push(buildListHtml(group));
+    } else {
+      out.push(`<p>${stripInternalAttrs(row.innerHTML)}</p>`); // .md-line
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * range.cloneContents() から通常コピー用の text/html・text/plain を組み立てる。
+ * img は元パスがアプリ外で解決できないため、html・plain どちらも alt テキストへ置き換える
+ * （置換後の同じクローンを両方の生成元にする）。
+ * 選択範囲が生 Markdown の (行, 列) へ解決できない場合（例: 空の付箋のプレースホルダ表示
+ * 「メモを入力…」は [data-line] を持たず、resolveSelectionPoint が対応する行を見つけられない）
+ * は null を返す。この場合、呼び出し元は独自のコピー処理をせず既定のコピーに任せる
+ * （解決できない DOM の断片を html・plain にそのまま流し込まないため）。
+ */
+function buildSelectionCopyPayload(range) {
+  const bounds = resolveSelectionBounds(range);
+  if (!bounds) return null;
+
+  const container = document.createElement('div');
+  container.appendChild(range.cloneContents());
+  container.querySelectorAll('img').forEach((img) => {
+    const alt = img.getAttribute('alt') || '';
+    // data-rel-src は renderMarkdown が書いた raw の相対パス（resolveImageSrc 前）。
+    // 拡張子の見た目を安定させるため、asset URL 化された src ではなくこちらを優先する
+    const src = img.dataset.relSrc || img.getAttribute('src') || '';
+    img.replaceWith(document.createTextNode(imageDisplayLabel(alt, src)));
+  });
+
+  // html: クローンのトップレベルに「行要素」（mdView 直下の要素の複製。常に <div data-line>
+  // か <pre data-line>）が 1 つでもあれば、行の並びとしてセマンティック HTML へ変換する。
+  // 複数行にまたがる選択はもちろん、選択が 1 行しか触れていなくても、その境界が
+  // 「行の手前」のようなコンテナレベルの位置（mdView 直下の子オフセット）で表現されている
+  // ときは、cloneContents がその行を属性ごとまるごと複製する（commonAncestorContainer が
+  // mdView になり、行要素は「完全または部分的に範囲内にある mdView の子」として扱われるため）。
+  // これは「行をまるごと選択する」典型的な操作（例: 行頭から次行の手前までドラッグ）で実際に
+  // 起こる形。<input data-line>（チェックボックス）や .md-order-num の span も data-line
+  // 相当の属性を持つことがあるが、それらは tagName が DIV/PRE ではないため区別できる
+  const hasRowElement = Array.from(container.children).some(
+    (el) => el.hasAttribute('data-line') && (el.tagName === 'DIV' || el.tagName === 'PRE'),
+  );
+  const html = hasRowElement
+    ? rowsToSemanticHtml(Array.from(container.children))
+    : stripInternalAttrs(container.innerHTML);
+
+  // plain: DOM クローンではなく、選択範囲の (行, 列) を生 Markdown へ解決する
+  // buildPlainFromSelection を使う（text/plain の仕様。行構造は raw のまま、インライン
+  // 装飾だけ可視テキストへ置換する。詳細は同関数のコメント参照）
+  const plain = buildPlainFromSelection(range, bounds);
+  return { html, plain };
+}
+
 // 画像選択中の ⌘C/⌘X はネイティブ Edit メニューのショートカットとして処理される
 // （keydown まで届かない）。selectImage が張った DOM 選択のおかげでメニュー項目が有効になり、
 // メニュー経由の Copy/Cut が WebKit の copy/cut イベントとして DOM に届く。selectedImage が
 // 無いとき（通常のテキスト選択）は preventDefault せず、ブラウザ既定のコピー/カットに任せる
 document.addEventListener('copy', (e) => {
-  if (!selectedImage) return;
+  if (selectedImage) {
+    e.preventDefault();
+    copySelectedImage();
+    return;
+  }
+  const sel = window.getSelection();
+  if (!sel.rangeCount || sel.isCollapsed) return; // 選択なしは既定に任せる（何もしない）
+  const range = sel.getRangeAt(0);
+  const ed = activeEditor();
+  if (ed && range.intersectsNode(ed)) return; // .raw-editor に触れる選択は既定の編集操作に任せる
+  if (!mdView.contains(range.commonAncestorContainer)) return;
+  const payload = buildSelectionCopyPayload(range);
+  if (!payload) return; // 生 Markdown へ解決できない選択（プレースホルダ等）は既定のコピーに任せる
   e.preventDefault();
-  copySelectedImage();
+  e.clipboardData.setData('text/html', payload.html);
+  e.clipboardData.setData('text/plain', payload.plain);
 });
 
 document.addEventListener('cut', (e) => {
@@ -1785,6 +2384,32 @@ window.addEventListener('beforeunload', () => {
 document.addEventListener('contextmenu', async (e) => {
   if (e.shiftKey) return;
   e.preventDefault();
+  // 「Markdown をコピー」の対象は、メニュー表示前のこの時点で計算して退避しておく。
+  // 直後の flushContent() は入力中の行を renderAll() で描画し直しうり、DOM 選択（Range）が
+  // 生きたまま invoke → メニュー表示まで持つ保証が無いため。resolveSelectionRange は未クローズの
+  // コードフェンスなど選択範囲の形によっては例外を投げうるため、ここで拾って握りつぶす
+  // （投げっぱなしにすると e.preventDefault() 済みのままメニューが一切開かなくなる）
+  let hasSelection = false;
+  try {
+    const sel = window.getSelection();
+    if (sel.rangeCount && !sel.isCollapsed) {
+      const range = sel.getRangeAt(0);
+      const ed = activeEditor();
+      const touchesRawEditor = ed && range.intersectsNode(ed);
+      if (!touchesRawEditor && mdView.contains(range.commonAncestorContainer)) {
+        const markdown = resolveSelectionRange(range);
+        // 空文字（可視文字ゼロ行の退化ケース等）なら、空のクリップボード書き込みを防ぐため
+        // 選択なし扱いにする（Rust 側は hasSelection が false ならメニュー項目自体を出さない）
+        if (markdown) {
+          pendingMarkdownCopy = markdown;
+          hasSelection = true;
+        }
+      }
+    }
+  } catch (err) {
+    console.error('resolve selection for context menu failed:', err);
+  }
+  if (!hasSelection) pendingMarkdownCopy = null;
   // メニューから削除が選ばれてもよいように、開く前に保存を済ませておく
   await flushContent();
   const img = e.target.closest('img[data-rel-src]');
@@ -1795,8 +2420,18 @@ document.addEventListener('contextmenu', async (e) => {
     isPinned: pinBtn.classList.contains('active'),
     currentColor: currentColor,
     imagePath,
+    hasSelection,
   }).catch(e => console.error('context menu failed:', e));
 });
+
+// 右クリックメニューの「Markdown をコピー」。contextmenu ハンドラが退避した
+// pendingMarkdownCopy をここで消費する（選択が無ければ Rust 側はメニュー項目自体を出さない）
+unlisteners.push(appWindow.listen('ctx-copy-markdown', () => {
+  const text = pendingMarkdownCopy;
+  pendingMarkdownCopy = null;
+  if (text == null) return;
+  invoke('copy_markdown', { text }).catch(e => console.error('copy markdown failed:', e));
+}));
 
 // ── Expose for Playwright tests ──────────────────────
 window.htmlToMarkdown = htmlToMarkdown;
@@ -1808,6 +2443,7 @@ window.changeZoom = changeZoom;
 window.resetZoom = resetZoom;
 window.performUndo = performUndo;
 window.performRedo = performRedo;
+window.resolveSelectionRange = resolveSelectionRange;
 
 
 // ── Keyboard: color dots (Enter/Space/Arrow) ───────

--- a/tests/unit/markdown-inline-segments.test.js
+++ b/tests/unit/markdown-inline-segments.test.js
@@ -1,0 +1,331 @@
+const { test, describe } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { escapeHtml } = require("../../src/utils.js");
+global.escapeHtml = escapeHtml;
+const { inlineMarkdown, inlineSegments } = require("../../src/markdown.js");
+
+// inlineMarkdown はインライン記法(bold/italic/del/code/image/link/裸URL)の変換本体。
+// ここでは escapeHtml 済みの文字列を直接渡し、素の逐次置換チェーンの出力をゴールデンマスターとして固定する。
+// inlineSegments は raw（escapeHtml 前）テキストを受け取る独立経路で、同じ置換チェーンを
+// オフセット追跡しながら適用する。html はどちらの経路でも 1 バイトも変わらない前提。
+//
+// 現実装の癖（そのまま固定している）:
+// - ネスト（*a **b** c*）: bold が先に置換されるため、em が strong を包む
+// - リンクテキストが URL のケース（[https://a.example](https://b.example)）:
+//   link 変換後に残る内側の URL テキストがバレ URL 変換の対象になり、<a> の中に <a> がネストする
+// - *** / **** の境界ケース: bold の非貪欲マッチと italic の再マッチが交差し、
+//   開始・終了タグの対応が入れ子として揃わない（<strong><em>text</strong></em> 等）
+// - 装飾直後に裸URLが続くケース（**https://u**https://u 等）: 裸URL変換のマッチが
+//   直前の装飾 group の途中に触れるため、inlineSegments 側は装飾と裸URLをまとめて
+//   1 セグメントに合併する（group が 2 つのセグメントに分裂しないための不変条件）
+const corpus = [
+  { name: "plain text", raw: "hello world", html: "hello world" },
+  { name: "empty string", raw: "", html: "" },
+  { name: "bold only", raw: "**bold**", html: "<strong>bold</strong>" },
+  { name: "italic only", raw: "*italic*", html: "<em>italic</em>" },
+  { name: "strikethrough only", raw: "~~del~~", html: "<del>del</del>" },
+  { name: "code only", raw: "`code`", html: "<code>code</code>" },
+  {
+    name: "bold and italic combined",
+    raw: "**bold** and *italic*",
+    html: "<strong>bold</strong> and <em>italic</em>",
+  },
+  {
+    name: "italic wraps bold (nested)",
+    raw: "*a **b** c*",
+    html: "<em>a <strong>b</strong> c</em>",
+  },
+  {
+    name: "code protects bold marker inside",
+    raw: "`**not bold**`",
+    html: "<code>**not bold**</code>",
+  },
+  {
+    name: "code protects italic marker inside",
+    raw: "`*a*`",
+    html: "<code>*a*</code>",
+  },
+  {
+    name: "bold containing code",
+    raw: "**bold `code` here**",
+    html: "<strong>bold <code>code</code> here</strong>",
+  },
+  { name: "unclosed bold", raw: "**a", html: "**a" },
+  { name: "unclosed italic", raw: "*a", html: "*a" },
+  { name: "unclosed code", raw: "`a", html: "`a" },
+  {
+    name: "image basic",
+    raw: "![alt](images/a.png)",
+    html: '<img alt="alt" src="images/a.png" data-rel-src="images/a.png" title="ダブルクリックで開く">',
+  },
+  {
+    name: "image with width",
+    raw: "![alt|300](images/a.png)",
+    html: '<img alt="alt" src="images/a.png" data-rel-src="images/a.png" title="ダブルクリックで開く" width="300">',
+  },
+  {
+    name: "image empty alt",
+    raw: "![](images/a.png)",
+    html: '<img alt="" src="images/a.png" data-rel-src="images/a.png" title="ダブルクリックで開く">',
+  },
+  {
+    name: "link",
+    raw: "[text](https://example.com)",
+    html: '<a href="https://example.com" data-url="https://example.com">text</a>',
+  },
+  {
+    name: "bare url",
+    raw: "visit https://example.com today",
+    html: 'visit <a href="https://example.com" data-url="https://example.com">https://example.com</a> today',
+  },
+  {
+    name: "link text is a different url",
+    raw: "[https://a.example](https://b.example)",
+    html:
+      '<a href="https://b.example" data-url="https://b.example">' +
+      '<a href="https://a.example" data-url="https://a.example">https://a.example</a></a>',
+  },
+  {
+    name: "url right after a quote (skip case)",
+    raw: '"https://example.com',
+    html: '"https://example.com',
+  },
+  {
+    name: "url right after equals (skip case)",
+    raw: "=https://example.com",
+    html: "=https://example.com",
+  },
+  { name: "escaped ampersand input", raw: "a & b", html: "a &amp; b" },
+  { name: "escaped lt input", raw: "a < b", html: "a &lt; b" },
+  {
+    name: "triple asterisks",
+    raw: "***text***",
+    html: "<strong><em>text</strong></em>",
+  },
+  {
+    name: "quadruple asterisks",
+    raw: "****text****",
+    html: "<strong>*<em>text</strong></em>*",
+  },
+  {
+    name: "image nested inside link",
+    raw: "[![alt](images/a.png)](https://example.com)",
+    html:
+      '<a href="https://example.com" data-url="https://example.com">' +
+      '<img alt="alt" src="images/a.png" data-rel-src="images/a.png" title="ダブルクリックで開く"></a>',
+  },
+  // 装飾直後に隙間なく裸URLが続くケース: 裸URL変換のマッチが直前の装飾 group の
+  // 途中に触れるため、group が分裂しないことの検証になる
+  {
+    name: "bold immediately followed by a bare url (reported bug repro)",
+    raw: "**https://u**https://u",
+    html:
+      '<strong><a href="https://u" data-url="https://u">https://u</a></strong>' +
+      '<a href="https://u" data-url="https://u">https://u</a>',
+  },
+  {
+    name: "italic immediately followed by a bare url (reported bug repro)",
+    raw: "*ahttps://u*https://u",
+    html:
+      '<em>a<a href="https://u" data-url="https://u">https://u</a></em>' +
+      '<a href="https://u" data-url="https://u">https://u</a>',
+  },
+  {
+    name: "strikethrough immediately followed by a bare url (reported bug repro)",
+    raw: "~~https://u~~https://u",
+    html:
+      '<del><a href="https://u" data-url="https://u">https://u</a></del>' +
+      '<a href="https://u" data-url="https://u">https://u</a>',
+  },
+  {
+    name: "triple-asterisk bold immediately followed by a bare url (reported bug repro)",
+    raw: "***https://u**https://u",
+    html:
+      '<strong>*<a href="https://u" data-url="https://u">https://u</a></strong>' +
+      '<a href="https://u" data-url="https://u">https://u</a>',
+  },
+  // 裸URLの直後に隙間なくコードスパンが続くケース: code 復元ステップが href/data-url
+  // 属性値の中にまで <code> タグを混入させる（置換チェーンの癖）。タグ除去が引用符を
+  // 意識しないと属性値内の '>' で誤って切れ、visibleText に属性値の断片が漏れ出す
+  {
+    name: "bare url immediately followed by a code span (visibleText bug repro)",
+    raw: "https://u`x`",
+    html: '<a href="https://u<code>x</code>" data-url="https://u<code>x</code>">https://u<code>x</code></a>',
+  },
+  {
+    name: "link whose url is immediately followed by a code span (visibleText bug repro)",
+    raw: "[t](https://u`x`)",
+    html: '<a href="https://u<code>x</code>" data-url="https://u<code>x</code>">t</a>',
+  },
+];
+
+describe("inlineMarkdown — ゴールデンマスター", () => {
+  for (const { name, raw, html } of corpus) {
+    test(name, () => {
+      assert.equal(inlineMarkdown(escapeHtml(raw)), html);
+    });
+  }
+});
+
+// visibleText（DOM textContent 相当）を、実装（src/markdown.js の stripTagsQuoteAware +
+// decodeEntities）とは別の書き方で独立に計算する。トートロジー再発防止のため、実装と
+// 同じ「文字を1つずつ舐めるループ」ではなく indexOf でタグの開始位置へジャンプする方式にし、
+// エンティティのデコードも replace ではなく split/join にして式そのものを変えている
+function independentTextContent(html) {
+  let out = "";
+  let pos = 0;
+  while (pos < html.length) {
+    const lt = html.indexOf("<", pos);
+    if (lt === -1) {
+      out += html.slice(pos);
+      break;
+    }
+    out += html.slice(pos, lt);
+    let cursor = lt + 1;
+    let quote = null;
+    while (cursor < html.length) {
+      const ch = html[cursor];
+      if (quote) {
+        if (ch === quote) quote = null;
+      } else if (ch === '"' || ch === "'") {
+        quote = ch;
+      } else if (ch === ">") {
+        cursor++;
+        break;
+      }
+      cursor++;
+    }
+    pos = cursor;
+  }
+  return out.split("&lt;").join("<").split("&gt;").join(">").split("&amp;").join("&");
+}
+
+describe("inlineSegments — 不変条件", () => {
+  for (const { name, raw } of corpus) {
+    test(name, () => {
+      const segments = inlineSegments(raw);
+
+      // 被覆: [0, raw.length) を隙間なく覆う
+      let cursor = 0;
+      for (const seg of segments) {
+        assert.equal(seg.srcStart, cursor, `srcStart は直前の srcEnd と連続する: ${name}`);
+        assert.ok(seg.srcEnd > seg.srcStart, `srcEnd は srcStart より大きい: ${name}`);
+        cursor = seg.srcEnd;
+      }
+      assert.equal(cursor, raw.length, `全セグメントの合計が raw 全体を覆う: ${name}`);
+
+      // 装飾セグメントを含め、全セグメントの raw.slice(srcStart, srcEnd) を順に連結すると raw 全体に一致する
+      const joinedSrc = segments.map((s) => raw.slice(s.srcStart, s.srcEnd)).join("");
+      assert.equal(joinedSrc, raw, `セグメントの src 範囲を連結すると raw に一致する: ${name}`);
+
+      // html 一致: 連結すると inlineMarkdown(escapeHtml(raw)) の出力と完全一致する
+      const joinedHtml = segments.map((s) => s.html).join("");
+      assert.equal(
+        joinedHtml,
+        inlineMarkdown(escapeHtml(raw)),
+        `html 連結が inlineMarkdown(escapeHtml(raw)) と一致する: ${name}`
+      );
+
+      // プレーンセグメント（装飾を含まない）では visibleText === raw.slice(srcStart, srcEnd)
+      for (const seg of segments) {
+        if (!/[<>]/.test(seg.html)) {
+          assert.equal(
+            seg.visibleText,
+            raw.slice(seg.srcStart, seg.srcEnd),
+            `プレーンセグメントの visibleText は raw の対応部分と一致する: ${name}`
+          );
+        }
+      }
+
+      // 全セグメントで visibleText が、独立実装（タグ除去 + エンティティデコード）の結果と一致する
+      for (const seg of segments) {
+        assert.equal(
+          seg.visibleText,
+          independentTextContent(seg.html),
+          `visibleText は独立実装のタグ除去(引用符対応)+デコード結果と一致する: ${name}`
+        );
+      }
+    });
+  }
+
+  test("空文字列はセグメント 0 件", () => {
+    assert.deepEqual(inlineSegments(""), []);
+  });
+});
+
+// ── inlineMarkdown / inlineSegments 二経路の出力一致 (property test) ──────────────
+// inlineMarkdown（素の逐次置換チェーン）と inlineSegments（オフセット追跡付きの別経路）は
+// 同じ置換チェーンを共有しているはずだが、経路が分かれている以上、固定コーパスだけでは
+// 突き合わせきれない組み合わせが残る。シード固定の擬似乱数（xorshift32）で
+// Markdown 記法に使う記号（改行・日本語・サロゲートペア・バッククォートと URL の隣接形を含む）
+// を交えたランダム入力を大量生成し、以下を検証する。Math.random / Date.now は使わない
+// （実行のたびに再現性が変わってしまうため）:
+//   (a) セグメント被覆の連続性（[0, raw.length) を隙間なく覆う）
+//   (b) 全セグメントの raw.slice(srcStart, srcEnd) を連結すると raw に一致する
+//   (c) html 連結が inlineMarkdown(escapeHtml(raw)) と一致する
+//   (d) visibleText が独立実装（タグ除去（引用符対応）+ エンティティデコード）の結果と一致する
+describe("inlineMarkdown / inlineSegments — 二経路の出力一致 (fuzz)", () => {
+  function makeRng(seed) {
+    let s = seed >>> 0 || 1;
+    return function next() {
+      s ^= s << 13;
+      s >>>= 0;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      s >>>= 0;
+      return s / 0x100000000;
+    };
+  }
+
+  const TOKENS = [
+    "*", "**", "***", "~~", "`", "!", "[", "]", "(", ")",
+    "https://", "example.com", "u", "https://u`x`", "https://u**x**",
+    "&", "<", ">", '"', "=",
+    " ", "a", "b", "1",
+    "\n", "あいう", "😀", // 改行 / 日本語 / サロゲートペア（絵文字）
+  ];
+
+  function randomRaw(rng) {
+    const len = Math.floor(rng() * 14);
+    let out = "";
+    for (let i = 0; i < len; i++) {
+      out += TOKENS[Math.floor(rng() * TOKENS.length)];
+    }
+    return out;
+  }
+
+  // シードは固定のまま複数本走らせ、単一シードの偏りに依存しないようにする
+  const SEEDS = [1, 7, 42, 1234, 20260828];
+  const ITERATIONS = 4000;
+
+  for (const seed of SEEDS) {
+    test(`fuzz: シード ${seed} で ${ITERATIONS} 件のランダム入力を検証`, () => {
+      const rng = makeRng(seed);
+      for (let n = 0; n < ITERATIONS; n++) {
+        const raw = randomRaw(rng);
+        const context = () => `seed=${seed} raw=${JSON.stringify(raw)} (iteration ${n})`;
+
+        const segments = inlineSegments(raw);
+
+        let cursor = 0;
+        for (const seg of segments) {
+          assert.equal(seg.srcStart, cursor, context());
+          assert.ok(seg.srcEnd > seg.srcStart, context());
+          cursor = seg.srcEnd;
+        }
+        assert.equal(cursor, raw.length, context());
+
+        const joinedSrc = segments.map((s) => raw.slice(s.srcStart, s.srcEnd)).join("");
+        assert.equal(joinedSrc, raw, context());
+
+        const joinedHtml = segments.map((s) => s.html).join("");
+        assert.equal(joinedHtml, inlineMarkdown(escapeHtml(raw)), context());
+
+        for (const seg of segments) {
+          assert.equal(seg.visibleText, independentTextContent(seg.html), context());
+        }
+      }
+    });
+  }
+});

--- a/tests/unit/note-lines.test.js
+++ b/tests/unit/note-lines.test.js
@@ -1,6 +1,11 @@
 const { test, describe } = require("node:test");
 const assert = require("node:assert/strict");
 
+// visibleOffsetToRawOffset は inlineSegments をブラウザのグローバルスコープ経由で参照する
+// （note.html の読み込み順で markdown.js → note-lines.js の順に読まれるのを前提にしている）。
+// markdown-codeblock.test.js の escapeHtml と同じ作法で、require 前に global へ生やす
+global.inlineSegments = require("../../src/markdown.js").inlineSegments;
+
 const {
   blockOffset,
   markerLength,
@@ -8,6 +13,7 @@ const {
   isEmptyListItem,
   CHECKBOX_RE,
   isImageOnlyLine,
+  visibleOffsetToRawOffset,
 } = require("../../src/note-lines.js");
 
 describe("getAutoPrefix", () => {
@@ -331,5 +337,80 @@ describe("isImageOnlyLine", () => {
 
   test("パストラバーサル細工 → false", () => {
     assert.equal(isImageOnlyLine("![](images/../notes.json)"), false);
+  });
+});
+
+describe("visibleOffsetToRawOffset", () => {
+  // ── プレーン行: 可視文字と raw 文字が 1:1 ─────────────────
+  test("プレーン行は可視オフセットがそのまま raw オフセット", () => {
+    const raw = "hello world";
+    for (let i = 0; i <= raw.length; i++) {
+      assert.equal(visibleOffsetToRawOffset(raw, i, false), i);
+      assert.equal(visibleOffsetToRawOffset(raw, i, true), i);
+    }
+  });
+
+  test("空文字列は 0 を返す", () => {
+    assert.equal(visibleOffsetToRawOffset("", 0, false), 0);
+  });
+
+  // ── 装飾セグメントの両端（自然な境界） ─────────────────
+  test("装飾セグメントの開始境界（within=0）は srcStart", () => {
+    // "**bold** tail" → 可視は "bold tail"。可視 0 は raw 0（"**" の直前）
+    assert.equal(visibleOffsetToRawOffset("**bold** tail", 0, false), 0);
+  });
+
+  test("装飾セグメントの終了境界（within=segLen）は srcEnd", () => {
+    // 可視 "bold"（4 文字）の直後 = raw の "**bold**"（8 文字）の直後
+    assert.equal(visibleOffsetToRawOffset("**bold** tail", 4, true), 8);
+    assert.equal(visibleOffsetToRawOffset("**bold** tail", 4, false), 8);
+  });
+
+  // ── 装飾セグメント内部への境界（丸め） ─────────────────
+  test("装飾セグメント内部・開始端（isEnd=false）は srcStart に丸める（記法を欠けさせない）", () => {
+    // 可視 "bo|ld"（2 文字目、"**bold**" の内部）→ 開始端なら raw 全体の先頭へ拡張
+    assert.equal(visibleOffsetToRawOffset("**bold** tail", 2, false), 0);
+  });
+
+  test("装飾セグメント内部・終了端（isEnd=true）は srcEnd に丸める（記法を欠けさせない）", () => {
+    assert.equal(visibleOffsetToRawOffset("**bold** tail", 2, true), 8);
+  });
+
+  test("取り消し線 ~~del~~ でも同様に丸める", () => {
+    assert.equal(visibleOffsetToRawOffset("~~del~~", 1, false), 0);
+    assert.equal(visibleOffsetToRawOffset("~~del~~", 1, true), 7);
+  });
+
+  // ── 画像記法: 可視文字数 0 ─────────────────────────────
+  test("画像記法は可視文字を持たず、直前の可視オフセットが raw 上の画像記法の開始位置に解決される", () => {
+    const raw = "before ![alt](images/00000000-0000-4000-8000-000000000001.png) after";
+    // "before " は可視 7 文字（raw も同じ 7 文字）、続く画像は可視 0 文字を挟むので、
+    // "before " の直後（可視オフセット 7）は isEnd の向きに関わらず同じ raw オフセット 7 に解決される
+    // （画像自体には選び取れる可視位置が無いため、開始端・終了端の区別が意味を持たない）
+    assert.equal(visibleOffsetToRawOffset(raw, 7, false), 7);
+    assert.equal(visibleOffsetToRawOffset(raw, 7, true), 7);
+  });
+
+  // ── コードスパン ────────────────────────────────────────
+  test("`code` の内部も装飾セグメントとして境界を欠けさせない", () => {
+    const raw = "see `foo` here";
+    // 可視 "foo" は raw の "`foo`"（5 文字）に対応
+    assert.equal(visibleOffsetToRawOffset(raw, 4, false), 4); // "see " の直後は 1:1
+    assert.equal(visibleOffsetToRawOffset(raw, 5, true), 9); // "foo" の直後 → "`foo`" の直後
+    assert.equal(visibleOffsetToRawOffset(raw, 5, false), 4); // "foo" の内部1文字目 → 開始端に丸め
+  });
+
+  // ── HTML エンティティを生む文字 ─────────────────────────
+  test("& < > を含む行でも可視オフセットは raw 1 文字ずつに対応する", () => {
+    const raw = "a & b < c > d";
+    for (let i = 0; i <= raw.length; i++) {
+      assert.equal(visibleOffsetToRawOffset(raw, i, false), i);
+    }
+  });
+
+  // ── 可視末尾を超えるオフセット ───────────────────────────
+  test("可視文字数の合計を超えるオフセットは raw 末尾にクランプする", () => {
+    const raw = "**bold**";
+    assert.equal(visibleOffsetToRawOffset(raw, 999, false), raw.length);
   });
 });

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -55,6 +55,7 @@ export async function injectNoteMock(
         case "delete_image":          return null;
         case "copy_image":            return null;
         case "cut_image":             return null;
+        case "copy_markdown":         return null;
         default:                      return null;
       }
     };

--- a/tests/visual/html-to-markdown.spec.ts
+++ b/tests/visual/html-to-markdown.spec.ts
@@ -89,6 +89,11 @@ test.describe("htmlToMarkdown", () => {
       .toBe("line1\nline2");
   });
 
+  test("hr → ---", async ({ notePage }) => {
+    expect(await convert(notePage, "<p>before</p><hr><p>after</p>"))
+      .toBe("before\n---\nafter\n");
+  });
+
   // ── Edge cases: empty nodes ──────────────────────────────
   test("empty <strong> produces no output", async ({ notePage }) => {
     expect(await convert(notePage, "<strong></strong>")).toBe("");
@@ -270,6 +275,58 @@ test.describe("htmlToMarkdown", () => {
   test("alt に改行を含む https image → 空白に置換", async ({ notePage }) => {
     expect(await convert(notePage, '<img src="https://example.com/cat.png" alt="line1\nline2">'))
       .toBe("[line1 line2](https://example.com/cat.png)");
+  });
+
+  // ── ネストした ul/ol → 2 スペース単位のインデント ─────────
+  test("ネストした ul → 親の文末に潰れず、2 スペースインデントの入れ子行になる", async ({ notePage }) => {
+    expect(await convert(notePage, "<ul><li>parent<ul><li>child</li></ul></li></ul>"))
+      .toBe("- parent\n  - child\n");
+  });
+
+  test("ネストした ol → 親の直下の子は 1 から採番し直し、2 スペースインデントになる", async ({ notePage }) => {
+    expect(await convert(notePage, "<ol><li>one<ol><li>two</li></ol></li><li>three</li></ol>"))
+      .toBe("1. one\n  1. two\n2. three\n");
+  });
+
+  test("2 階層ネストした ul → インデントが階層ぶん積み重なる", async ({ notePage }) => {
+    expect(await convert(
+      notePage,
+      "<ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>",
+    )).toBe("- a\n  - b\n    - c\n");
+  });
+
+  test("兄弟 li にネストしたリストがあっても、後続の兄弟 li は巻き込まれない", async ({ notePage }) => {
+    expect(await convert(
+      notePage,
+      "<ul><li>a<ul><li>a1</li></ul></li><li>b</li></ul>",
+    )).toBe("- a\n  - a1\n- b\n");
+  });
+
+  // ── pre → フェンス（```） ──────────────────────────────────
+  test("pre > code → フェンスで囲む", async ({ notePage }) => {
+    expect(await convert(notePage, "<pre><code>const x = 1;</code></pre>"))
+      .toBe("```\nconst x = 1;\n```\n");
+  });
+
+  test("複数行の pre > code → 改行を保持したままフェンスで囲む", async ({ notePage }) => {
+    expect(await convert(notePage, "<pre><code>line1\nline2</code></pre>"))
+      .toBe("```\nline1\nline2\n```\n");
+  });
+
+  test("code の無い pre → pre 自身のテキストをフェンスで囲む", async ({ notePage }) => {
+    expect(await convert(notePage, "<pre>plain</pre>")).toBe("```\nplain\n```\n");
+  });
+
+  // 構文ハイライト目的でトークンごとに <span> を挟む貼り付け元（VS Code 等）を想定
+  test("pre > code 内の装飾タグ（構文ハイライト等）はテキストとして読み捨てる", async ({ notePage }) => {
+    expect(await convert(
+      notePage,
+      '<pre><code><span class="hljs-keyword">const</span> x = 1;</code></pre>',
+    )).toBe("```\nconst x = 1;\n```\n");
+  });
+
+  test("空の pre は出力しない", async ({ notePage }) => {
+    expect(await convert(notePage, "<pre></pre>")).toBe("");
   });
 
   // ── img: 同一 data: URI の重複 ────────────────────────────

--- a/tests/visual/selection-copy-e2e.spec.ts
+++ b/tests/visual/selection-copy-e2e.spec.ts
@@ -1,0 +1,1198 @@
+import { test, expect, injectNoteMock, enterEdit } from "./fixtures";
+
+// 描画部分（markdown-view）のテキスト選択に対するコピー挙動（issue #70）。
+// - 通常コピー（⌘C 相当）: text/html（装飾付き）と text/plain を同時にクリップボードへ載せる。
+//   text/plain は行構造（インデント・リスト記号・チェックボックス記法・コードフェンス・
+//   --- ・> ・# 見出しマーカー）は raw のまま残し、インライン装飾（**太字** 等）だけを
+//   可視テキストへ置換したもの（「形式なしでも構造が読める」ことを狙う）
+// - 「Markdown をコピー」（右クリックメニュー）: 選択範囲の生 Markdown 記法のままコピーする
+// 実際の Range 選択はマウスドラッグではなく、note.js と同じ nodeAt 方式で DOM 上の
+// (行, 可視オフセット) から Range を組み立てて再現する。
+
+/** markdown-view の (行, 可視オフセット) の 2 点を DOM 選択（Range）として張る。note.js の
+ * nodeAt と同じアルゴリズムをページ内で組み立てる（行末を超えるオフセットは行末にクランプ）。 */
+function selectMarkdownRange(
+  page: import("@playwright/test").Page,
+  startLine: number,
+  startOffset: number,
+  endLine: number,
+  endOffset: number,
+) {
+  return page.evaluate(
+    ([sl, so, el, eo]) => {
+      const pointAtInPage = (elm: Element, visibleOffset: number) => {
+        const walker = document.createTreeWalker(elm, NodeFilter.SHOW_TEXT);
+        let remaining = visibleOffset;
+        let node: Text | null;
+        let last: Text | null = null;
+        while ((node = walker.nextNode() as Text | null)) {
+          last = node;
+          if (remaining <= node.textContent!.length) return { node, offset: remaining };
+          remaining -= node.textContent!.length;
+        }
+        return last ? { node: last, offset: last.textContent!.length } : { node: elm, offset: 0 };
+      };
+      const startEl = document.querySelector(`#markdown-view [data-line="${sl}"]`)!;
+      const endEl = document.querySelector(`#markdown-view [data-line="${el}"]`)!;
+      const start = pointAtInPage(startEl, so as number);
+      const end = pointAtInPage(endEl, eo as number);
+      const range = document.createRange();
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    },
+    [startLine, startOffset, endLine, endOffset] as const,
+  );
+}
+
+/** document へ copy の ClipboardEvent を dispatch し、preventDefault の有無とセットされた
+ * text/html・text/plain を返す。 */
+function dispatchCopyWithClipboardData(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const dt = new DataTransfer();
+    const ev = new ClipboardEvent("copy", { bubbles: true, cancelable: true, clipboardData: dt });
+    const notCanceled = document.dispatchEvent(ev);
+    return {
+      notCanceled,
+      html: dt.getData("text/html"),
+      plain: dt.getData("text/plain"),
+    };
+  });
+}
+
+function capturedCalls(page: import("@playwright/test").Page, cmd: string) {
+  return page.evaluate(
+    (c) => (window as any).__captured_invokes.filter((call: any) => call.cmd === c),
+    cmd,
+  );
+}
+
+test.describe("通常コピー（markdown-view のテキスト選択、⌘C 相当）", () => {
+  test("複数行選択: text/plain に記法が含まれず、text/html に装飾タグが含まれ、preventDefault される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "**bold** line0\nline1 text" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 1 行目全体（可視 "bold line0"）〜 2 行目全体（"line1 text"）を選択
+    await selectMarkdownRange(page, 0, 0, 1, "line1 text".length);
+
+    const { notCanceled, html, plain } = await dispatchCopyWithClipboardData(page);
+
+    expect(notCanceled).toBe(false); // preventDefault() された
+    expect(plain).toBe("bold line0\nline1 text");
+    expect(plain).not.toContain("**");
+    expect(html).toContain("<strong>bold</strong>");
+
+    await ctx.close();
+  });
+
+  test("画像を含む選択: text/html に img タグが無く、alt テキストで代替される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+    await injectNoteMock(
+      page,
+      { content: `before\n![caption](${IMAGE_PATH})\nafter` },
+      {},
+      { captureInvokes: true },
+    );
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 2, "after".length);
+
+    const { html, plain } = await dispatchCopyWithClipboardData(page);
+
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain(IMAGE_PATH);
+    expect(html).toContain("caption");
+    expect(plain).not.toContain("![");
+
+    await ctx.close();
+  });
+
+  test(".raw-editor 内の選択に触れる copy は preventDefault されない（既定動作に任せる）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "editable line" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await enterEdit(page, 0);
+    await page.evaluate(() => {
+      const ed = document.querySelector("#editor")!;
+      const range = document.createRange();
+      range.selectNodeContents(ed);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { notCanceled } = await dispatchCopyWithClipboardData(page);
+    expect(notCanceled).toBe(true); // preventDefault されていない = 既定のコピーに任せた
+
+    await ctx.close();
+  });
+
+  test("選択なしの copy は何もしない（text/html・text/plain がセットされない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "plain line" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => window.getSelection()?.removeAllRanges());
+
+    const { notCanceled, html, plain } = await dispatchCopyWithClipboardData(page);
+    expect(notCanceled).toBe(true);
+    expect(html).toBe("");
+    expect(plain).toBe("");
+
+    await ctx.close();
+  });
+
+  test("1 行内で装飾をまたぐ部分選択: plain はインライン装飾だけ外した可視テキストになる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    // raw: "abc **bold** def" / 可視: "abc bold def"
+    await injectNoteMock(page, { content: "abc **bold** def" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 可視 "abc bold def" の 1 文字目〜10 文字目（"bc bold d"）。<strong> の内部をまたぐ部分選択
+    await selectMarkdownRange(page, 0, 1, 0, 10);
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("bc bold d");
+
+    await ctx.close();
+  });
+
+  test("序数リスト行の全選択: plain は raw の番号マーカーを含む行そのものになる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "1. item text" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("1. item text");
+
+    await ctx.close();
+  });
+
+  // renderMarkdown は番号行の連続ブロックごとに 1 から自動採番し直す（raw の数字は無視する）ため、
+  // 画面表示の番号と raw の番号がずれることがある。plain は raw の番号をそのまま残す仕様（画面
+  // 表示に合わせて採番し直さない）ことを、raw と表示がずれる具体例で確認する
+  test("番号リストの raw 番号が画面表示の連番と異なっていても、plain は raw の番号のまま残す", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    // renderMarkdown は新しい番号ブロックを常に 1 から表示するため、raw で "5." と書いても
+    // 画面表示は "1." になる
+    await injectNoteMock(page, { content: "5. item text" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("5. item text");
+
+    await ctx.close();
+  });
+
+  test("チェックボックス行の全選択: plain は raw のチェックボックス記法（- [ ] ）を含む行そのものになる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "- [ ] task text" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("- [ ] task text");
+
+    await ctx.close();
+  });
+});
+
+test.describe("通常コピー: text/html のセマンティック変換（複数行選択）", () => {
+  test("見出し・入れ子リスト・チェックボックス・引用・コードブロック・空行・通常行が構造化された HTML になり、data-*/class を含まない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = [
+      "# Heading",
+      "- a",
+      "  - a1",
+      "- b",
+      "- [ ] todo",
+      "- [x] done",
+      "> q1",
+      "> q2",
+      "plain line",
+      "```",
+      "code line",
+      "```",
+      "",
+      "last line",
+    ].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 13, "last line".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+
+    expect(html).toBe(
+      "<h1>Heading</h1>"
+      + "<ul><li>a<ul><li>a1</li></ul></li><li>b</li></ul>"
+      + "<ul><li>[ ] todo</li><li>[x] done</li></ul>"
+      + "<blockquote><p>q1</p><p>q2</p></blockquote>"
+      + "<p>plain line</p>"
+      + '<pre style="font-family: monospace"><code>code line</code></pre>'
+      + "<p></p>"
+      + "<p>last line</p>",
+    );
+    expect(html).not.toMatch(/data-|class=/);
+
+    await ctx.close();
+  });
+
+  test("番号リストの途中から選択しても、画面に見えている番号が <ol start> に反映される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["1. i1", "2. i2", "3. i3", "4. i4"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 3 番目の項目（表示上 "3."）から末尾まで選択
+    await selectMarkdownRange(page, 2, 0, 3, "4. i4".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    expect(html).toBe('<ol start="3"><li value="3">i3</li><li value="4">i4</li></ol>');
+
+    await ctx.close();
+  });
+
+  // .md-order-num（自動採番の表示専用プレフィックス）より後ろから選択が始まると、選択範囲の
+  // クローンにはそのスパンが含まれない。クローンから番号を読むと拾えず 1 にフォールバックして
+  // 画面の番号とずれるバグがあったため、元の行要素（mdView 側）から番号を読むことを確認する
+  test("番号スパンより後ろ（項目本文の途中）から選択しても <ol start> が画面の番号のままになる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["1. i1", "2. i2", "3. i3", "4. i4"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // "3. i3" の "3. " の直後（"i3" の "i" の手前）から選択開始
+    await selectMarkdownRange(page, 2, 3, 3, "4. i4".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    expect(html).toBe('<ol start="3"><li value="3">i3</li><li value="4">i4</li></ol>');
+
+    await ctx.close();
+  });
+
+  // renderMarkdown は番号行以外（bullet 等）が挟まるとカウンタをリセットするため、入れ子を
+  // 挟んだ番号リストは画面表示・text/plain が「1 / 1 / 2」のように連番が途中でリセットされる
+  // ことがある。種別混在でも 1 つの <ol> にまとめる仕様上、value を付けないとブラウザの既定の
+  // 自動採番（1 / 2 / 3）に頼ることになり画面表示と食い違うため、各 <li> に value を明示する
+  test("入れ子を挟んだ番号リスト（bullet でカウンタがリセットされる）→ 各 <li> に画面表示どおりの value が付く", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["1. one", "  - sub", "1. two", "2. three"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 3, "2. three".length);
+
+    const { html, plain } = await dispatchCopyWithClipboardData(page);
+    // plain は raw の行構造のまま（インデント・"- " マーカーも残る）。画面表示・html の value は
+    // 「1 / 1 / 2」（"1. two" の直前の bullet 行でカウンタがリセットされる）
+    expect(plain).toBe("1. one\n  - sub\n1. two\n2. three");
+    expect(html).toBe(
+      '<ol start="1"><li value="1">one<ul><li>sub</li></ul></li>'
+      + '<li value="1">two</li><li value="2">three</li></ol>',
+    );
+
+    await ctx.close();
+  });
+
+  // 種別（bullet/ordered/check）ごとに連続グループを分けると種別をまたぐ入れ子が失われる。
+  // レベル差による親子関係は種別をまたいで判定し、ノードごとに正しいタグ（check は ul）へ
+  // 振り分けられることを確認する
+  test("bullet の下に check がネストしても、種別ごとに分断されず 1 つのリストにまとまる", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["- 買い物", "  - [ ] 牛乳", "  - [ ] パン", "- 掃除"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 3, "掃除".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    expect(html).toBe(
+      "<ul><li>買い物<ul><li>[ ] 牛乳</li><li>[ ] パン</li></ul></li><li>掃除</li></ul>",
+    );
+
+    await ctx.close();
+  });
+
+  // htmlToMarkdown に通すと `- [ ] 牛乳` の形に戻り、本物のチェックボックスとして復元される
+  // （li 先頭が `[ ] `/`[x] ` の平文になっているため、貼り戻し先で `- [ ] ...` と解釈される）
+  test("round-trip: 種別混在（bullet の下に check）の入れ子も元の Markdown にそのまま戻る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["- 買い物", "  - [ ] 牛乳", "  - [ ] パン", "- 掃除"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 3, "掃除".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    const roundTripped = await page.evaluate((h: string) => (window as any).htmlToMarkdown(h), html);
+
+    expect((roundTripped as string).replace(/\n$/, "")).toBe(content);
+
+    await ctx.close();
+  });
+
+  // htmlToMarkdown（リッチテキストペースト変換）に通し、別の付箋へ貼り戻したときに構造が
+  // 復元されることを確認する。チェックボックスも `[x] `/`[ ] ` の平文表現から `- [x] `/`- [ ] `
+  // として本物のチェックボックスに復元される
+  test("round-trip: 生成した text/html を htmlToMarkdown に通すと、元の Markdown にそのまま戻る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const lines = [
+      "# Title",
+      "- a",
+      "  - a1",
+      "- b",
+      "1. x",
+      "2. y",
+      "---",
+      "> q1",
+      "> q2",
+      "```",
+      "code",
+      "```",
+      "",
+      "plain",
+      "- [ ] todo",
+      "- [x] done",
+    ];
+    const content = lines.join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 15, "- [x] done".length);
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    const roundTripped = await page.evaluate((h: string) => (window as any).htmlToMarkdown(h), html);
+
+    // nodeToMd は各ブロックの末尾に \n を付けるため、末尾に 1 つ多く付く分だけ剥がして比較する
+    expect((roundTripped as string).replace(/\n$/, "")).toBe(content);
+
+    await ctx.close();
+  });
+});
+
+test.describe("通常コピー: text/plain（行構造は raw のまま、インライン装飾だけ外す）", () => {
+  test("見出し・リスト（入れ子）・チェックボックス・引用・区切り線・コードブロック・空行を含む複数行選択で、マーカー・インデント・フェンスが残り、コード内の装飾記法は外さない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = [
+      "# **Heading**",
+      "- *italic* item",
+      "  - `code` sub",
+      "- [ ] ~~strike~~ todo",
+      "> quote **bold**",
+      "---",
+      "```",
+      "raw **not** stripped",
+      "```",
+      "",
+      "5. five",
+    ].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 10, "5. five".length);
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe(
+      "# Heading\n"
+      + "- italic item\n"
+      + "  - code sub\n"
+      + "- [ ] strike todo\n"
+      + "> quote bold\n"
+      + "---\n"
+      + "```\n"
+      + "raw **not** stripped\n" // コードブロックの中身は markdown 記法として解釈しない（raw のまま）
+      + "```\n"
+      + "\n"
+      + "5. five", // renderMarkdown は表示上 "1." に採番し直すが、plain は raw の "5." を残す
+    );
+
+    await ctx.close();
+  });
+
+  // 「行頭から次行の先頭までドラッグ」の典型操作では、選択終端が次行の可視オフセット 0
+  // （＝そのマーカー直後、内容は 1 文字も選択されていない）に落ちる。resolveSelectionBounds が
+  // これを切り詰めないと、次行のマーカー（`> ` / `- [ ] ` / `1. ` 等）だけが混入してしまう
+  test("選択終端が次行の先頭（可視オフセット 0）に落ちても、次行のマーカーが混入しない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["first line", "> quote", "- [ ] task", "1. item"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 1 行目の先頭（0,0）〜 2 行目の可視オフセット 0（"> " の直後、内容の手前）
+    await selectMarkdownRange(page, 0, 0, 1, 0);
+    const { plain: plainQuote } = await dispatchCopyWithClipboardData(page);
+    expect(plainQuote).toBe("first line\n");
+    expect(plainQuote).not.toContain(">");
+
+    // 2 行目の先頭（0,0）〜 3 行目の可視オフセット 0（"- [ ] " の直後、内容の手前）
+    await selectMarkdownRange(page, 1, 0, 2, 0);
+    const { plain: plainCheck } = await dispatchCopyWithClipboardData(page);
+    expect(plainCheck).toBe("> quote\n");
+    expect(plainCheck).not.toContain("[ ]");
+
+    // 3 行目の先頭（0,0）〜 4 行目の可視オフセット 0（"1. " の直後、内容の手前）
+    await selectMarkdownRange(page, 2, 0, 3, 0);
+    const { plain: plainOrdered } = await dispatchCopyWithClipboardData(page);
+    expect(plainOrdered).toBe("- [ ] task\n");
+    expect(plainOrdered).not.toContain("1.");
+
+    await ctx.close();
+  });
+
+  // コード行にはマーカーという概念が無く、raw の生テキストがそのまま可視テキストになる。
+  // 「終了端が次行の可視オフセット 0（＝マーカー長と一致）なら切り詰める」正規化を無条件に
+  // 適用すると、コード行の内容がたまたまマーカーパターン（"- " 等）に一致する文字数で選択を
+  // 止めたときに、選択済みの文字（この場合 "  - "）ごと落ちてしまっていた
+  test("コードブロック内で終了端がマーカー相当の文字数と一致しても、選択済みの文字が落ちない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["head", "```", "  - li", "```"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const w0 = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const t0 = w0.nextNode() as Text;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(t0, 0);
+      range.setEnd(tc, 4); // "  - li" の "  - "（4 文字）の直後で止める
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("head\n```\n  - ");
+
+    await ctx.close();
+  });
+
+  test("コードブロック内で開始端がマーカー相当の文字数と一致しても、選択していない行頭が混入しない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["```", "  - listish", "```"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(tc, 4); // "  - listish" の "  - "（4 文字）の直後から始める
+      range.setEnd(tc, 8); // "list" まで
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("list");
+
+    await ctx.close();
+  });
+
+  // コードブロックの可視テキストはフェンス内側の内容行だけなので、選択終端が「閉じた
+  // ブロックの最後の内容行の末尾」に解決されると、閉じフェンス行が行スライスの範囲外に落ちる
+  // （開きフェンスは選択がブロック上方から入ると自然に含まれるのに非対称だった）
+  test("選択終端がブロックの最後の内容行の末尾に一致すると、閉じフェンス行を含めて取る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["head", "```", "code line", "```"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const w0 = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const t0 = w0.nextNode() as Text;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(t0, 0);
+      range.setEnd(tc, tc.textContent!.length); // "code line" の末尾ちょうど
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("head\n```\ncode line\n```");
+
+    await ctx.close();
+  });
+
+  // ブロックの可視テキスト全体（内容行の先頭〜末尾）をちょうど選択した場合、開き・閉じ両方の
+  // フェンスを含めて丸ごと取れる（非対称にしない）
+  test("ブロックの可視テキスト全体（内容行のみ）を選択すると、開き・閉じ両方のフェンスを含めて取る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["```", "code line", "```"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const range = document.createRange();
+      range.selectNodeContents(codeEl); // 内容行の可視テキスト全体（"code line"）だけを選択
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("```\ncode line\n```");
+
+    await ctx.close();
+  });
+
+  // 複数行あるブロックのうち 1 行だけ（先頭〜末尾）を選択したときは、その行が
+  // ブロックの最初の内容行でも最後の内容行でもない限り、両端が揃ってブロック全体を覆っては
+  // いないためフェンスを付けない。片側だけ付くと未クローズの断片ができ、貼り戻すと以降の行まで
+  // コードブロック化してしまう
+  test("複数行あるブロックの内容行 1 行だけを選択（先頭〜末尾）しても、フェンスは付かない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = ["```js", "line1", "line2", "```"].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text; // "line1\nline2"
+      const range = document.createRange();
+      range.setStart(tc, 0);
+      range.setEnd(tc, "line1".length); // "line1" の先頭〜末尾だけ（"line2" には触れない）
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("line1");
+
+    await ctx.close();
+  });
+});
+
+test.describe("通常コピー: 画像（alt 空/非空）", () => {
+  const IMAGE_PATH = "images/00000000-0000-4000-8000-000000000001.png";
+
+  test("alt が非空 + 拡張子あり → html・plain とも「(alt.拡張子)」になる（生 Markdown 記法は出さない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = [
+      `with alt ![cat](${IMAGE_PATH}) end`,
+      `no alt ![](${IMAGE_PATH}) end`,
+    ].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 2 行目の可視テキストは "no alt " + [img は可視文字を持たない] + " end" = "no alt  end"（11 文字）
+    await selectMarkdownRange(page, 0, 0, 1, "no alt  end".length);
+
+    const { html, plain } = await dispatchCopyWithClipboardData(page);
+    // alt 非空（"cat"）も拡張子付きにする（"(cat.png)"）。alt 空のフォールバックラベルも
+    // src の拡張子を含める（"(画像.png)"）
+    expect(html).toBe("<p>with alt (cat.png) end</p><p>no alt (画像.png) end</p>");
+    expect(plain).toBe("with alt (cat.png) end\nno alt (画像.png) end");
+    expect(html).not.toContain(IMAGE_PATH);
+    expect(plain).not.toContain(IMAGE_PATH);
+    expect(html).not.toContain("![");
+    expect(plain).not.toContain("![");
+
+    await ctx.close();
+  });
+
+  test("拡張子が読み取れないパスなら、alt 非空は「(alt)」、alt 空は「(画像)」のまま", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = [
+      "with alt ![cat](https://example.com/image) end",
+      "no alt ![](https://example.com/image) end",
+    ].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // 2 行目の可視テキストは "no alt " + [img は可視文字を持たない] + " end" = "no alt  end"（11 文字）
+    await selectMarkdownRange(page, 0, 0, 1, "no alt  end".length);
+
+    const { html, plain } = await dispatchCopyWithClipboardData(page);
+    expect(html).toBe("<p>with alt (cat) end</p><p>no alt (画像) end</p>");
+    expect(plain).toBe("with alt (cat) end\nno alt (画像) end");
+
+    await ctx.close();
+  });
+
+  // リンクや装飾に包まれた画像（`[![alt](p)](url)` / `**![a](p)**`）は inlineSegments が
+  // リンク・装飾と画像をまとめて 1 つのセグメントに合併するため、raw が画像記法だけでは
+  // 終わらず完全一致にならない。visibleText が空になる点は素の画像と同じなので、それで判定する
+  test("リンク・装飾に包まれた画像も「(alt.拡張子)」またはフォールバックラベルになる（消えない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    const content = [
+      `[![alt](${IMAGE_PATH})](https://example.com) after`,
+      `**![b](${IMAGE_PATH})** after`,
+    ].join("\n");
+    await injectNoteMock(page, { content }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 1, "b after".length);
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("(alt.png) after\n(b.png) after");
+
+    await ctx.close();
+  });
+});
+
+// hr（<hr> は子ノードを持たない）や内容行の無い空フェンス（<code> が空）は、その行に可視の
+// テキストノードが 1 つも無い。resolveSelectionPoint は選択の開始・終了をテキストノード基準で
+// 区別するため、その行だけを選択しても start/end が同じ点に潰れ、plain が空文字になっていた
+test.describe("通常コピー: 可視文字を持たない行だけの選択", () => {
+  test("--- のみの全選択 → plain が --- になる（空文字にならない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "---" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const mdView = document.getElementById("markdown-view")!;
+      const range = document.createRange();
+      range.selectNodeContents(mdView);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("---");
+
+    await ctx.close();
+  });
+
+  test("内容行の無い空フェンスのみの全選択 → plain がフェンスそのものになる（空文字にならない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "```\n```" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const mdView = document.getElementById("markdown-view")!;
+      const range = document.createRange();
+      range.selectNodeContents(mdView);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { plain } = await dispatchCopyWithClipboardData(page);
+    expect(plain).toBe("```\n```");
+
+    await ctx.close();
+  });
+});
+
+test.describe("通常コピー: 生 Markdown へ解決できない選択は既定のコピーに任せる", () => {
+  test("空の付箋（プレースホルダ表示）を選択して copy → preventDefault されず、text/html にプレースホルダ文言が載らない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const placeholder = document.querySelector(".md-placeholder")!;
+      const range = document.createRange();
+      range.selectNodeContents(placeholder);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { notCanceled, html, plain } = await dispatchCopyWithClipboardData(page);
+    expect(notCanceled).toBe(true); // preventDefault されていない = 既定のコピーに任せた
+    expect(html).toBe("");
+    expect(plain).toBe("");
+
+    await ctx.close();
+  });
+});
+
+// 「1 行だけ選択」は cloneContents() の形が選択の張り方で 2 通りに分かれる：
+// (a) 選択の境界が mdView 直下の子オフセット（コンテナレベル）で表現される場合、その行要素は
+//     属性ごとまるごと複製される（行頭から次行の手前までドラッグする等、実際の操作で起こる）。
+//     こちらは rowsToSemanticHtml を通し、見出し等の構造を維持する
+// (b) 選択の両端がその行のテキストノード内に収まる場合（selectNodeContents 等）、行要素
+//     そのものはクローンに現れず、内部の子（チェックボックス行の <input>+<span> など）が
+//     そのままトップレベルの子になる。こちらは装飾付きインライン HTML から
+//     class・data-*・<input> を落とすだけの経路になる
+test.describe("通常コピー: 単一行選択（複数行にまたがらない）でも属性が残らない", () => {
+  test("見出しを丸ごと1行選択（行頭がコンテナレベルの境界になる操作）→ <h1> に構造化される", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "# Heading\nnext line" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const mdView = document.getElementById("markdown-view")!;
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const walker = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const textNode = walker.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(mdView, 0); // 行の直前（mdView 直下の子オフセット）から
+      range.setEnd(textNode, textNode.textContent!.length); // 行末まで
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    expect(html).toBe("<h1>Heading</h1>");
+
+    await ctx.close();
+  });
+
+  test("チェックボックス行の全選択（selectNodeContents）→ input と data-* が clipboard に残らない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "- [x] done task" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const { html } = await dispatchCopyWithClipboardData(page);
+    expect(html).not.toContain("<input");
+    expect(html).not.toMatch(/data-/);
+    expect(html).toContain("done task");
+
+    await ctx.close();
+  });
+});
+
+test.describe("resolveSelectionRange（Markdown をコピーが使う生 Markdown の写像）", () => {
+  test("装飾記法の内部に選択境界が落ちても記法を欠けさせない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    // raw: "abc **bold** def" / 可視: "abc bold def"
+    await injectNoteMock(page, { content: "abc **bold** def" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+      const nodeAt = (offset: number) => {
+        let remaining = offset;
+        let node: Text | null;
+        let last: Text | null = null;
+        const w = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+        while ((node = w.nextNode() as Text | null)) {
+          last = node;
+          if (remaining <= node.textContent!.length) return { node, offset: remaining };
+          remaining -= node.textContent!.length;
+        }
+        return last ? { node: last, offset: last.textContent!.length } : { node: el, offset: 0 };
+      };
+      // 可視 "abc bold def" の 5 文字目（"bold" の内部、"b" の直後）〜 11 文字目（" def" の内部、"e" の直後）
+      const start = nodeAt(5);
+      const end = nodeAt(11);
+      const range = document.createRange();
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    // 開始端は装飾セグモント "**bold**" の内部に落ちるので記法全体（srcStart）まで拡張され、
+    // 終了端は plain セグメントの内部なのでそのままの位置で切れる
+    expect(markdown).toBe("**bold** de");
+
+    await ctx.close();
+  });
+
+  test("選択が行頭の可視位置から始まると、行頭のマーカー（リスト記号等）を含めて取る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "- item text" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const el = document.querySelector('#markdown-view [data-line="0"]')!;
+      const range = document.createRange();
+      range.selectNodeContents(el); // 可視テキスト全体（"item text"）を選択
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("- item text");
+
+    await ctx.close();
+  });
+
+  // 選択終端が次行の先頭（可視オフセット 0 ＝マーカー直後）に落ちると、resolveSelectionBounds が
+  // 切り詰める前は次行のマーカーだけを拾ってしまっていた（「行頭から次行の先頭までドラッグ」の
+  // 典型操作。text/plain と resolveSelectionBounds を共有するため同じ修正で両方直る）
+  test("選択終端が次行の先頭（可視オフセット 0）に落ちても、次行のマーカーが混入しない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "first line\n> quote" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const range = document.createRange();
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const row1 = document.querySelector('#markdown-view [data-line="1"]')!;
+      const w0 = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const t0 = w0.nextNode() as Text;
+      range.setStart(t0, 0);
+      // 2 行目の可視オフセット 0（マーカー直後）＝ row1 の先頭（コンテナレベルの境界）
+      range.setEnd(row1, 0);
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("first line\n");
+    expect(markdown).not.toContain(">");
+
+    await ctx.close();
+  });
+
+  test("コードブロック内で終了端がマーカー相当の文字数と一致しても、選択済みの文字が落ちない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "head\n```\n  - li\n```" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const w0 = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const t0 = w0.nextNode() as Text;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(t0, 0);
+      range.setEnd(tc, 4); // "  - li" の "  - "（4 文字）の直後で止める
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("head\n```\n  - ");
+
+    await ctx.close();
+  });
+
+  test("選択終端がブロックの最後の内容行の末尾に一致すると、閉じフェンス行を含めて取る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "head\n```\ncode line\n```" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const row0 = document.querySelector('#markdown-view [data-line="0"]')!;
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const w0 = document.createTreeWalker(row0, NodeFilter.SHOW_TEXT);
+      const t0 = w0.nextNode() as Text;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text;
+      const range = document.createRange();
+      range.setStart(t0, 0);
+      range.setEnd(tc, tc.textContent!.length); // "code line" の末尾ちょうど
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("head\n```\ncode line\n```");
+
+    await ctx.close();
+  });
+
+  test("ブロックの可視テキスト全体（内容行のみ）を選択すると、開き・閉じ両方のフェンスを含めて取る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "```\ncode line\n```" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const range = document.createRange();
+      range.selectNodeContents(codeEl); // 内容行の可視テキスト全体（"code line"）だけを選択
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("```\ncode line\n```");
+
+    await ctx.close();
+  });
+
+  test("複数行あるブロックの内容行 1 行だけを選択（先頭〜末尾）しても、フェンスは付かない", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "```js\nline1\nline2\n```" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const wc = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+      const tc = wc.nextNode() as Text; // "line1\nline2"
+      const range = document.createRange();
+      range.setStart(tc, 0);
+      range.setEnd(tc, "line1".length); // "line1" の先頭〜末尾だけ（"line2" には触れない）
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("line1");
+
+    await ctx.close();
+  });
+
+  // 可視文字ゼロ行（hr・空フェンス）の退化補正は resolveSelectionBounds に一元化してあるため、
+  // text/plain（buildPlainFromSelection）と「Markdown をコピー」（resolveSelectionRange）の
+  // どちらも同じ結果になる
+  test("--- のみの全選択 → text/plain と同じく空文字にならず --- が返る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "---" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const mdView = document.getElementById("markdown-view")!;
+      const range = document.createRange();
+      range.selectNodeContents(mdView);
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    expect(markdown).toBe("---");
+
+    await ctx.close();
+  });
+});
+
+test.describe("右クリックメニューの「Markdown をコピー」", () => {
+  test("選択ありで右クリック → hasSelection: true で show_context_menu が呼ばれ、ctx-copy-markdown で退避した生 Markdown が copy_markdown へ渡る", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "**bold** line0\nline1" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await selectMarkdownRange(page, 0, 0, 0, "bold line0".length);
+
+    await page.locator('#markdown-view [data-line="0"]').first().click({ button: "right" });
+
+    await expect.poll(async () => (await capturedCalls(page, "show_context_menu")).length).toBe(1);
+    const menuCalls = await capturedCalls(page, "show_context_menu");
+    expect((menuCalls[0].args as any).hasSelection).toBe(true);
+
+    // ネイティブメニューの「Markdown をコピー」選択を、appWindow の ctx-copy-markdown リスナー
+    // を直接発火させることで模す（Playwright にはネイティブメニューが無いため）
+    await page.evaluate(() => {
+      const listeners = (window as any).__appWindowListeners["ctx-copy-markdown"] || [];
+      listeners.forEach((fn: () => void) => fn());
+    });
+
+    await expect.poll(async () => (await capturedCalls(page, "copy_markdown")).length).toBe(1);
+    const copyCalls = await capturedCalls(page, "copy_markdown");
+    expect((copyCalls[0].args as any).text).toBe("**bold** line0");
+
+    await ctx.close();
+  });
+
+  test("選択なしで右クリック → hasSelection: false", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "line0" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => window.getSelection()?.removeAllRanges());
+    await page.locator('#markdown-view [data-line="0"]').first().click({ button: "right" });
+
+    await expect.poll(async () => (await capturedCalls(page, "show_context_menu")).length).toBe(1);
+    const menuCalls = await capturedCalls(page, "show_context_menu");
+    expect((menuCalls[0].args as any).hasSelection).toBe(false);
+
+    await ctx.close();
+  });
+
+  // 空行だけを選択すると resolveSelectionRange は raw の内容どおり空文字を返す（これ自体は
+  // 正しい）。空文字のまま hasSelection: true にすると、copy_markdown へ空文字が渡り
+  // クリップボードが空になってしまうため、空文字なら選択なし扱いにする
+  test("空行だけを選択して右クリック → resolveSelectionRange が空文字を返すため hasSelection: false", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "line0\n\nline2" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      const row1 = document.querySelector('#markdown-view [data-line="1"]')!; // 2 行目（空行）
+      const range = document.createRange();
+      range.selectNodeContents(row1);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+    // 空行は見た目の高さが低く actionability チェックに引っかかりうるため force で直接発火する
+    await page.locator('#markdown-view [data-line="1"]').click({ button: "right", force: true });
+
+    await expect.poll(async () => (await capturedCalls(page, "show_context_menu")).length).toBe(1);
+    const menuCalls = await capturedCalls(page, "show_context_menu");
+    expect((menuCalls[0].args as any).hasSelection).toBe(false);
+
+    await ctx.close();
+  });
+
+  // 未クローズのコードフェンス（EOF まで ``` が閉じない）は data-line-end が「閉じフェンス行」
+  // ではなく「最後の内容行自身」を指すため、選択範囲の写像が特殊なケースになる。
+  test("内容行が無い未クローズフェンス（```だけ）を選択して右クリックしても例外にならずメニューが開く", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    await injectNoteMock(page, { content: "```" }, {}, { captureInvokes: true });
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    // markdown-view 全体（＝空の内容を持つ未クローズフェンスの pre 1 個）を選択する。
+    // この選択で resolveSelectionRange が例外を投げると、e.preventDefault() 済みのまま
+    // show_context_menu に到達できずメニューが一切開かなくなる
+    await page.evaluate(() => {
+      const el = document.getElementById("markdown-view")!;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+    await page.locator("#markdown-view").click({ button: "right" });
+
+    await expect.poll(async () => (await capturedCalls(page, "show_context_menu")).length).toBe(1);
+
+    await ctx.close();
+  });
+});
+
+test.describe("未クローズのコードフェンス内の選択（resolveSelectionRange の行写像）", () => {
+  test("閉じフェンスが無くても最後の内容行末まで正しく写像される（末尾行が欠落しない）", async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
+    const page = await ctx.newPage();
+    // 閉じフェンス無し（EOF まで ``` のまま）。内容行は "foo" "bar" の 2 行
+    await injectNoteMock(page, { content: "```\nfoo\nbar" }, {}, {});
+    await page.goto("/note.html?id=test-note-id");
+    await page.waitForLoadState("networkidle");
+
+    const markdown = await page.evaluate(() => {
+      const codeEl = document.querySelector("#markdown-view pre.md-codeblock code")!;
+      const range = document.createRange();
+      range.selectNodeContents(codeEl); // フェンス内側の可視テキスト全体（"foo\nbar"）を選択
+      return (window as unknown as { resolveSelectionRange(r: Range): string | null })
+        .resolveSelectionRange(range);
+    });
+
+    // 末尾行（"bar"）が行写像のループ範囲から外れて欠落しないことを確認する
+    expect(markdown).toBe("foo\nbar");
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## 背景

描画部分のテキスト選択をコピーすると、ブラウザ既定のコピーがレンダリング後の DOM をそのまま載せるため、貼り付け先で見出し・リスト・コードブロックの構造が失われる（`class` 頼みの div は外部アプリに意味を持たない）。生 Markdown を取り出す手段も無い。

## 仕様

- 通常コピー（⌘C / Edit メニュー / 右クリックの Copy）は text/html と text/plain を同時にクリップボードへ載せる
  - text/html: セマンティック HTML（h1〜h3・入れ子 ul/ol・blockquote・等幅 style 付き pre）。Google Docs / Notion / Word 等に書式として貼れる。チェックボックスは `[x]` / `[ ]` の平文リスト項目で、別の付箋へ貼るとチェックボックスに復元される
  - text/plain: 行構造（インデント・リスト記号・チェックボックス記法・`#` 見出しマーカー・コードフェンス・`---`・`> `）は生 Markdown のまま残し、インライン装飾（`**` 等）だけ外したテキスト
- 右クリックメニューに「Markdown をコピー」を追加: 選択範囲の生 Markdown 記法のままコピーする。付箋間の複製（画像込み）や Markdown エディタへの持ち出し用
- 画像は `(alt.拡張子)`（alt が空なら `(画像.拡張子)`）のテキストに置換する（画像パスが外部アプリで解決できないため）。画像単体選択のコピーは従来どおり画像バイナリ
- コードブロックは内容全体を選ぶとフェンス込みで取れる。ブロック内の一部だけの選択にはフェンスが付かない
- 生エディタ内で完結する選択と、選択なしの ⌘C は既定動作のまま

## やったこと

- markdown.js: インライン記法のセグメント列 API `inlineSegments`（ソースオフセット・可視テキスト付き）を新設（描画経路の `inlineMarkdown` は挙動・性能とも不変。出力一致をゴールデンマスターとシード固定 fuzz で縛る）
- FE（コピー）: copy イベントで選択を生 Markdown の行範囲へ解決し、セマンティック HTML と行構造維持のプレーンテキストを組み立てて `clipboardData` にセット。可視オフセット→ソースオフセットの写像は `inlineSegments` による
- FE（ペースト変換）: 入れ子リスト・`pre`・`hr` を Markdown に戻せるようにし、コピーした HTML が別の付箋・Web ページ由来の貼り付けの両方で復元されるようにする
- BE: 右クリックメニューに「Markdown をコピー」項目（選択があるときだけ表示）を追加し、`copy_markdown` コマンド（arboard・メインスレッド委譲）で書き込む
- テスト: 選択の解決・写像の境界（マーカー・コードブロック・画像・退化ケース）の E2E 43 件と、セグメント列の単体テストを追加

## 確認したこと

- cargo fmt / clippy / test、eslint、node UT 262 件、Playwright 377 件（VRT ベースライン差分なし）
- 実機で Google Docs / Notion / Slack / Word / 別の付箋への貼り付け（書式・チェックボックス復元・コードブロック）、書式なし貼り付けの行構造、「Markdown をコピー」、画像ラベル、画像単体コピーの維持

## 関連リンク

- Closes #70
