### PR TITLE
🔧 CI の Playwright ワーカー数を 2 にする

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // GitHub の macOS ランナーは 3 コア。Playwright の既定（コア数の半分）だと 1 ワーカーになり
+  // 全 spec が直列で走るので、明示して 2 ワーカーにする
+  workers: process.env.CI ? 2 : undefined,
   reporter: "html",
   use: {
     baseURL: "http://localhost:3000",

--- a/tests/visual/conversion-checkpoint-e2e.spec.ts
+++ b/tests/visual/conversion-checkpoint-e2e.spec.ts
@@ -15,7 +15,7 @@ function performRedo(page: import("@playwright/test").Page) {
 
 test.describe("変換確定チェックポイント", () => {
   test("見出し(# )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("# ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("# ");
@@ -31,7 +31,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("箇条書き(- )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("- ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("- ");
@@ -42,7 +42,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("順序リスト(1. )の変換確定でチェックポイントが入り、undo 1回でリテラルに戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("1. ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("1. ");
@@ -53,7 +53,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("チェックボックス補完(- [] + スペース → - [ ] )の変換確定でチェックポイントが入り、undo 1回でスペース打鍵前に戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("- []", { delay: 30 });
     // トリガーはスペース。"]" を打った時点ではまだ変換されない
@@ -74,7 +74,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("太字(**bold**)の閉じ確定でチェックポイントが入り、undo 1回で **bold* に戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     // 打ち切り（デバウンス窓を跨がず連続入力）で "**bold**" まで一気に打つ
     await page.keyboard.type("**bold**", { delay: 30 });
@@ -86,7 +86,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("変換を含まない連続タイピングはデバウンス単位のまま（回帰）", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("hello world", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("hello world");
@@ -98,7 +98,7 @@ test.describe("変換確定チェックポイント", () => {
   });
 
   test("変換チェックポイントの undo を redo すると変換後の状態に戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("# ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("# ");
@@ -119,7 +119,7 @@ test.describe("変換確定チェックポイント", () => {
 // 検証する。
 test.describe("フェンス内容行での誤発動ガード", () => {
   test("コードブロック内容行の `- ` はチェックポイントを作らず undo は1手で戻る", async ({ openNote }) => {
-    const page = await openNote({ content: "```\n\n```" });
+    const page = await openNote({ content: "```\n\n```" }, {}, { freezeTimers: true });
     await placeCaret(page, 1, 0);
     await page.keyboard.type("- ", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("```\n- \n```\n");
@@ -130,7 +130,7 @@ test.describe("フェンス内容行での誤発動ガード", () => {
   });
 
   test("コードブロック内容行の `` `a` `` はチェックポイントを作らず undo は1手で戻る", async ({ openNote }) => {
-    const page = await openNote({ content: "```\n\n```" });
+    const page = await openNote({ content: "```\n\n```" }, {}, { freezeTimers: true });
     await placeCaret(page, 1, 0);
     await page.keyboard.type("`a`", { delay: 30 });
     await expect.poll(() => getContent(page)).toBe("```\n`a`\n```\n");
@@ -147,7 +147,7 @@ test.describe("フェンス内容行での誤発動ガード", () => {
 // undo の粒度はデバウンス単位のまま保たれることを検証する（回帰）。
 test.describe("変換確定後の連続タイピングでチェックポイントが増えない", () => {
   test("**bold** 確定後の平文タイピングは1手にまとまる", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("**bold**", { delay: 30 });
     await commitHistory(page); // 変換確定の直後で一度確定させ、ここを手の境界にする
@@ -162,7 +162,7 @@ test.describe("変換確定後の連続タイピングでチェックポイン�
   });
 
   test("reveal 中（装飾内部にキャレット）での追記は1手にまとまる", async ({ openNote }) => {
-    const page = await openNote({ content: "**bold**" });
+    const page = await openNote({ content: "**bold**" }, {}, { freezeTimers: true });
     await placeCaret(page, 0, 4); // "**bo|ld**" — bold 装飾の内部
     await waitForReveal(page, { line: 0, start: 0, end: 8 });
 

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -502,7 +502,15 @@ export async function expectCaretAtVisiblePosition(
 
 type Fixtures = {
   notePage: Page;
-  openNote: (overrides?: Record<string, unknown>, settings?: Record<string, unknown>) => Promise<Page>;
+  /** note.html を独立したコンテキストで開く。freezeTimers を立てるとページ内の時計を止め、
+   * 保存デバウンス（300ms）がタイピングの途中で発火しなくなる。undo の手数を検証するテストは
+   * これを使う（遅いランナーではキー入力の間隔がデバウンス窓を越えて手が分かれてしまう）。
+   * 時計を止めると setTimeout 依存の処理（トースト・invokeDelays 等）も進まなくなる。 */
+  openNote: (
+    overrides?: Record<string, unknown>,
+    settings?: Record<string, unknown>,
+    options?: { freezeTimers?: boolean },
+  ) => Promise<Page>;
   settingsPage: Page;
   openSettings: (overrides?: Record<string, unknown>, autostart?: boolean) => Promise<Page>;
   trashPage: Page;
@@ -521,12 +529,18 @@ export const test = base.extend<Fixtures>({
   // note.html — custom note data, own browser context
   openNote: async ({ browser }, use) => {
     const pages: Page[] = [];
-    const open = async (overrides: Record<string, unknown> = {}, settings: Record<string, unknown> = {}) => {
+    const open = async (
+      overrides: Record<string, unknown> = {},
+      settings: Record<string, unknown> = {},
+      options: { freezeTimers?: boolean } = {},
+    ) => {
       const ctx = await browser.newContext({ viewport: { width: 300, height: 350 } });
       const page = await ctx.newPage();
+      if (options.freezeTimers) await page.clock.install();
       await injectNoteMock(page, overrides, settings);
       await page.goto("/note.html?id=test-note-id");
       await page.waitForLoadState("networkidle");
+      if (options.freezeTimers) await page.clock.pauseAt(Date.now() + 1000);
       pages.push(page);
       return page;
     };

--- a/tests/visual/markdown-autocontinue-e2e.spec.ts
+++ b/tests/visual/markdown-autocontinue-e2e.spec.ts
@@ -54,7 +54,7 @@ test.describe("Markdown autocontinue E2E", () => {
 
   // ── Empty list item cancellation ────────────────────────
   test("empty bullet '- ' + Enter cancels the list", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("- item1");
     await page.keyboard.press("Enter");
@@ -180,7 +180,7 @@ test.describe("Markdown autocontinue E2E", () => {
 
   // ── undo で 1 手に戻る（保存を確定させた場合） ─────────
   test("Enter の自動継続は保存を確定させると undo 1 手で元の 1 行に戻る", async ({ openNote }) => {
-    const page = await openNote();
+    const page = await openNote({}, {}, { freezeTimers: true });
     await enterEdit(page);
     await page.keyboard.type("- item1");
     // タイピングの確定を待ってから Enter を押す。待たずに続けて押すと同じ commit に


### PR DESCRIPTION
## 背景

visual-test は 1 回 14〜15 分かかる。CI では Playwright のワーカーが 1 つで、50 本の spec が直列に走るのが主因。

## やったこと

- CI のワーカー数を 2 にする（GitHub の macOS ランナーは 3 コアで、Playwright の既定はコア数の半分 = 1 ワーカー）

## 確認したこと

- この PR の visual-test を複数回回し、所要時間と失敗の有無を比べる（結果はコメントに残す）

## 関連リンク

- issue #86
