### PR TITLE
✅ E2E の実時間待ちを廃止し ⌘A / ⌘W のテストを追加する

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,9 @@ npm test
 # 単体テストだけ（ブラウザを起動しないので速い）
 npm run test:unit
 
+# 単体テストの行カバレッジ（単体テストが require する src/*.js の未実行行を洗い出す）
+npm run test:unit:coverage
+
 # 特定エンジンだけ（実機は WKWebView なので webkit 差分の切り分けに使う）
 npm run test:chromium
 npm run test:webkit

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lint": "eslint . --max-warnings 0",
     "test": "node --test tests/unit/*.test.js && playwright test",
     "test:unit": "node --test tests/unit/*.test.js",
+    "test:unit:coverage": "node --test --experimental-test-coverage tests/unit/*.test.js",
     "test:chromium": "playwright test --project=chromium",
     "test:webkit": "playwright test --project=webkit",
     "test:update": "playwright test --update-snapshots",

--- a/src/note.js
+++ b/src/note.js
@@ -2342,7 +2342,20 @@ function restoreNonCollapsedSelectionAfterRevealClear(sel) {
 // mdView への collapsed キャレット移動はすべてネイティブ（クリック・矢印キー等）に任せているため、
 // selectionchange だけが「キャレットが今どこにあるか」を検知できる唯一の経路になる。IME 変換中
 // （composing）は切り替えない。
+//
+// selectionSettleSeq はハンドラが走り終えた回数。ブラウザは selectionchange を非同期に配送するため、
+// テストはキー入力の後にこの値が進むのを待つことで「reveal の再判定・再描画・キャレット復元が
+// 済んだ」ことを実時間の待機なしに確定できる（window.getSelectionSettleSeq で公開）
+let selectionSettleSeq = 0;
 document.addEventListener('selectionchange', () => {
+  try {
+    handleSelectionChange();
+  } finally {
+    selectionSettleSeq++;
+  }
+});
+
+function handleSelectionChange() {
   if (composing) return;
   const sel = window.getSelection();
   const range = sel.rangeCount ? sel.getRangeAt(0) : null;
@@ -2375,7 +2388,7 @@ document.addEventListener('selectionchange', () => {
   renderAll();
   // 再描画で失われたキャレットを、可視幅が変わった後の DOM でも同じソース位置へ復元する
   if (point) placeCaretAtRaw(point.line, point.col);
-});
+}
 
 // mdView がフォーカスを失うとキャレットは表示されなくなるため、reveal も表示する意味が無い。
 // IME 変換中（composing）の blur は、renderAll() が変換中の WebKit ネイティブ書き込み DOM ごと
@@ -3483,6 +3496,7 @@ window.selectAllNote = selectAllNote;
 // インライン生表示（reveal）の現在の状態。selectionchange 駆動で非同期に確定するため、
 // テストは DOM の見た目だけでなくこの値で「reveal が確定したか」を待てる
 window.getRevealState = () => revealState;
+window.getSelectionSettleSeq = () => selectionSettleSeq;
 // 保留中の保存デバウンスをその場で確定させる。テストが undo の手数を検証する際、実時間で
 // デバウンス窓を待つ代わりにこれを呼べば決定的に commit を確定できる
 window.flushContent = flushContent;

--- a/tests/visual/autosave-debounce-e2e.spec.ts
+++ b/tests/visual/autosave-debounce-e2e.spec.ts
@@ -1,14 +1,21 @@
 import { test, expect, injectNoteMock, enterEdit } from "./fixtures";
 
+// デバウンス窓（saveTimer, note.js scheduleSave）の経過を検証するテストなので、
+// 実時間待機ではなく page.clock で仮想時計を進めて決定的に確定させる。
+// page.clock.install() はページ内の全タイマーを止めるため、injectNoteMock の invokeDelays
+// （setTimeout で応答を遅らせる）とは併用できない。
+
 test.describe("自動保存デバウンス", () => {
   test("高速連続入力 → 最後の入力から300ms後に1回だけinvoke", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
+    await page.clock.install();
     await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
     await enterEdit(page);
+    await page.clock.pauseAt(Date.now() + 1000); // 以降、時計は runFor で進めた分しか進まない
 
     // キャプチャをリセット
     await page.evaluate(() => { (window as any).__captured_invokes.length = 0; });
@@ -16,21 +23,20 @@ test.describe("自動保存デバウンス", () => {
     // 高速で5文字連続入力（各入力間にデバウンスリセットが起こる）
     await page.locator("#markdown-view").pressSequentially("abcde", { delay: 50 });
 
-    // 入力直後（50ms * 5 = 250ms程度）はまだデバウンス中
+    // 仮想時計は入力の間止まったままなので、まだデバウンス中
     const callsImmediate = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length
     );
     expect(callsImmediate).toBe(0);
 
-    // デバウンス完了を待機（最後の入力から300ms）
-    await expect.poll(() =>
-      page.evaluate(() =>
-        (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length
-      ),
-      { timeout: 5000 },
-    ).toBe(1);
+    // デバウンス窓（300ms）の直前までは保存されず、窓を越えた時点で保存される
+    await page.clock.runFor(299);
+    const callsBeforeWindow = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length
+    );
+    expect(callsBeforeWindow).toBe(0);
+    await page.clock.runFor(2);
 
-    // invoke が正確に1回だけ呼ばれ、最後の入力内容が含まれていることを確認
     const calls = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content")
     );
@@ -43,19 +49,21 @@ test.describe("自動保存デバウンス", () => {
   test("デバウンス中の再入力 → タイマーリセットされ最終的に1回だけinvoke", async ({ browser }) => {
     const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
     const page = await ctx.newPage();
+    await page.clock.install();
     await injectNoteMock(page, { content: "" }, {}, { captureInvokes: true });
     await page.goto("/note.html?id=test-note-id");
     await page.waitForLoadState("networkidle");
 
     await enterEdit(page);
+    await page.clock.pauseAt(Date.now() + 1000);
 
     await page.evaluate(() => { (window as any).__captured_invokes.length = 0; });
 
     // 1文字入力
     await page.locator("#markdown-view").press("x");
 
-    // 200ms待機（300msデバウンス内）
-    await page.waitForTimeout(200);
+    // デバウンス窓（300ms）内まで仮想時計を進める
+    await page.clock.runFor(200);
 
     // デバウンスタイマー内にもう1文字入力 → タイマーリセット
     await page.locator("#markdown-view").press("y");
@@ -66,15 +74,14 @@ test.describe("自動保存デバウンス", () => {
     );
     expect(callsMid).toBe(0);
 
-    // 最後の入力から300ms+α待機してinvokeを確認
-    await expect.poll(() =>
-      page.evaluate(() =>
-        (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length
-      ),
-      { timeout: 5000 },
-    ).toBe(1);
+    // リセットされた窓は y の入力から数え直される（x から 300ms 経っても保存されない）
+    await page.clock.runFor(299);
+    const callsBeforeWindow = await page.evaluate(() =>
+      (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content").length
+    );
+    expect(callsBeforeWindow).toBe(0);
+    await page.clock.runFor(2);
 
-    // 最終コンテンツに両方の文字が含まれている
     const calls = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "update_note_content")
     );

--- a/tests/visual/caret-geometry-e2e.spec.ts
+++ b/tests/visual/caret-geometry-e2e.spec.ts
@@ -1,5 +1,6 @@
 import {
   test, expect, placeCaret, waitForReveal, getRevealState, caretRect, charRect, expectCaretAtVisiblePosition,
+  pressAndSettle,
 } from "./fixtures";
 
 // キャレットのジオメトリ（実際のピクセル位置）の回帰テスト。raw・DOM 上のキャレット位置が
@@ -107,9 +108,10 @@ test.describe("インライン生表示（reveal）の切替でキャレット�
     // reveal 状態を保っている歩どうしの間でだけ、小刻みな単調増加を検証する
     let prev = (await caretRect(page))!;
     let prevReveal = await getRevealState(page);
+    // 9 歩で raw col 1 → 10（文書末）にちょうど届く。文書末に着いた後の ArrowRight は
+    // 選択が動かず pressAndSettle が待ち続けるので、歩数は content の長さと連動させること
     for (let i = 0; i < 9; i++) {
-      await page.keyboard.press("ArrowRight");
-      await page.waitForTimeout(50); // selectionchange 駆動の reveal 再判定・再描画の決着待ち
+      await pressAndSettle(page, "ArrowRight"); // selectionchange 駆動の reveal 再判定・再描画の決着待ち
       const rect = (await caretRect(page))!;
       const reveal = await getRevealState(page);
       if (JSON.stringify(reveal) === JSON.stringify(prevReveal)) {

--- a/tests/visual/checkbox-toggle.spec.ts
+++ b/tests/visual/checkbox-toggle.spec.ts
@@ -52,7 +52,8 @@ test.describe("checkbox toggle interaction", () => {
 
     const checkbox = page.locator('input[type="checkbox"]').first();
     await checkbox.click();
-    await page.waitForTimeout(400);
+    // change ハンドラは saveNow() を同期で呼ぶ（デバウンスしない）ので、click が返った時点で
+    // 記録は確定している
 
     const captured = await page.evaluate(() => (window as any).__capturedContent);
     expect(captured.length).toBeGreaterThan(0);
@@ -67,7 +68,8 @@ test.describe("checkbox toggle interaction", () => {
 
     const checkbox = page.locator('input[type="checkbox"]').first();
     await checkbox.click();
-    await page.waitForTimeout(400);
+    // change ハンドラは saveNow() を同期で呼ぶ（デバウンスしない）ので、click が返った時点で
+    // 記録は確定している
 
     const captured = await page.evaluate(() => (window as any).__capturedContent);
     expect(captured.length).toBeGreaterThan(0);

--- a/tests/visual/decoration-partial-selection-edit-e2e.spec.ts
+++ b/tests/visual/decoration-partial-selection-edit-e2e.spec.ts
@@ -1,4 +1,7 @@
-import { test, expect, getContent, placeCaret, selectMarkdownRange, commitHistory } from "./fixtures";
+import {
+  test, expect, getContent, placeCaret, selectMarkdownRange, commitHistory, waitForReveal,
+  settleSelection, pressAndSettle,
+} from "./fixtures";
 
 // 部分的に選択された装飾（太字/斜字/取り消し線/インラインコード/リンク）の削除・置換。
 // 選択が装飾セグメントを部分的にしか覆っていないとき、そのセグメントのマーカーは保存し
@@ -27,15 +30,14 @@ function dispatchPaste(page: import("@playwright/test").Page, plain: string) {
   }, plain);
 }
 
-/** mdView を blur して reveal を確実に解除する。splice 直後の selectionchange（キャレット
- * 復元）はブラウザが非同期に発火するため、blur を先に投げると「まだ revealState が更新されて
- * いない」タイミングに当たって blur の条件分岐（if (!revealState) return）が素通りし、直後に
- * 遅れて届いた selectionchange が改めて reveal を有効化してしまうことがある（1 行に複数の
- * 装飾がある行で発生しやすい）。先に selectionchange の決着を待ってから blur する。 */
+/** mdView を blur して reveal を解除する。splice 直後の selectionchange（キャレット復元）は
+ * ブラウザが非同期に発火するため、その決着前に blur すると blur の条件分岐
+ * （if (!revealState) return）が素通りし、遅れて届いた selectionchange が改めて reveal を
+ * 有効化してしまう。呼び出し側は直前の編集操作を pressAndSettle / settleSelection で決着させて
+ * おくこと。 */
 async function blurEditor(page: import("@playwright/test").Page) {
-  await page.waitForTimeout(100);
   await page.evaluate(() => (document.getElementById("markdown-view") as HTMLElement).blur());
-  await page.waitForTimeout(50);
+  await waitForReveal(page, null);
 }
 
 /** キャレットが装飾セグメントの手前（srcStart、reveal 前から到達できる安定した境界）にある
@@ -45,8 +47,7 @@ async function blurEditor(page: import("@playwright/test").Page) {
  * 一度 reveal を有効にしてから raw 1 文字ずつ進んで内容の直前まで辿り着く必要がある。 */
 async function stepRight(page: import("@playwright/test").Page, times: number) {
   for (let i = 0; i < times; i++) {
-    await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(50);
+    await pressAndSettle(page, "ArrowRight");
   }
 }
 
@@ -56,7 +57,7 @@ test.describe("部分選択された太字の削除はマーカーを保存す�
 
     // 可視 "abc bold def" の "b"（4〜5文字目）だけを選択する
     await selectMarkdownRange(page, 0, 4, 0, 5);
-    await page.keyboard.press("Backspace");
+    await pressAndSettle(page, "Backspace");
 
     expect(await getContent(page)).toBe("abc **old** def");
     // 削除直後はキャレットが装飾の可視末尾に残り reveal が有効なままなので、装飾タグでの
@@ -69,7 +70,7 @@ test.describe("部分選択された太字の削除はマーカーを保存す�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 5, 0, 11); // 可視 "old de"
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc **b**f");
     await blurEditor(page);
@@ -80,7 +81,7 @@ test.describe("部分選択された太字の削除はマーカーを保存す�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 4, 0, 8); // 可視 "bold" 全体
-    await page.keyboard.press("Backspace");
+    await pressAndSettle(page, "Backspace");
 
     expect(await getContent(page)).toBe("abc  def");
     expect(await page.locator("#markdown-view strong").count()).toBe(0);
@@ -91,7 +92,7 @@ test.describe("部分選択された太字の削除はマーカーを保存す�
 
     // 可視 "bold and italic" のうち "ld and ita"（太字の途中〜斜字の途中）を選択
     await selectMarkdownRange(page, 0, 2, 0, 12);
-    await page.keyboard.press("Backspace");
+    await pressAndSettle(page, "Backspace");
 
     expect(await getContent(page)).toBe("**bo***lic*");
     await blurEditor(page);
@@ -103,7 +104,7 @@ test.describe("部分選択された太字の削除はマーカーを保存す�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 4, 0, 5);
-    await page.keyboard.press("Backspace");
+    await pressAndSettle(page, "Backspace");
     expect(await getContent(page)).toBe("abc **old** def");
 
     await commitHistory(page); // 保存を確定させ history へ積ませる
@@ -118,7 +119,7 @@ test.describe("部分選択への置換（タイピング・ペースト）も�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 4, 0, 5); // 可視 "b"
-    await page.keyboard.press("X");
+    await pressAndSettle(page, "X");
 
     expect(await getContent(page)).toBe("abc **Xold** def");
     await blurEditor(page);
@@ -129,7 +130,7 @@ test.describe("部分選択への置換（タイピング・ペースト）も�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 4, 0, 5); // 可視 "b"
-    await dispatchPaste(page, "XY");
+    await settleSelection(page, () => dispatchPaste(page, "XY"));
 
     expect(await getContent(page)).toBe("abc **XYold** def");
     await blurEditor(page);
@@ -140,7 +141,7 @@ test.describe("部分選択への置換（タイピング・ペースト）も�
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 5, 0, 11); // 可視 "old de"
-    await page.keyboard.press("X");
+    await pressAndSettle(page, "X");
 
     expect(await getContent(page)).toBe("abc **bX**f");
     await blurEditor(page);
@@ -153,7 +154,9 @@ test.describe("⌘X はコピーされる可視範囲と削除される可視範
     const page = await openNote({ content: "abc **bold** def" });
 
     await selectMarkdownRange(page, 0, 5, 0, 11); // 可視 "old de"
-    const { notCanceled, plain } = await dispatchCutWithClipboardData(page);
+    let result!: { notCanceled: boolean; plain: string };
+    await settleSelection(page, async () => { result = await dispatchCutWithClipboardData(page); });
+    const { notCanceled, plain } = result;
 
     expect(notCanceled).toBe(false); // preventDefault された
     expect(plain).toBe("old de");
@@ -176,7 +179,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc **x** def" });
     await placeCaret(page, 0, 4); // "abc |**x** def"（装飾の手前）
     await stepRight(page, 2); // 開くマーカー "**" を越えて内容 "x" の直前へ
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc  def");
     await blurEditor(page);
@@ -187,7 +190,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc *x* def" });
     await placeCaret(page, 0, 4); // "abc |*x* def"
     await stepRight(page, 1); // 開くマーカー "*" を越えて内容の直前へ
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc  def");
     await blurEditor(page);
@@ -198,7 +201,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc ~~x~~ def" });
     await placeCaret(page, 0, 4); // "abc |~~x~~ def"
     await stepRight(page, 2); // 開くマーカー "~~" を越えて内容の直前へ
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc  def");
     await blurEditor(page);
@@ -209,7 +212,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc `x` def" });
     await placeCaret(page, 0, 4); // "abc |`x` def"
     await stepRight(page, 1); // 開くマーカー "`" を越えて内容の直前へ
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc  def");
     await blurEditor(page);
@@ -220,7 +223,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc [x](https://example.com) def" });
     await placeCaret(page, 0, 4); // "abc |[x](https://example.com) def"
     await stepRight(page, 1); // "[" を越えてラベル "x" の直前へ
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
 
     expect(await getContent(page)).toBe("abc [](https://example.com) def");
     await blurEditor(page);
@@ -233,7 +236,7 @@ test.describe("可視文字が空になった装飾はマーカーごと正規�
     const page = await openNote({ content: "abc **x** def" });
     await placeCaret(page, 0, 4);
     await stepRight(page, 2);
-    await page.keyboard.press("Delete");
+    await pressAndSettle(page, "Delete");
     expect(await getContent(page)).toBe("abc  def");
 
     await commitHistory(page);

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -97,6 +97,7 @@ export async function injectNoteMock(
       webviewWindow: {
         getCurrentWebviewWindow: () => ({
           startDragging: async () => {},
+          close: async () => { (window as any).__closeWasCalled = true; },
           outerPosition: async () => ({ x: 0, y: 0 }),
           outerSize: async () => ({ width: 300, height: 350 }),
           setAlwaysOnTop: async () => {},
@@ -273,6 +274,28 @@ export async function waitForReveal(page: Page, expected: RevealState) {
     },
     expected,
   );
+}
+
+/** action（キー入力・ペースト等）の後に selectionchange ハンドラが少なくとも 1 回走り終える
+ * まで待つ。ブラウザは selectionchange を非同期に配送するため、直後に DOM・reveal・キャレット
+ * 位置を読むと再判定・再描画・キャレット復元の前の状態を掴むことがある。実時間の待機
+ * （waitForTimeout）は CI の遅いランナーで足りなくなるので、ハンドラの完了回数で待つ。
+ * action が選択を一切動かさない場合はハンドラが走らず待ち続けるため、キャレットが動く
+ * 操作にだけ使う。ハンドラは IME 変換中（composing）は何もせずに抜けるので、変換中の
+ * 操作に使っても「済んだ」ことにはならない。 */
+export async function settleSelection(page: Page, action: () => Promise<unknown>) {
+  const seq = () => page.evaluate(() => (window as unknown as { getSelectionSettleSeq(): number }).getSelectionSettleSeq());
+  const before = await seq();
+  await action();
+  await page.waitForFunction(
+    (b) => (window as unknown as { getSelectionSettleSeq(): number }).getSelectionSettleSeq() > b,
+    before,
+  );
+}
+
+/** キーを 1 回押し、それに伴う selectionchange の処理が済むまで待つ（settleSelection 参照）。 */
+export function pressAndSettle(page: Page, key: string) {
+  return settleSelection(page, () => page.keyboard.press(key));
 }
 
 /** markdown-view の (行, 可視オフセット) の 2 点を DOM 選択（Range）として張る。note.js の

--- a/tests/visual/image-delete-e2e.spec.ts
+++ b/tests/visual/image-delete-e2e.spec.ts
@@ -245,7 +245,8 @@ test.describe("選択中の画像を Backspace / Delete で削除する", () => 
     await page.keyboard.press("Backspace"); // in-flight 中の連打（キーリピート相当）
     await page.keyboard.press("Backspace");
 
-    await page.waitForTimeout(400); // 200ms の遅延 + マージン
+    // 遅延させた delete_image の応答が反映される（content が差し替わる）まで待ってから数える
+    await expect.poll(() => page.evaluate(() => (window as any).getRawContent())).toBe("text0");
 
     const calls = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "delete_image"),

--- a/tests/visual/image-open-e2e.spec.ts
+++ b/tests/visual/image-open-e2e.spec.ts
@@ -129,8 +129,8 @@ test.describe("画像のダブルクリック・右クリックメニュー", ()
     });
     await page.evaluate(dispatchOnImage, "dblclick");
 
-    // invoke されないことを確定させるため、明示的に待ってから0件であることを確認する
-    await page.waitForTimeout(100);
+    // dblclick ハンドラは dispatch 中に同期的に invoke を呼ぶ（呼ぶなら）ので、dispatch が
+    // 返った時点で呼び出し記録は確定している
     const calls = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image"),
     );

--- a/tests/visual/image-resize-e2e.spec.ts
+++ b/tests/visual/image-resize-e2e.spec.ts
@@ -310,7 +310,8 @@ test.describe("画像のリサイズハンドル", () => {
       document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 0, clientY: 0 }));
     });
 
-    await page.waitForTimeout(100);
+    // dblclick ハンドラは dispatch 中に同期的に invoke を呼ぶ（呼ぶなら）ので、dispatch が
+    // 返った時点で呼び出し記録は確定している
     const calls = await page.evaluate(() =>
       (window as any).__captured_invokes.filter((c: any) => c.cmd === "open_image"),
     );

--- a/tests/visual/inline-reveal-e2e.spec.ts
+++ b/tests/visual/inline-reveal-e2e.spec.ts
@@ -1,6 +1,6 @@
 import {
   test, expect, placeCaret, getContent, selectMarkdownRange, waitForReveal, getRevealState, getCaretPosition,
-  extendSelectionTo, commitHistory,
+  extendSelectionTo, commitHistory, pressAndSettle,
 } from "./fixtures";
 
 // インライン生表示（reveal）。キャレット（collapsed）が装飾（太字/斜字/取り消し線/インラインコード/
@@ -13,18 +13,16 @@ import {
 // window.placeCaretAtRaw で直接そこへテレポートすることはできない）。そのため、そうした位置は
 // reveal 済みの到達可能な境界（可視先頭・可視末尾）から矢印キーで 1 歩ずつ動いて到達する
 // （実際のユーザー操作と同じ経路）。矢印キー1回ごとに selectionchange の再描画が決着するまで
-// 少し待つ（stepRight/stepLeft）。reveal の切替はキー入力ごとのフル再描画なので、待たずに
+// 待つ（stepRight/stepLeft）。reveal の切替はキー入力ごとのフル再描画なので、待たずに
 // 連打すると再描画の途中に次のキーが割り込み得る（Playwright の高速な合成入力ならではの
 // 現象で、本テストの検証対象ではない）。
 
 /** ArrowRight/ArrowLeft を押し、selectionchange 駆動の再描画・reveal 再判定が決着するまで待つ。 */
-async function stepRight(page: import("@playwright/test").Page) {
-  await page.keyboard.press("ArrowRight");
-  await page.waitForTimeout(50);
+function stepRight(page: import("@playwright/test").Page) {
+  return pressAndSettle(page, "ArrowRight");
 }
-async function stepLeft(page: import("@playwright/test").Page) {
-  await page.keyboard.press("ArrowLeft");
-  await page.waitForTimeout(50);
+function stepLeft(page: import("@playwright/test").Page) {
+  return pressAndSettle(page, "ArrowLeft");
 }
 
 test.describe("キャレットが装飾の中・境界にあるとマーカーが見える", () => {
@@ -185,10 +183,8 @@ test.describe("選択の開始・拡張は reveal を解除しつつ選択その
     // stepRight と同様、selectionchange 駆動の再描画が決着するまで待ってから次のキーを送る
     // （待たずに連打すると再描画の途中に次のキーが割り込みうる。ファイル冒頭のコメント参照）
     await page.keyboard.down("Shift");
-    await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(50);
-    await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(50);
+    await stepRight(page);
+    await stepRight(page);
     await page.keyboard.up("Shift");
 
     expect(await getRevealState(page)).toBeNull(); // 非 collapsed の間 revealState は必ず null
@@ -246,10 +242,8 @@ test.describe("非 collapsed の選択中は revealState が必ず null（不変
     await waitForReveal(page, { line: 0, start: 4, end: 12 });
 
     await page.keyboard.down("Shift");
-    await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(50);
-    await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(50);
+    await stepRight(page);
+    await stepRight(page);
     await page.keyboard.up("Shift");
     expect(await getRevealState(page)).toBeNull();
 

--- a/tests/visual/select-all-close-e2e.spec.ts
+++ b/tests/visual/select-all-close-e2e.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, placeCaret, getContent, enterEdit } from "./fixtures";
+
+// ⌘A（付箋の本文を全選択）と ⌘W（ウィンドウを閉じる）。どちらも document の keydown で拾う
+// ショートカット（src/note.js の selectAllNote と末尾のハンドラ）。
+
+function selectionText(page: import("@playwright/test").Page) {
+  return page.evaluate(() => window.getSelection()!.toString());
+}
+
+test.describe("⌘A は付箋の本文を全選択する", () => {
+  test("複数行の本文が装飾込みで全選択され、続く Backspace で空になる", async ({ openNote }) => {
+    const page = await openNote({ content: "line1\n**bold** and *it*\n- item" });
+    await placeCaret(page, 0, 2);
+
+    await page.keyboard.press("Meta+a");
+
+    const text = await selectionText(page);
+    for (const part of ["line1", "bold", "it", "item"]) expect(text).toContain(part);
+
+    await page.keyboard.press("Backspace");
+    await expect.poll(() => getContent(page)).toBe("");
+  });
+
+  test("空の付箋では選択を作らない", async ({ openNote }) => {
+    const page = await openNote({ content: "" });
+    await enterEdit(page);
+
+    await page.keyboard.press("Meta+a");
+
+    expect(await selectionText(page)).toBe("");
+    expect(await page.evaluate(() => window.getSelection()!.isCollapsed)).toBe(true);
+  });
+
+  test("画像を含む本文でも前後のテキストが選択され、画像の選択状態は解除される", async ({ openNote }) => {
+    const page = await openNote({ content: "head\n![](images/00000000-0000-4000-8000-000000000001.png)\ntail" });
+    await placeCaret(page, 1); // 画像行にキャレットを置くと画像が選択状態になる
+    await expect(page.locator("#markdown-view .img-selected")).toHaveCount(1);
+
+    await page.keyboard.press("Meta+a");
+
+    const text = await selectionText(page);
+    expect(text).toContain("head");
+    expect(text).toContain("tail");
+    await expect(page.locator("#markdown-view .img-selected")).toHaveCount(0);
+  });
+
+  test("⌘⇧A のような修飾の組み合わせ違いでは反応しない", async ({ openNote }) => {
+    const page = await openNote({ content: "abc\ndef" });
+    await placeCaret(page, 0, 1);
+
+    await page.keyboard.press("Meta+Shift+a");
+
+    expect(await selectionText(page)).toBe("");
+  });
+});
+
+test.describe("⌘W はウィンドウを閉じる", () => {
+  test("⌘W でウィンドウの close が呼ばれる", async ({ openNote }) => {
+    const page = await openNote({ content: "abc" });
+    await placeCaret(page, 0, 1);
+
+    await page.keyboard.press("Meta+w");
+
+    await expect.poll(() => page.evaluate(() => (window as any).__closeWasCalled === true)).toBe(true);
+  });
+
+  test("修飾なしの w は文字として入力され close は呼ばれない", async ({ openNote }) => {
+    const page = await openNote({ content: "abc" });
+    await placeCaret(page, 0, 3);
+
+    await page.keyboard.press("w");
+
+    await expect.poll(() => getContent(page)).toBe("abcw");
+    expect(await page.evaluate(() => (window as any).__closeWasCalled)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 背景

E2E の一部が `waitForTimeout` の実時間待ちに頼っていて、遅いランナーではデバウンス窓や selectionchange の再描画に間に合わず落ちることがあった。また ⌘A / ⌘W に回帰テストが無かった。

## やったこと

- テスト基盤: キー入力の後は selectionchange ハンドラの完了（note.js がテスト向けに公開する回数）を待つ仕組みに揃え、自動保存デバウンスは Playwright の仮想時計で窓の境界を検証する。実時間待ちに依存する spec は無い
- E2E: ⌘A の全選択（複数行・空の付箋・画像を含む本文・修飾違いの無反応）と ⌘W のウィンドウクローズを追加（chromium + webkit）
- 計測: `npm run test:unit:coverage` で単体テストの行カバレッジを出せるようにした（CI には入れない。未実行行を洗い出す用途）

## 仕様の注意点

- ウィンドウを閉じる判定は `metaKey || ctrlKey` のままだが、テストで固定したのは ⌘W だけ。macOS では ⌃W が「直前の単語を削除」の標準キーなので、Ctrl 側を仕様として固定するかは別途判断する

## 確認したこと

- eslint、node 単体テスト、Playwright（chromium 全体を 3 回、webkit の関連 spec）

## 関連リンク

- issue #86
