### PR TITLE
✨ 記法変換の瞬間を undo の区切りにする

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,9 @@ const markdown = {
   parseImageAlt: "readonly",
   scanFenceRanges: "readonly",
   isRevealableKind: "readonly",
+  classifyLine: "readonly",
+  lineConversionOccurred: "readonly",
+  inlineKindCounts: "readonly",
 };
 const noteLines = {
   blockOffset: "readonly",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ const noteLines = {
 const history = {
   createHistory: "readonly",
   firstDiffLine: "readonly",
+  diffColumn: "readonly",
 };
 
 export default [

--- a/src/history.js
+++ b/src/history.js
@@ -68,7 +68,30 @@ function firstDiffLine(oldContent, newContent) {
   return len;
 }
 
+/**
+ * oldLine・newLine の共通 prefix と共通 suffix を取り、newLine 側の変更区間の終端
+ * （newLine.length - 共通 suffix 長）を、undo/redo 後にキャレットを置く raw 列として返す
+ * （firstDiffLine が返した行番号と組み合わせて使う）。prefix だけで求めると、削除された文字の
+ * 復元（undo-of-delete）で復元文字の手前に置かれてしまうため、suffix 側も見て変更区間の終端に置く。
+ * 共通 suffix は共通 prefix と重ならない範囲までしか伸びない（重なりを許すと両方の行長の短い方を
+ * 超えてしまう）ため、戻り値は newLine の長さを超えない。
+ */
+function diffColumn(oldLine, newLine) {
+  const max = Math.min(oldLine.length, newLine.length);
+  let prefix = 0;
+  while (prefix < max && oldLine[prefix] === newLine[prefix]) prefix++;
+  let suffix = 0;
+  const suffixMax = max - prefix;
+  while (
+    suffix < suffixMax &&
+    oldLine[oldLine.length - 1 - suffix] === newLine[newLine.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  return newLine.length - suffix;
+}
+
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
-  module.exports = { createHistory, firstDiffLine };
+  module.exports = { createHistory, firstDiffLine, diffColumn };
 }

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -478,6 +478,67 @@ function scanFenceRanges(lines) {
   return ranges;
 }
 
+/** 行（fence 範囲は含まない、1 行単位）のブロック種別を判定する。renderMarkdown 本体と、
+ * note.js の変換検出（splice 前後でこの種別が変わったかを比較し、undo チェックポイントの
+ * トリガーにする）が同じ判定を共有するための土台。fence はここに含めず scanFenceRanges 側の
+ * 責務のまま（複数行にまたがる判定のため 1 行単位のこの関数とは性質が異なる）。
+ *
+ * contentStart は trimmedLine 上でのマーカー長（renderInline に渡す内容の開始位置）。
+ * trimmedLine.slice(contentStart) が renderInline に渡る内容と一致し、renderMarkdown・
+ * lineConversionOccurred の双方がここから同じ値を引く（slice 幅の二重管理を避ける）。 */
+function classifyLine(line) {
+  // インデントは 2 スペース単位。奇数分は切り捨てる（例: 半端な 3 スペースは level 1 のまま）。
+  // タブ文字は非対応（スペースのみ見る）
+  const indentMatch = line.match(/^( +)/);
+  const spaces = indentMatch ? indentMatch[1].length : 0;
+  const level = Math.floor(spaces / 2);
+  const trimmedLine = spaces > 0 ? line.slice(spaces) : line;
+  let type, contentStart;
+  if (/^[-*] \[x\] /i.test(trimmedLine)) { type = 'checked'; contentStart = 6; }
+  else if (/^[-*] \[ \] /.test(trimmedLine)) { type = 'checkbox'; contentStart = 6; }
+  else if (level === 0 && trimmedLine.startsWith('### ')) { type = 'h3'; contentStart = 4; }
+  else if (level === 0 && trimmedLine.startsWith('## ')) { type = 'h2'; contentStart = 3; }
+  else if (level === 0 && trimmedLine.startsWith('# ')) { type = 'h1'; contentStart = 2; }
+  else if (level === 0 && /^([-*_])\s*(?:\1\s*){2,}$/.test(trimmedLine)) { type = 'hr'; contentStart = trimmedLine.length; }
+  else if (/^[-*] /.test(trimmedLine)) { type = 'bullet'; contentStart = 2; }
+  else if (/^> /.test(trimmedLine)) { type = 'quote'; contentStart = 2; }
+  else if (/^\d+\. /.test(trimmedLine)) { type = 'ordered'; contentStart = trimmedLine.match(/^\d+\. /)[0].length; }
+  else if (line === '') { type = 'empty'; contentStart = 0; }
+  else { type = 'text'; contentStart = 0; }
+  return { type, trimmedLine, level, contentStart };
+}
+
+/** line 単体のブロック種別・インライン装飾が before → after で新規に成立したか。classifyLine・
+ * inlineSegments という描画側の判定をそのまま比較に使い、変換の意味を独自パーサで再定義しない。
+ * ブロック種別の変化は、行き先が装飾の付かない 'text'/'empty' のとき対象外にする（装飾解除の
+ * 逆方向・空行への最初の 1 文字目は「変換」ではない）。インライン装飾は kind ごとの出現数を
+ * 比較し、増えた kind があれば新規成立とみなす（前段の中間状態が別 kind に見える場合があっても、
+ * 完成した kind の増加自体は検出できる）。inlineKindCounts へは classifyLine の contentStart で
+ * マーカーを除いた内容だけを渡す（マーカー込みで渡すと、行頭の `* ` のようなマーカーの一部を
+ * ITALIC_RE 等が装飾の一部として誤って食い込む）。フェンス内容行の除外は呼び出し側の責務
+ * （note.js の checkpointConversion）で、この関数自身は行の所属を知らない。 */
+function lineConversionOccurred(before, after) {
+  if (before === after) return false;
+  const beforeInfo = classifyLine(before);
+  const afterInfo = classifyLine(after);
+  if (afterInfo.type !== beforeInfo.type && afterInfo.type !== 'text' && afterInfo.type !== 'empty') return true;
+  const beforeCounts = inlineKindCounts(beforeInfo.trimmedLine.slice(beforeInfo.contentStart));
+  for (const [kind, count] of inlineKindCounts(afterInfo.trimmedLine.slice(afterInfo.contentStart))) {
+    if (count > (beforeCounts.get(kind) || 0)) return true;
+  }
+  return false;
+}
+
+/** content（マーカーを除いた内容）の inlineSegments を kind ごとの出現数へ集計する
+ * （プレーンテキスト側の kind: null は含まない）。 */
+function inlineKindCounts(content) {
+  const counts = new Map();
+  for (const seg of inlineSegments(content)) {
+    if (seg.kind) counts.set(seg.kind, (counts.get(seg.kind) || 0) + 1);
+  }
+  return counts;
+}
+
 /** 行内容（マーカーを除いた raw）を装飾込みの html にする。revealRange（{start, end}、
  * text 上のローカルな raw オフセット）を渡すと、それに一致する装飾セグメントだけ生 raw で
  * 表示する（inlineSegments 経由）。無指定時は通常の逐次置換チェーン（inlineMarkdown）を使う。 */
@@ -520,18 +581,13 @@ function renderMarkdown(text, reveal) {
       i = end;
       continue;
     }
-    // Measure and strip indent for nested lists
-    // Indent level is based on 2-space units; odd spaces are truncated (e.g. 3 spaces = level 1)
-    // Note: only spaces are considered; tab characters are not supported and will be ignored
-    const indentMatch = line.match(/^( +)/);
-    const spaces = indentMatch ? indentMatch[1].length : 0;
-    const level = Math.floor(spaces / 2);
-    const trimmedLine = spaces > 0 ? line.slice(spaces) : line;
+    const { type, trimmedLine, level, contentStart } = classifyLine(line);
+    const content = trimmedLine.slice(contentStart);
     const indentClass = level > 0 ? ` md-indent-${Math.min(level, 5)}` : '';
     const revealHere = reveal && reveal.line === i ? { start: reveal.start, end: reveal.end } : null;
 
     // Reset ordered list counters when line is not a numbered list
-    if (!/^\d+\. /.test(trimmedLine)) {
+    if (type !== 'ordered') {
       lastOrderedLevel = -1;
       Object.keys(orderedCounters).forEach(k => delete orderedCounters[k]);
     }
@@ -540,42 +596,41 @@ function renderMarkdown(text, reveal) {
     // 解決（note.js の domPointForContentVisible）がテキストノードを見つけられず、ブロック
     // 直下（<input> の直前 = 見た目上チェックボックスの位置）へフォールバックしてしまう。
     // 潰れない文字（&nbsp;）を 1 つ挟んでテキストノードを確保する
-    if (/^[-*] \[x\] /i.test(trimmedLine)) {
-      const inner = renderInline(trimmedLine.slice(6), revealHere) || '&nbsp;';
+    if (type === 'checked') {
+      const inner = renderInline(content, revealHere) || '&nbsp;';
       result.push(`<div class="md-check checked${indentClass}" data-line="${i}"><input type="checkbox" checked data-line="${i}"><span>${inner}</span></div>`);
       continue;
     }
-    if (/^[-*] \[ \] /.test(trimmedLine)) {
-      const inner = renderInline(trimmedLine.slice(6), revealHere) || '&nbsp;';
+    if (type === 'checkbox') {
+      const inner = renderInline(content, revealHere) || '&nbsp;';
       result.push(`<div class="md-check${indentClass}" data-line="${i}"><input type="checkbox" data-line="${i}"><span>${inner}</span></div>`);
       continue;
     }
-    if (level === 0 && trimmedLine.startsWith('### ')) {
-      result.push(`<div class="md-h3" data-line="${i}">${renderInline(trimmedLine.slice(4), revealHere)}</div>`);
+    if (type === 'h3') {
+      result.push(`<div class="md-h3" data-line="${i}">${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (level === 0 && trimmedLine.startsWith('## ')) {
-      result.push(`<div class="md-h2" data-line="${i}">${renderInline(trimmedLine.slice(3), revealHere)}</div>`);
+    if (type === 'h2') {
+      result.push(`<div class="md-h2" data-line="${i}">${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (level === 0 && trimmedLine.startsWith('# ')) {
-      result.push(`<div class="md-h1" data-line="${i}">${renderInline(trimmedLine.slice(2), revealHere)}</div>`);
+    if (type === 'h1') {
+      result.push(`<div class="md-h1" data-line="${i}">${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (level === 0 && /^([-*_])\s*(?:\1\s*){2,}$/.test(trimmedLine)) {
+    if (type === 'hr') {
       result.push(`<hr class="md-hr" data-line="${i}">`);
       continue;
     }
-    if (/^[-*] /.test(trimmedLine)) {
-      result.push(`<div class="md-bullet${indentClass}" data-line="${i}">${renderInline(trimmedLine.slice(2), revealHere)}</div>`);
+    if (type === 'bullet') {
+      result.push(`<div class="md-bullet${indentClass}" data-line="${i}">${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (/^> /.test(trimmedLine)) {
-      result.push(`<div class="md-blockquote${indentClass}" data-line="${i}">${renderInline(trimmedLine.slice(2), revealHere)}</div>`);
+    if (type === 'quote') {
+      result.push(`<div class="md-blockquote${indentClass}" data-line="${i}">${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (/^\d+\. /.test(trimmedLine)) {
-      const m = trimmedLine.match(/^(\d+)\. (.*)/);
+    if (type === 'ordered') {
       // Auto-increment: reset counter only for new deeper nesting or new list block
       if (lastOrderedLevel < 0) {
         // New ordered list block after non-list line
@@ -592,20 +647,23 @@ function renderMarkdown(text, reveal) {
       // 内容が空だと通常の半角スペースは contenteditable 上で潰れてしまい（他に文字が無い
       // ノードの末尾空白は折りたたまれる）、キャレットの着地点が無くなって beforeinput が
       // 発火しない。潰れない区切り文字として &nbsp;（U+00A0）を使う
-      const sep = m[2] === '' ? ' ' : ' ';
-      result.push(`<div class="md-ordered${indentClass}" data-line="${i}"><span class="md-order-num">${displayNum}.</span>${sep}${renderInline(m[2], revealHere)}</div>`);
+      const sep = content === '' ? ' ' : ' ';
+      result.push(`<div class="md-ordered${indentClass}" data-line="${i}"><span class="md-order-num">${displayNum}.</span>${sep}${renderInline(content, revealHere)}</div>`);
       continue;
     }
-    if (line === '') {
+    if (type === 'empty') {
       result.push(`<div class="md-empty" data-line="${i}"></div>`);
       continue;
     }
-    result.push(`<div class="md-line${indentClass}" data-line="${i}">${renderInline(trimmedLine, revealHere)}</div>`);
+    result.push(`<div class="md-line${indentClass}" data-line="${i}">${renderInline(content, revealHere)}</div>`);
   }
   return result.join('');
 }
 
 // ブラウザでは module が未定義なので、この行は classic script の読み込みに影響しない
 if (typeof module !== 'undefined') {
-  module.exports = { renderMarkdown, inlineMarkdown, inlineSegments, parseImageAlt, scanFenceRanges, isRevealableKind };
+  module.exports = {
+    renderMarkdown, inlineMarkdown, inlineSegments, parseImageAlt, scanFenceRanges, isRevealableKind,
+    classifyLine, lineConversionOccurred, inlineKindCounts,
+  };
 }

--- a/src/note.js
+++ b/src/note.js
@@ -1119,7 +1119,10 @@ function flushContent() {
 // メニューイベントの二重到達があっても history の巻き戻りが 1 回で済むようにする
 let applyingHistory = false;
 
-/** history から返った content を適用し、差分行にキャレットを置いて保存する共通処理。 */
+/** history から返った content を適用し、差分位置にキャレットを置いて保存する共通処理。diffLine が
+ * prevContent（差し替え前）と content（差し替え後）の両方に存在する行であれば、その行同士を
+ * diffColumn で比較した列に置く。行数が増減して diffLine が片方にしか無い場合（末尾の行追加・削除）は
+ * 比較対象の行が無いため、行末（col=null）へフォールバックする。 */
 async function applyHistoryContent(prevContent, content) {
   if (content == null) return;
   clearImageSelection();
@@ -1127,7 +1130,13 @@ async function applyHistoryContent(prevContent, content) {
   renderAll();
   const diffLine = firstDiffLine(prevContent, content);
   if (diffLine != null) {
-    placeCaretAtRaw(Math.min(diffLine, getLines().length - 1), null);
+    const lines = getLines();
+    const line = Math.min(diffLine, lines.length - 1);
+    const prevLines = prevContent.split('\n');
+    const col = diffLine < prevLines.length && diffLine < lines.length
+      ? diffColumn(prevLines[diffLine], lines[diffLine])
+      : null;
+    placeCaretAtRaw(line, col);
   }
   await saveNow();
 }
@@ -1320,16 +1329,17 @@ function resolveEditableBounds() {
   return bounds;
 }
 
-/** 打ち終えたチェックボックス記法（`- []`・`-[x]` 等）を `- [ ] `/`- [x] ` へ補完する。
- * line の行頭〜col が丸ごと CHECKBOX_RE に一致するときだけ発火する（マーカーの手前に
- * 他の文字があれば対象外）。フェンス内容行は splitLineAt 等と同じ findBlock 由来の inFence
+/** 打ち終えたチェックボックス記法（`- []`・`-[x]` 等）を `- [ ] `/`- [x] ` へ補完する。col は
+ * 直前に打ったスペースの直後（マーカーの手前に他の文字があれば対象外）。標準記法 `- [ ]`
+ * （`[`と`]`の間に既にスペースがある）はこの時点で CHECKBOX_RE に一致しないため対象外のまま
+ * （そのまま打鍵で成立する）。フェンス内容行は splitLineAt 等と同じ findBlock 由来の inFence
  * 判定で対象外にする（コードとして書いた `- []` を書き換えない）。insertText の splice 直後に
  * 呼ぶことで、debounce 前の追加 splice として同じ undo 単位にまとまる。 */
 function maybeAutocompleteCheckbox(line, col) {
   const block = findBlock(line);
   if (block && block.start !== block.end) return;
   const lines = getLines();
-  const m = lines[line].slice(0, col).match(CHECKBOX_RE);
+  const m = lines[line].slice(0, col - 1).match(CHECKBOX_RE);
   if (!m) return;
   const replacement = m[2].toLowerCase() === 'x' ? `${m[1]} [x] ` : `${m[1]} [ ] `;
   lines[line] = replacement + lines[line].slice(col);
@@ -1375,10 +1385,17 @@ function checkpointConversion(line, spliceFn) {
 function onInsertText(data) {
   const bounds = resolveEditableBounds();
   if (!bounds) return;
-  checkpointConversion(bounds.start.line, () => commitSelectionReplacement(bounds, data));
-  if (data === ']') {
-    checkpointConversion(bounds.start.line, () => maybeAutocompleteCheckbox(bounds.start.line, bounds.start.col + data.length));
+  if (data === ' ') {
+    // スペース自体の挿入とチェックボックス補完判定を 1 回の checkpointConversion にまとめる
+    // （スペース打鍵の直前を undo チェックポイントにするため。分けると、スペース挿入だけの
+    // splice を挟んだ状態が checkpoint されてしまい、⌘Z 1 回で打鍵前まで戻らなくなる）
+    checkpointConversion(bounds.start.line, () => {
+      commitSelectionReplacement(bounds, data);
+      maybeAutocompleteCheckbox(bounds.start.line, bounds.start.col + data.length);
+    });
+    return;
   }
+  checkpointConversion(bounds.start.line, () => commitSelectionReplacement(bounds, data));
 }
 
 /** collapsed キャレット位置の bounds（start === end）。resolveSelectionBounds のマーカー境界

--- a/src/note.js
+++ b/src/note.js
@@ -1336,11 +1336,49 @@ function maybeAutocompleteCheckbox(line, col) {
   applyLines(lines, line, replacement.length);
 }
 
+// ── 変換確定チェックポイント ─────────────────────────────
+// ① は再描画の帰結としての記法変換を受容する（`# ` を打ち終えると見出しに変わる、`**bold**` を
+// 閉じると太字になる、等）。undo は rawContent の splice 履歴なので変換それ自体は取り消し対象に
+// ならないが、変換を起こした splice の直前で明示的に editHistory.commit を打っておけば、その
+// splice がデバウンス（saveNow, 300ms）でまとまる前の内容が undo チェックポイントとして残り、
+// ⌘Z 1 回で「変換を起こした 1 打鍵」だけを取り消せる（変換前のリテラルへ戻る）。
+//
+// 対象は insertText 経由の 1 文字入力（直接の splice と、続けて起きるチェックボックス補完の
+// 追加 splice）に絞る。ペースト・Enter・削除・Tab インデント等は複数行にまたがりうる・意味の
+// 異なる編集であり、同じ判定をかけると打鍵以外の操作でも undo 粒度が変わってしまう。
+// 逆方向（装飾が解除される splice）はチェックポイント不要（lineConversionOccurred 参照）。
+
+/** line に対する 1 回の splice（spliceFn）の前後で lineConversionOccurred なら、splice 前の
+ * rawContent を undo チェックポイントとして明示的に commit する。line は spliceFn の前後で
+ * 行番号が変わらない前提（呼び出し元はいずれも改行を含まない 1 文字挿入）。フェンス内容行は
+ * maybeAutocompleteCheckbox と同じ findBlock 判定で対象外にする（コードとして書いた `- ` や
+ * `` `a` `` を、classifyLine・inlineSegments が行単位でブロック/装飾と誤認して変換扱いしないため）。
+ *
+ * 不変条件: commit するのは splice 前の内容（beforeContent）なので、この呼び出し直後は
+ * historyLast（beforeContent）と rawContent（spliceFn 後の内容）が一時的にずれる。これが害を
+ * 及ぼさないのは、全 splice 経路が applyLines → scheduleSave で終わり、次の saveNow の commit が
+ * いずれ rawContent 側へ追いつくこと、かつ performUndo/performRedo が history を触る前に必ず
+ * flushContent でこの追いつきを先に確定させることの両方が成り立つ限りにおいてである。 */
+function checkpointConversion(line, spliceFn) {
+  const block = findBlock(line);
+  if (block && block.start !== block.end) {
+    spliceFn();
+    return;
+  }
+  const before = getLines()[line] ?? '';
+  const beforeContent = rawContent;
+  spliceFn();
+  const after = getLines()[line] ?? '';
+  if (lineConversionOccurred(before, after)) editHistory?.commit(beforeContent);
+}
+
 function onInsertText(data) {
   const bounds = resolveEditableBounds();
   if (!bounds) return;
-  commitSelectionReplacement(bounds, data);
-  if (data === ']') maybeAutocompleteCheckbox(bounds.start.line, bounds.start.col + data.length);
+  checkpointConversion(bounds.start.line, () => commitSelectionReplacement(bounds, data));
+  if (data === ']') {
+    checkpointConversion(bounds.start.line, () => maybeAutocompleteCheckbox(bounds.start.line, bounds.start.col + data.length));
+  }
 }
 
 /** collapsed キャレット位置の bounds（start === end）。resolveSelectionBounds のマーカー境界

--- a/tests/unit/history.test.js
+++ b/tests/unit/history.test.js
@@ -1,7 +1,7 @@
 const { test, describe } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { createHistory, firstDiffLine } = require("../../src/history.js");
+const { createHistory, firstDiffLine, diffColumn } = require("../../src/history.js");
 
 describe("createHistory: commit", () => {
   test("historyLast と同値の commit は積まない（undo できない）", () => {
@@ -118,5 +118,43 @@ describe("firstDiffLine", () => {
 
   test("末尾行だけ差分がある場合はその行番号", () => {
     assert.equal(firstDiffLine("a\nb", "a\nc"), 1);
+  });
+});
+
+describe("diffColumn", () => {
+  test("行末に文字が追加された場合は追加後の行末（redo-of-insert 相当）", () => {
+    assert.equal(diffColumn("abc", "abcdef"), 6);
+  });
+
+  test("行の途中に文字が挿入された場合は挿入文字の後ろ（redo-of-insert 相当）", () => {
+    assert.equal(diffColumn("abcdef", "abcXdef"), 4);
+  });
+
+  test("行の途中の文字が削除された場合は削除位置（undo-of-insert 相当）", () => {
+    assert.equal(diffColumn("abcXdef", "abcdef"), 3);
+  });
+
+  test("行末の文字が削除され undo で復元される場合は復元文字の後ろ（undo-of-delete 相当）", () => {
+    assert.equal(diffColumn("ab", "abc"), 3);
+  });
+
+  test("行の途中の文字が削除され undo で復元される場合は復元文字の後ろ（undo-of-delete 相当）", () => {
+    assert.equal(diffColumn("acdef", "abcdef"), 2);
+  });
+
+  test("先頭から全く異なる場合（完全置換）は置換後の行末", () => {
+    assert.equal(diffColumn("abc", "xyz"), 3);
+  });
+
+  test("完全一致なら行の長さ", () => {
+    assert.equal(diffColumn("abc", "abc"), 3);
+  });
+
+  test("片方が空文字なら 0", () => {
+    assert.equal(diffColumn("abc", ""), 0);
+  });
+
+  test("戻り値は newLine の長さを超えない（呼び出し側の行境界クランプと独立に安全）", () => {
+    assert.equal(diffColumn("abcdefgh", "abc"), 3);
   });
 });

--- a/tests/unit/markdown-conversion-checkpoint.test.js
+++ b/tests/unit/markdown-conversion-checkpoint.test.js
@@ -1,0 +1,91 @@
+const { test, describe } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { escapeHtml } = require("../../src/utils.js");
+global.escapeHtml = escapeHtml;
+const { lineConversionOccurred, inlineKindCounts } = require("../../src/markdown.js");
+
+// lineConversionOccurred は note.js の checkpointConversion（undo チェックポイントのトリガー）が
+// 使う純粋関数。before/after は checkpointConversion が渡す形（1 文字挿入の前後、改行を含まない
+// 1 行）に揃えてある。フェンス内容行の除外はこの関数の責務ではなく呼び出し側
+// （note.js の checkpointConversion、findBlock 判定）が担う（末尾の describe 参照）。
+
+describe("lineConversionOccurred — ブロック種別ごとの変換検出", () => {
+  const cases = [
+    { name: "見出し1(h1): # → # ", before: "#", after: "# ", expected: true },
+    { name: "見出し2(h2): ## → ## ", before: "##", after: "## ", expected: true },
+    { name: "見出し3(h3): ### → ### ", before: "###", after: "### ", expected: true },
+    { name: "箇条書き: - → - ", before: "-", after: "- ", expected: true },
+    { name: "引用: > → > ", before: ">", after: "> ", expected: true },
+    { name: "順序リスト: 1. → 1. ", before: "1.", after: "1. ", expected: true },
+    { name: "チェックボックス補完: - [ ] → - [ ] ", before: "- [ ]", after: "- [ ] ", expected: true },
+    { name: "チェック済み補完: - [x] → - [x] ", before: "- [x]", after: "- [x] ", expected: true },
+    { name: "区切り線(hr): -- → ---", before: "--", after: "---", expected: true },
+  ];
+  for (const { name, before, after, expected } of cases) {
+    test(name, () => assert.equal(lineConversionOccurred(before, after), expected));
+  }
+});
+
+describe("lineConversionOccurred — empty/text への遷移は対象外", () => {
+  const cases = [
+    { name: "空行への最初の1文字目は変換ではない", before: "", after: "a", expected: false },
+    { name: "装飾解除の逆方向（text→empty）も対象外", before: "a", after: "", expected: false },
+  ];
+  for (const { name, before, after, expected } of cases) {
+    test(name, () => assert.equal(lineConversionOccurred(before, after), expected));
+  }
+});
+
+describe("lineConversionOccurred — インライン装飾の kind 増加", () => {
+  const cases = [
+    { name: "太字の閉じ確定: **bold* → **bold**", before: "**bold*", after: "**bold**", expected: true },
+    { name: "斜字の閉じ確定: *a → *a*", before: "*a", after: "*a*", expected: true },
+    { name: "コードの閉じ確定: `a → `a`", before: "`a", after: "`a`", expected: true },
+    { name: "取り消し線の閉じ確定: ~~a → ~~a~~", before: "~~a", after: "~~a~~", expected: true },
+    { name: "リンクの閉じ確定: [a](https://e → [a](https://e)", before: "[a](https://e", after: "[a](https://e)", expected: true },
+    { name: "装飾を伴わないプレーンタイピングは対象外", before: "hello", after: "hello!", expected: false },
+  ];
+  for (const { name, before, after, expected } of cases) {
+    test(name, () => assert.equal(lineConversionOccurred(before, after), expected));
+  }
+});
+
+// classifyLine の contentStart（マーカー長）を経由して、マーカーを除いた内容だけを
+// inlineKindCounts に渡すことの検証。マーカー込みで渡すと、行頭の `* ` のようなマーカーの
+// 先頭 `*` が ITALIC_RE に装飾の一部として食い込まれ、実際の描画（renderInline が受け取る
+// 内容も同じくマーカーを除いた文字列）とずれる。
+describe("lineConversionOccurred — マーカー込みで渡すと生じるずれの回帰", () => {
+  test("箇条書き行の内容側で新規に斜字が成立する（マーカーの `*` を巻き込まない）", () => {
+    // 内容は "a *b" → "a *b*"。行頭の `* ` マーカーを除けば斜字が新規成立している
+    assert.equal(lineConversionOccurred("* a *b", "* a *b*"), true);
+  });
+
+  test("マーカーの `*` と内容の `*` が対にならず、斜字は成立していない", () => {
+    // 内容は "a " → "a *"。開き `*` が 1 つ増えただけで閉じておらず、斜字は未成立
+    assert.equal(lineConversionOccurred("* a ", "* a *"), false);
+  });
+});
+
+// lineConversionOccurred はブロック・インライン装飾の判定だけを行う純粋関数で、行がフェンス
+// 内容行かどうかは知らない（引数の line は checkpointConversion 経由で渡る 1 行の raw だけで、
+// 前後の行やフェンス範囲を持たない）。フェンス内容行を対象外にするのは、findBlock で描画済み
+// ブロックを見られる呼び出し側（note.js の checkpointConversion）の責務であり、この関数自身は
+// フェンス内容行に対しても通常の行と同じ判定を返す。
+describe("lineConversionOccurred — フェンス内容行の除外は呼び出し側の責務", () => {
+  test("フェンス内容行を想定した入力でも、この関数自体は通常どおり検出する", () => {
+    assert.equal(lineConversionOccurred("", "- "), true);
+  });
+});
+
+describe("inlineKindCounts", () => {
+  test("装飾が無ければ空", () => {
+    assert.deepEqual(inlineKindCounts("hello"), new Map());
+  });
+
+  test("kind ごとの出現数を数える", () => {
+    const counts = inlineKindCounts("**a** *b* **c**");
+    assert.equal(counts.get("bold"), 2);
+    assert.equal(counts.get("italic"), 1);
+  });
+});

--- a/tests/visual/checkbox-autocomplete-e2e.spec.ts
+++ b/tests/visual/checkbox-autocomplete-e2e.spec.ts
@@ -1,50 +1,55 @@
 import { test, expect, enterEdit, getContent } from "./fixtures";
 
+// トリガーは `]` の直後に打ったスペース。`]` を打った時点では変換せず、その直後にスペースを
+// 打った時点で `- []`・`-[x]` 等（CHECKBOX_RE の対象）を `- [ ] `/`- [x] ` へ正規化する。
+// 標準記法 `- [ ]`（`[`と`]`の間に既にスペース）は CHECKBOX_RE に一致しないため、この正規化を
+// 経由せず、スペースを打った時点でそのまま通常の打鍵として成立する。
+
 test.describe("checkbox autocomplete E2E", () => {
-  test("typing '- []' autocompletes to '- [ ] '", async ({ openNote }) => {
+  test("typing '- [] ' autocompletes to '- [ ] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("- []", { delay: 30 });
+    await page.keyboard.type("- [] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("- [ ] ");
   });
 
-  test("typing '- [x]' autocompletes to '- [x] '", async ({ openNote }) => {
+  test("typing '- [x] ' autocompletes to '- [x] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("- [x]", { delay: 30 });
+    await page.keyboard.type("- [x] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("- [x] ");
   });
 
-  test("typing '- [X]' autocompletes to '- [x] '", async ({ openNote }) => {
+  test("typing '- [X] ' autocompletes to '- [x] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("- [X]", { delay: 30 });
+    await page.keyboard.type("- [X] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("- [x] ");
   });
 
-  test("typing '* []' autocompletes to '* [ ] '", async ({ openNote }) => {
+  test("typing '* [] ' autocompletes to '* [ ] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("* []", { delay: 30 });
+    await page.keyboard.type("* [] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("* [ ] ");
   });
 
-  test("typing '-[]' autocompletes to '- [ ] '", async ({ openNote }) => {
+  test("typing '-[] ' autocompletes to '- [ ] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("-[]", { delay: 30 });
+    await page.keyboard.type("-[] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("- [ ] ");
   });
 
-  test("typing '*[x]' autocompletes to '* [x] '", async ({ openNote }) => {
+  test("typing '*[x] ' autocompletes to '* [x] '", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("*[x]", { delay: 30 });
+    await page.keyboard.type("*[x] ", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("* [x] ");
   });
@@ -52,10 +57,26 @@ test.describe("checkbox autocomplete E2E", () => {
   test("cursor is placed after autocomplete", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
-    await page.keyboard.type("- []", { delay: 30 });
+    await page.keyboard.type("- [] ", { delay: 30 });
     await page.keyboard.type("task", { delay: 30 });
     const text = await getContent(page);
     expect(text).toBe("- [ ] task");
+  });
+
+  test("does not autocomplete right after ']' (before the trigger space)", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("- []", { delay: 30 });
+    const text = await getContent(page);
+    expect(text).toBe("- []");
+  });
+
+  test("'- [ ] ' (already spaced) is not re-normalized by the trigger space", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("- [ ] ", { delay: 30 });
+    const text = await getContent(page);
+    expect(text).toBe("- [ ] ");
   });
 
   test("does not autocomplete on second line without checkbox", async ({ openNote }) => {
@@ -69,9 +90,9 @@ test.describe("checkbox autocomplete E2E", () => {
   test("does not autocomplete inside a fenced code block", async ({ openNote }) => {
     const page = await openNote({ content: "```\n\n```" });
     await enterEdit(page, 1);
-    await page.keyboard.type("- []", { delay: 30 });
+    await page.keyboard.type("- [] ", { delay: 30 });
     const text = await getContent(page);
     // 閉じフェンスが最終行になる編集は applyLines が末尾に空行を確保する（ensureTrailingLineAfterClosedFence）
-    expect(text).toBe("```\n- []\n```\n");
+    expect(text).toBe("```\n- [] \n```\n");
   });
 });

--- a/tests/visual/conversion-checkpoint-e2e.spec.ts
+++ b/tests/visual/conversion-checkpoint-e2e.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect, enterEdit, getContent, commitHistory, placeCaret, waitForReveal } from "./fixtures";
+
+// ① は再描画の帰結としての記法変換を受容する（`# ` を打ち終えると見出しに変わる等）。
+// ② はその変換を起こした splice の直前で明示的に editHistory.commit するチェックポイントで、
+// ⌘Z 1 回が「変換を起こした 1 打鍵」だけを取り消せることを検証する。⌘Z はネイティブメニュー
+// 経由（undo-redo-e2e.spec.ts 参照）のため、ここでも window.performUndo/performRedo を直接呼ぶ。
+
+function performUndo(page: import("@playwright/test").Page) {
+  return page.evaluate(() => (window as any).performUndo());
+}
+
+function performRedo(page: import("@playwright/test").Page) {
+  return page.evaluate(() => (window as any).performRedo());
+}
+
+test.describe("変換確定チェックポイント", () => {
+  test("見出し(# )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("# ", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("# ");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("#");
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("");
+  });
+
+  test("箇条書き(- )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("- ", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("- ");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("-");
+  });
+
+  test("順序リスト(1. )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("1. ", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("1. ");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("1.");
+  });
+
+  test("チェックボックス補完(- [] → - [ ] )の変換確定でチェックポイントが入り、undo 1回で補完前に戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("- []", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("- [ ] ");
+    await commitHistory(page);
+
+    // 補完前（"- []"、まだ箇条書きのまま）に 1 回で戻る
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("- []");
+
+    // 補完前の "- " 成立の打鍵にも独立したチェックポイントが残っている
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("-");
+  });
+
+  test("太字(**bold**)の閉じ確定でチェックポイントが入り、undo 1回で **bold* に戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    // 打ち切り（デバウンス窓を跨がず連続入力）で "**bold**" まで一気に打つ
+    await page.keyboard.type("**bold**", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("**bold**");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("**bold*");
+  });
+
+  test("変換を含まない連続タイピングはデバウンス単位のまま（回帰）", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("hello world", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("hello world");
+    await commitHistory(page);
+
+    // 記法変換を含まないので、チェックポイントは増えず 1 回の undo で空に戻る
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("");
+  });
+
+  test("変換チェックポイントの undo を redo すると変換後の状態に戻る", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("# ", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("# ");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("#");
+
+    await performRedo(page);
+    await expect.poll(() => getContent(page)).toBe("# ");
+  });
+});
+
+// checkpointConversion は classifyLine・inlineSegments という描画側の判定をそのまま使うため、
+// フェンス内容行に対して素通しで呼ぶと、コードとして書いた記法（`- ` や `` `a` ``）まで
+// ブロック/装飾の新規成立として誤検出する。maybeAutocompleteCheckbox と同じ findBlock 判定で
+// フェンス内容行を対象外にし、コード内のタイピングが undo チェックポイントを増やさないことを
+// 検証する。
+test.describe("フェンス内容行での誤発動ガード", () => {
+  test("コードブロック内容行の `- ` はチェックポイントを作らず undo は1手で戻る", async ({ openNote }) => {
+    const page = await openNote({ content: "```\n\n```" });
+    await placeCaret(page, 1, 0);
+    await page.keyboard.type("- ", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("```\n- \n```\n");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("```\n\n```");
+  });
+
+  test("コードブロック内容行の `` `a` `` はチェックポイントを作らず undo は1手で戻る", async ({ openNote }) => {
+    const page = await openNote({ content: "```\n\n```" });
+    await placeCaret(page, 1, 0);
+    await page.keyboard.type("`a`", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("```\n`a`\n```\n");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("```\n\n```");
+  });
+});
+
+// checkpointConversion は 1 文字挿入ごとに呼ばれるが、実際にチェックポイントを打つのは
+// lineConversionOccurred が真のときだけ。変換確定後の平文タイピングや、reveal 中（装飾内部に
+// キャレットがある間）の追記では新規成立が起きないため、打鍵ごとにチェックポイントが増えず
+// undo の粒度はデバウンス単位のまま保たれることを検証する（回帰）。
+test.describe("変換確定後の連続タイピングでチェックポイントが増えない", () => {
+  test("**bold** 確定後の平文タイピングは1手にまとまる", async ({ openNote }) => {
+    const page = await openNote();
+    await enterEdit(page);
+    await page.keyboard.type("**bold**", { delay: 30 });
+    await commitHistory(page); // 変換確定の直後で一度確定させ、ここを手の境界にする
+    await expect.poll(() => getContent(page)).toBe("**bold**");
+
+    await page.keyboard.type(" and more", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("**bold** and more");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("**bold**");
+  });
+
+  test("reveal 中（装飾内部にキャレット）での追記は1手にまとまる", async ({ openNote }) => {
+    const page = await openNote({ content: "**bold**" });
+    await placeCaret(page, 0, 4); // "**bo|ld**" — bold 装飾の内部
+    await waitForReveal(page, { line: 0, start: 0, end: 8 });
+
+    await page.keyboard.type("xyz", { delay: 30 });
+    await expect.poll(() => getContent(page)).toBe("**boxyzld**");
+    await commitHistory(page);
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("**bold**");
+  });
+});

--- a/tests/visual/conversion-checkpoint-e2e.spec.ts
+++ b/tests/visual/conversion-checkpoint-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, enterEdit, getContent, commitHistory, placeCaret, waitForReveal } from "./fixtures";
+import { test, expect, enterEdit, getContent, commitHistory, placeCaret, waitForReveal, getCaretPosition } from "./fixtures";
 
 // ① は再描画の帰結としての記法変換を受容する（`# ` を打ち終えると見出しに変わる等）。
 // ② はその変換を起こした splice の直前で明示的に editHistory.commit するチェックポイントで、
@@ -23,6 +23,8 @@ test.describe("変換確定チェックポイント", () => {
 
     await performUndo(page);
     await expect.poll(() => getContent(page)).toBe("#");
+    // 変換確定チェックポイントの undo 後は、行末固定ではなく差分位置（"#" の直後）にキャレットが来る
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 0, col: 1 });
 
     await performUndo(page);
     await expect.poll(() => getContent(page)).toBe("");
@@ -50,16 +52,21 @@ test.describe("変換確定チェックポイント", () => {
     await expect.poll(() => getContent(page)).toBe("1.");
   });
 
-  test("チェックボックス補完(- [] → - [ ] )の変換確定でチェックポイントが入り、undo 1回で補完前に戻る", async ({ openNote }) => {
+  test("チェックボックス補完(- [] + スペース → - [ ] )の変換確定でチェックポイントが入り、undo 1回でスペース打鍵前に戻る", async ({ openNote }) => {
     const page = await openNote();
     await enterEdit(page);
     await page.keyboard.type("- []", { delay: 30 });
+    // トリガーはスペース。"]" を打った時点ではまだ変換されない
+    await expect.poll(() => getContent(page)).toBe("- []");
+    await page.keyboard.type(" ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("- [ ] ");
     await commitHistory(page);
 
-    // 補完前（"- []"、まだ箇条書きのまま）に 1 回で戻る
+    // トリガーのスペースを打つ直前（"- []"、まだ箇条書きのまま）に 1 回で戻る
     await performUndo(page);
     await expect.poll(() => getContent(page)).toBe("- []");
+    // 削除された "]" の手前ではなく、"]" の直後（col 4）にキャレットが来る
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 0, col: 4 });
 
     // 補完前の "- " 成立の打鍵にも独立したチェックポイントが残っている
     await performUndo(page);

--- a/tests/visual/undo-redo-e2e.spec.ts
+++ b/tests/visual/undo-redo-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, injectNoteMock, enterEdit, getContent, placeCaret, commitHistory } from "./fixtures";
+import { test, expect, injectNoteMock, enterEdit, getContent, placeCaret, commitHistory, getCaretPosition } from "./fixtures";
 
 // ⌘Z/⌘⇧Z はネイティブメニュー（src-tauri/src/menu.rs）が拾い edit-history イベントで
 // フロントへ通知するため、chromium からはキーボードショートカットを再現できない。
@@ -88,6 +88,69 @@ test.describe("Undo/Redo", () => {
       return (node instanceof Element ? node : node?.parentElement)?.closest("[data-line]")?.getAttribute("data-line");
     });
     expect(line).toBe("1");
+
+    await ctx.close();
+  });
+
+  test("undo 後のキャレットが行途中の差分位置に置かれる（行末へ飛ばない）", async ({ browser }) => {
+    const { ctx, page } = await openCaptured({ content: "abcdef" }, browser);
+
+    await placeCaret(page, 0, 3);
+    await page.locator("#markdown-view").pressSequentially("X");
+    await commitHistory(page);
+    await expect.poll(() => getContent(page)).toBe("abcXdef");
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("abcdef");
+    // 差分は行の途中（挿入した X の位置）なので、行末（col 6）ではなくその位置にキャレットが戻る
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 0, col: 3 });
+
+    await performRedo(page);
+    await expect.poll(() => getContent(page)).toBe("abcXdef");
+    // redo は挿入を再適用する側なので、挿入した X の後ろ（col 4）に戻る
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 0, col: 4 });
+
+    await ctx.close();
+  });
+
+  test("Enter で行が増える編集を undo/redo すると、対応する行が無い側は行末に置かれる", async ({ browser }) => {
+    const { ctx, page } = await openCaptured({ content: "" }, browser);
+
+    await enterEdit(page);
+    await page.locator("#markdown-view").pressSequentially("hello");
+    await commitHistory(page);
+    await expect.poll(() => getContent(page)).toBe("hello");
+
+    await page.keyboard.press("Enter");
+    await page.locator("#markdown-view").pressSequentially("world");
+    await commitHistory(page);
+    await expect.poll(() => getContent(page)).toBe("hello\nworld");
+
+    // undo 後は 1 行しかなく、削除された行（diffLine が指す行）を newLine 側に持てないため
+    // diffColumn は使わず、残った行の行末に置く
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("hello");
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 0, col: 5 });
+
+    // redo で行が戻ったときも、増えた行は oldLine 側に無いので同様に行末へ置く
+    await performRedo(page);
+    await expect.poll(() => getContent(page)).toBe("hello\nworld");
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 1, col: 5 });
+
+    await ctx.close();
+  });
+
+  test("複数行の下の方を行途中で編集して undo → その行のその位置に戻る（末尾行へ飛ばない）", async ({ browser }) => {
+    const { ctx, page } = await openCaptured({ content: "aaa\nbbb\nccc" }, browser);
+
+    await placeCaret(page, 2, 1);
+    await page.locator("#markdown-view").pressSequentially("X");
+    await commitHistory(page);
+    await expect.poll(() => getContent(page)).toBe("aaa\nbbb\ncXcc");
+
+    await performUndo(page);
+    await expect.poll(() => getContent(page)).toBe("aaa\nbbb\nccc");
+    await expect.poll(() => getCaretPosition(page)).toEqual({ line: 2, col: 1 });
 
     await ctx.close();
   });


### PR DESCRIPTION
## 背景

記法を打ち終えると即座に装飾へ変換される（`# ` で見出し、`**bold**` の閉じで太字）が、undo の粒度は保存デバウンス単位なので、⌘Z 1 回で変換前に戻れるとは限らなかった。

## 仕様

- 記法変換が確定した打鍵（見出し / リスト / チェックボックス / 引用 / 順序リストの成立、`**bold**` 等のインライン装飾の閉じ）の直前を undo の区切りにする。⌘Z 1 回で変換を起こした 1 打鍵だけが取り消され、変換前の状態に戻る。変換を含まない連続タイピングの undo 粒度は変えない
- undo / redo 後のキャレットは変更のあった位置に置く（挿入の undo は変更の始端、削除の undo は復元した文字の後ろ、行数が変わって対応する行が無い場合は行末）
- チェックボックス補完は `]` の直後にスペースを打った時点で `- []` を `- [ ] ` に正規化する（`- [ ]` を手打ちしたときと同じタイミング）
- コードフェンス内容行・ペースト・Enter・削除・IME 確定は対象外

## やったこと

- FE: 1 文字入力の splice 前後で行のブロック種別とインライン装飾の成立を比較する純粋関数（描画と同じ判定を共有）を新設し、変換を検出したら splice 前の内容を履歴に確定する。undo / redo の着地位置を差分の行・列から算出
- テスト: 変換検出の単体テーブルテストと、変換ごとの undo / redo・キャレット位置・細切れにならないことの E2E（chromium + webkit）

## 確認したこと

- eslint、node 単体テスト 423 件、Playwright（chromium 549 件、webkit の関連 spec）、cargo fmt / clippy / test
- 実機で見出し / リスト / 太字の変換 undo、undo 後のキャレット位置、チェックボックス補完のタイミング

## 関連リンク

- Closes #84
- 関連 issue: #89
